### PR TITLE
Improve build system and instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,15 +13,4 @@ endif()
 # Install to the Assets directory.
 set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_LIST_DIR}/Assets)
 
-# TODO: This is running "publish" on a normal build.
-#       Ideally we'd only copy the C# DLL to Assets on install.
-add_custom_target(
-    CesiumForUnity ALL
-    dotnet publish CesiumForUnity -c $<CONFIG>
-    WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
-    VERBATIM
-)
-
 add_subdirectory(CesiumForUnityNative)
-
-add_dependencies(CesiumForUnityNative CesiumForUnity)

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ To make sure things are set up correctly, open a command-prompt (PowerShell is a
 Clone the `cesium-unity-samples` (game) project and `cesium-unity` (plugin) project anywhere you like:
 
 ```
-git clone https://github.com/CesiumGS/cesium-unity-samples.git
-git clone https://github.com/CesiumGS/cesium-unity.git
+git clone --recurse-submodules https://github.com/CesiumGS/cesium-unity-samples.git
+git clone --recurse-submodules https://github.com/CesiumGS/cesium-unity.git
 ```
 
-Make sure to also clone the submodules.
+Be sure to also clone the submodules. If you forgot the `--recurse-submodules` option when you cloned, run `git submodule update --init --recursive`.
 
 Create a directory junction (symbol link) from the game project's Assets directory into the plugin's Assets directory. On Windows 11, this should just work. On Windows 10, you may need to enable "Developer Mode" and/or use an Administrator command prompt. If you've put the two repos side-by-side as shown above, simply run the following in PowerShell:
 
@@ -44,7 +44,22 @@ Unity only loads assets found in the game's Assets folder. By using a symlink, w
  In order to build succesfully, the HintPaths in [CesiumForUnity.csproj](CesiumForUnity/CesiumForUnity.csproj) must be correct. On Mac, for instance, the UnityEngine.dll HintPath is:
 `/Applications/Unity/Hub/Editor/2021.3.2f1/Unity.app/Contents/Managed/UnityEngine.dll`
 
-The build consists of both C# and C++ code, but both can be invoked with a single CMake command. In the root `cesium-unity` directory, run:
+The build consists of both C# and C++ code. The C# code must be compiled first, because its compilation process generates some code that is needed by the C++ build. To build the C# code, run the following in the root `cesium-unity` directory:
+
+```
+dotnet publish CesiumForUnity -c Debug
+```
+
+Replace `Debug` with `Release` for a release build.
+
+This will do the following:
+
+* Compile the Cesium for Unity C# code.
+* Generate (on the fly) some new C# code for interop with C++ and compile that in, too.
+* Generate C++ header and source files for the C++ side of the interop.
+* Copy the built DLLs and PDBs to the `Assets` directory.
+
+To build the C++ code, run the following from the `cesium-unity` directory:
 
 ```
 cmake -B build -S .
@@ -53,11 +68,8 @@ cmake --build build --target install
 
 (or just use `CMake: Configure` and `CMake: Install` from Visual Studio Code)
 
-This will do a few things:
+The CMake build will:
 
-* Compile the Cesium for Unity C# code.
-* Generate (on the fly) some new C# code for interop with C++ and compile that in, too.
-* Generate C++ header and source files for the C++ side of the interop.
 * Compile the DLL containing the C++ code.
 * Copy the built DLLs and PDBs to the `Assets` directory.
 


### PR DESCRIPTION
The previous build instructions didn't actually work, if you started from a clean slate. They said to run the CMake build, which would automatically invoke the C# build. That sounded good in theory, but didn't work well because:

1. The CMake configure uses a glob to find all the C++ source files, including the generated ones.
2. When the configure runs, the generated files don't exist yet.
3. When the build runs, the C# build is invoked, too, which finally generates the C++ source files.
4. CMake charges ahead, now doing the C++ build, but because the configure-time globs don't include the generated source files, the build fails.

Running CMake configure/build again fixes this, but it's still not great.

So this PR updates the instructions to say to run the C# build explicitly before running the C++ build, and removes the automatic invocation of the C# build via CMake.

Also added a note to the instructions about `--recurse-submodules` in the `git clone`.