### PR TITLE
default to build on native architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,6 @@ project(cesium-unity
 # position independent code.
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-if(APPLE)
-    set(CMAKE_OSX_ARCHITECTURES "x86_64")
-endif()
-
 # Install to the Assets directory.
 set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_LIST_DIR}/Assets)
 


### PR DESCRIPTION
Tested building with Apple Silicon. It just works. I attempted to build a universal binary (both x86_64 and arm64), which would be ideal, but it runs into configure error.

According to [this page](https://cmake.org/cmake/help/latest/variable/CMAKE_APPLE_SILICON_PROCESSOR.html), the user could just set that variable on the command line, (i.e.```cmake -DCMAKE_APPLE_SILICON_PROCESSOR=x86_64 -B build -S . ```) to control whether to build for M1 or Intel. By default, it builds whatever the host architecture is.