### PR TITLE
changes in order build on mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ project(cesium-unity
     LANGUAGES CXX C
 )
 
+if(APPLE)
+    set(CMAKE_OSX_ARCHITECTURES "x86_64")
+endif()
+
 # Install to the Assets directory.
 set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_LIST_DIR}/Assets)
 

--- a/Reinterop/CodeGenerator.cs
+++ b/Reinterop/CodeGenerator.cs
@@ -227,7 +227,10 @@ namespace Reinterop
             result.CppImplementationInvoker.Functions.Add(new(
                 Content:
                     $$"""
-                    __declspec(dllexport) {{returnType.AsInteropType().GetFullyQualifiedName()}} {{invokeCallbackName}}({{string.Join(", ", interopParameters.Select(p => $"{p.InteropType.GetFullyQualifiedName()} {p.Name}"))}}) {
+                    #if __WIN32
+                    __declspec(dllexport)
+                    #endif
+                    {{returnType.AsInteropType().GetFullyQualifiedName()}} {{invokeCallbackName}}({{string.Join(", ", interopParameters.Select(p => $"{p.InteropType.GetFullyQualifiedName()} {p.Name}"))}}) {
                       auto pFunc = reinterpret_cast<std::function<{{itemType.GetFullyQualifiedName()}}::FunctionSignature>*>(pCallbackFunction);
                       {{resultImplementation}}(*pFunc)({{string.Join(", ", callParameters)}});
                       {{returnImplementation}}
@@ -237,7 +240,10 @@ namespace Reinterop
             result.CppImplementationInvoker.Functions.Add(new(
                 Content:
                     $$"""
-                    __declspec(dllexport) void {{disposeCallbackName}}(void* pCallbackFunction) {
+                    #if __WIN32
+                    __declspec(dllexport)
+                    #endif
+                    void {{disposeCallbackName}}(void* pCallbackFunction) {
                       auto pFunc = reinterpret_cast<std::function<{{itemType.GetFullyQualifiedName()}}::FunctionSignature>*>(pCallbackFunction);
                       delete pFunc;
                     }

--- a/Reinterop/GeneratedInit.cs
+++ b/Reinterop/GeneratedInit.cs
@@ -49,7 +49,10 @@
             headerNamespace.Members.Add(
                 $$"""
                 extern "C" {
-                __declspec(dllexport) void initializeReinterop(void** functionPointers, std::int32_t count);
+                #if __WIN32
+                __declspec(dllexport)
+                #endif
+                void initializeReinterop(void** functionPointers, std::int32_t count);
                 }
                 """);
 
@@ -73,8 +76,10 @@
             sourceNamespace.Members.Add(
                 $$"""
                 extern "C" {
-
-                __declspec(dllexport) void initializeReinterop(void** functionPointers, std::int32_t count) {
+                #if __WIN32
+                __declspec(dllexport)
+                #endif
+                void initializeReinterop(void** functionPointers, std::int32_t count) {
                   // If this assertion fails, the C# and C++ layers are out of sync.
                   assert(count == {{Functions.Count}});
                 

--- a/Reinterop/MethodsImplementedInCpp.cs
+++ b/Reinterop/MethodsImplementedInCpp.cs
@@ -22,7 +22,10 @@ namespace Reinterop
             result.CppImplementationInvoker.Functions.Add(new(
                 Content:
                     $$"""
-                    __declspec(dllexport) void* {{createName}}(void* handle) {
+                    #if __WIN32
+                    __declspec(dllexport)
+                    #endif
+                    void* {{createName}}(void* handle) {
                       const {{wrapperType.GetFullyQualifiedName()}} wrapper{{{objectHandleType.GetFullyQualifiedName()}}(handle)};
                       return reinterpret_cast<void*>(new {{implType.GetFullyQualifiedName()}}(wrapper));
                     }
@@ -54,7 +57,10 @@ namespace Reinterop
             result.CppImplementationInvoker.Functions.Add(new(
                 Content:
                     $$"""
-                    __declspec(dllexport) void {{disposeName}}(void* handle, void* pImpl) {
+                    #if __WIN32
+                    __declspec(dllexport)
+                    #endif
+                    void {{disposeName}}(void* handle, void* pImpl) {
                       const {{wrapperType.GetFullyQualifiedName()}} wrapper{{{objectHandleType.GetFullyQualifiedName()}}(handle)};
                       auto pImplTyped = reinterpret_cast<{{implType.GetFullyQualifiedName()}}*>(pImpl);
                       pImplTyped->JustBeforeDelete(wrapper);
@@ -233,7 +239,10 @@ namespace Reinterop
             result.CppImplementationInvoker.Functions.Add(new(
                 Content:
                     $$"""
-                    __declspec(dllexport) {{interopReturnType.GetFullyQualifiedName()}} {{name}}({{parameterListString}}) {
+                    #if __WIN32
+                    __declspec(dllexport)
+                    #endif
+                    {{interopReturnType.GetFullyQualifiedName()}} {{name}}({{parameterListString}}) {
                       const {{wrapperType.GetFullyQualifiedName()}} wrapper{{{objectHandleType.GetFullyQualifiedName()}}(handle)};
                       auto pImplTyped = reinterpret_cast<{{implType.GetFullyQualifiedName()}}*>(pImpl);
                       {{new[] { implementation }.JoinAndIndent("  ")}}


### PR DESCRIPTION
Other changes:

changing the hint path:

 <HintPath>/Applications/Unity/Hub/Editor/2021.3.2f1/Unity.app/Contents/Managed/UnityEngine.dll</HintPath>
<HintPath>/Applications/Unity/Hub/Editor/2021.3.2f1/Unity.app/Contents/Managed/UnityEditor.dll</HintPath>

The command to set up the symbolic link that worked for me is:
cd cesium-unity
ln -s /Users/josephkaile/Documents/unity-project/cesium-unity/Assets ../cesium-unity-samples/Assets/CesiumForUnity

ln -s source target
 
 and source should be an absolute path.
