### PR TITLE
Implement list element access, allow multiple overlays (sort of)

### DIFF
--- a/CesiumForUnity/ConfigureReinterop.cs
+++ b/CesiumForUnity/ConfigureReinterop.cs
@@ -1,5 +1,6 @@
 ﻿using Reinterop;
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
@@ -142,6 +143,13 @@ internal partial class ConfigureReinterop
         CesiumRasterOverlay overlay = go.GetComponent<CesiumRasterOverlay>();
         baseOverlay.AddToTileset();
         baseOverlay.RemoveFromTileset();
+
+        List<CesiumRasterOverlay> overlays = new List<CesiumRasterOverlay>();
+        go.GetComponents<CesiumRasterOverlay>(overlays);
+        for (int i = 0; i < overlays.Count; ++i)
+        {
+          CesiumRasterOverlay anOverlay = overlays[i];
+        }
 
         MonoBehaviour mb = tileset;
         mb.StartCoroutine(new NativeCoroutine(endIteration => endIteration).GetEnumerator());

--- a/CesiumForUnityNative/src/Cesium3DTilesetImpl.cpp
+++ b/CesiumForUnityNative/src/Cesium3DTilesetImpl.cpp
@@ -9,6 +9,7 @@
 #include <DotNet/CesiumForUnity/Cesium3DTileset.h>
 #include <DotNet/CesiumForUnity/CesiumRasterOverlay.h>
 #include <DotNet/CesiumForUnity/NativeCoroutine.h>
+#include <DotNet/System/Collections/Generic/List1.h>
 #include <DotNet/System/Collections/IEnumerator.h>
 #include <DotNet/System/Func2.h>
 #include <DotNet/System/Object.h>
@@ -183,10 +184,12 @@ void Cesium3DTilesetImpl::updateLastViewUpdateResultState(
 void Cesium3DTilesetImpl::DestroyTileset(
     const DotNet::CesiumForUnity::Cesium3DTileset& tileset) {
   // Remove any existing raster overlays
-  // TODO: support more than one
-  CesiumForUnity::CesiumRasterOverlay overlay =
-      tileset.gameObject().GetComponent<CesiumForUnity::CesiumRasterOverlay>();
-  if (overlay != nullptr) {
+  System::Collections::Generic::List1<CesiumForUnity::CesiumRasterOverlay>
+      overlays{};
+  tileset.gameObject().GetComponents<CesiumForUnity::CesiumRasterOverlay>(
+      overlays);
+  for (int32_t i = 0, len = overlays.Count(); i < len; ++i) {
+    CesiumForUnity::CesiumRasterOverlay overlay = overlays[i];
     overlay.RemoveFromTileset();
   }
 
@@ -205,10 +208,12 @@ void Cesium3DTilesetImpl::LoadTileset(
       options);
 
   // Add any overlay components
-  // TODO: support more than one
-  CesiumForUnity::CesiumRasterOverlay overlay =
-      tileset.gameObject().GetComponent<CesiumForUnity::CesiumRasterOverlay>();
-  if (overlay != nullptr) {
+  System::Collections::Generic::List1<CesiumForUnity::CesiumRasterOverlay>
+      overlays{};
+  tileset.gameObject().GetComponents<CesiumForUnity::CesiumRasterOverlay>(
+      overlays);
+  for (int32_t i = 0, len = overlays.Count(); i < len; ++i) {
+    CesiumForUnity::CesiumRasterOverlay overlay = overlays[i];
     overlay.AddToTileset();
   }
 }

--- a/Reinterop/ExposeToCppSyntaxWalker.cs
+++ b/Reinterop/ExposeToCppSyntaxWalker.cs
@@ -95,6 +95,19 @@ namespace Reinterop
             this.AddConstructor(methodSymbol);
         }
 
+        public override void VisitElementAccessExpression(ElementAccessExpressionSyntax node)
+        {
+            base.VisitElementAccessExpression(node);
+
+            // Look for the property for accessing elements of a list (or similar) by index.
+            ISymbol? symbol = this._semanticModel.GetSymbolInfo(node).Symbol;
+            IPropertySymbol? property = symbol as IPropertySymbol;
+            if (property == null)
+                return;
+
+            this.AddProperty(property);
+        }
+
         /// <summary>
         /// Find a member on a type or any of its base classes.
         /// </summary>

--- a/Reinterop/README.md
+++ b/Reinterop/README.md
@@ -64,7 +64,7 @@ void start() {
 }
 ```
 
-Build the generated C++ code into a shared library and copy it alongside the .NET assembly built by your C# project. Add C# code to call the generated method `Reinterop.ReinteropInitializer.Initialize()` at startup. This will initialize the interop layer and then call the `start` function in the C++ code. From there your C++ code can call back into .NET as it fees fit.
+Build the generated C++ code into a shared library and copy it alongside the .NET assembly built by your C# project. Add C# code to call the generated method `Reinterop.ReinteropInitializer.Initialize()` at startup. This will initialize the interop layer and then call the `start` function in the C++ code. From there your C++ code can call back into .NET as it sees fit.
 
 # Debugging
 
@@ -87,3 +87,9 @@ It is sometimes useful to temporarily disable the code generator so that you can
 With that change, your project will no longer compile because the generated code is missing. To fix that, find the previously-generated code in your project's `obj\Debug\netstandard2.1\generated\Reinterop\Reinterop.RoslynIncrementalGenerator` (or similar), and copy the entire contents into a folder called `generated` in your project's top-level directory. Your project should now build again.
 
 To revert back to on-the-fly generation, delete the `generated` folder and uncomment the lines in the .csproj.
+
+# Extending ExposeToCppSyntaxWalker
+
+If you want to discover more elements in `ConfigureReinterop` so that you can generate code for them, you will probably need to know what syntax elements you're looking for, and it's sometimes not very obvious. But if you install the ".NET Compiler Platform SDK" in Visual Studio, you can go to View -> Other Windows -> Syntax Visualizer. Then find the code you want to capture in `ConfigureReinterop.cs` (or wherever), click it, and look at the elements in the Syntax Visualizer window. If the window is broken, make a trivial modification to the code (e.g. add a space and then remove it) and the the tree should appear.
+
+To install the ".NET Compiler Platform SDK", just go to Add/Remove Programs, modify your Visual Studio installation, and find it under Individual Components.


### PR DESCRIPTION
This PR extends Reinterop to allow use of element access properties from C++. So now you can access the individual elements in a `List<T>`, for example.

And by leveraging that, all raster overlays are now added to and removed from the Tileset, rather than just the first.
