### PR TITLE
Add colliders to tilesets

### DIFF
--- a/CesiumForUnity/Cesium3DTileset.cs
+++ b/CesiumForUnity/Cesium3DTileset.cs
@@ -219,6 +219,24 @@ namespace CesiumForUnity
             set { this._logSelectionStats = value; }
         }
 
+        [SerializeField]
+        [Header("Physics")]
+        [Tooltip("Whether to generate physics meshes for this tileset.\n\n" +
+            "Disabling this option will improve the performance of tile loading, " +
+            "but it will no longer be possible to collide with the tileset since " +
+            "the physics meshes will not be created.")]
+        [InspectorName("Create Physics Meshes")]
+        private bool _createPhysicsMeshes = true;
+
+        public bool createPhysicsMeshes
+        {
+            get => this._createPhysicsMeshes;
+            set {
+                this._createPhysicsMeshes = value;
+                this.RecreateTileset();
+            }
+        }
+
         private partial void Start();
         private partial void Update();
         private partial void OnValidate();

--- a/CesiumForUnity/ConfigureReinterop.cs
+++ b/CesiumForUnity/ConfigureReinterop.cs
@@ -142,6 +142,7 @@ internal partial class ConfigureReinterop
         tileset.loadingDescendantLimit = tileset.loadingDescendantLimit;
         tileset.enforceCulledScreenSpaceError = tileset.enforceCulledScreenSpaceError;
         tileset.culledScreenSpaceError = tileset.culledScreenSpaceError;
+        tileset.createPhysicsMeshes = tileset.createPhysicsMeshes;
 
         Cesium3DTileset tilesetFromGameObject = go.GetComponent<Cesium3DTileset>();
         MeshRenderer meshRendererFromGameObject = go.GetComponent<MeshRenderer>();

--- a/CesiumForUnityNative/src/UnityPrepareRendererResources.cpp
+++ b/CesiumForUnityNative/src/UnityPrepareRendererResources.cpp
@@ -133,9 +133,15 @@ void* UnityPrepareRendererResources::prepareInMainThread(
         System::String("CesiumDefaultTilesetMaterial"));
   }
 
+  const bool createPhysicsMeshes = tilesetComponent.createPhysicsMeshes();
+
   model.forEachPrimitiveInScene(
       -1,
-      [&pModelGameObject, &tileTransform, opaqueMaterial, pCoordinateSystem](
+      [&pModelGameObject,
+       &tileTransform,
+       opaqueMaterial,
+       pCoordinateSystem,
+       createPhysicsMeshes](
           const Model& gltf,
           const Node& node,
           const Mesh& mesh,
@@ -355,9 +361,11 @@ void* UnityPrepareRendererResources::prepareInMainThread(
 
         meshFilter.mesh(unityMesh);
 
-        UnityEngine::MeshCollider meshCollider =
-            primitiveGameObject.AddComponent<UnityEngine::MeshCollider>();
-        meshCollider.sharedMesh(unityMesh);
+        if (createPhysicsMeshes) {
+          UnityEngine::MeshCollider meshCollider =
+              primitiveGameObject.AddComponent<UnityEngine::MeshCollider>();
+          meshCollider.sharedMesh(unityMesh);
+        }
       });
 
   return pModelGameObject.release();


### PR DESCRIPTION
This PR implements basic physics for tilesets by adding a `MeshCollider` and `Rigidbody` to every primitive that is generated from a glTF.

I noticed that there's a option to disable physics meshes from being generated in Unreal -- should this option be implemented here as well?