### PR TITLE
fix for il2cpp

### DIFF
--- a/Reinterop/CodeGenerator.cs
+++ b/Reinterop/CodeGenerator.cs
@@ -207,6 +207,7 @@ namespace Reinterop
                     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
                     private unsafe delegate IntPtr {{csBaseName}}Type(IntPtr callbackFunction);
                     private static unsafe readonly {{csBaseName}}Type {{csBaseName}}Delegate = new {{csBaseName}}Type({{csBaseName}});
+                    [AOT.MonoPInvokeCallback(typeof({{csBaseName}}Type))]
                     private static unsafe IntPtr {{csBaseName}}(IntPtr callbackFunction)
                     {
                         var receiver = new {{csType.Symbol.Name}}{{genericTypeHash}}NativeFunction(callbackFunction);
@@ -301,6 +302,7 @@ namespace Reinterop
                     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
                     private unsafe delegate System.IntPtr {{csCombineDelegatesName}}Type(System.IntPtr thiz, System.IntPtr rhs);
                     private static unsafe readonly {{csCombineDelegatesName}}Type {{csCombineDelegatesName}}Delegate = new {{csCombineDelegatesName}}Type({{csCombineDelegatesName}});
+                    [AOT.MonoPInvokeCallback(typeof({{csCombineDelegatesName}}Type))]
                     private static unsafe System.IntPtr {{csCombineDelegatesName}}(System.IntPtr thiz, System.IntPtr rhs)
                     {
                         {{csType.GetFullyQualifiedName()}} left = ({{csType.GetFullyQualifiedName()}})ObjectHandleUtility.GetObjectFromHandle(thiz)!;
@@ -320,6 +322,7 @@ namespace Reinterop
                     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
                     private unsafe delegate System.IntPtr {{csRemoveDelegateName}}Type(System.IntPtr thiz, System.IntPtr rhs);
                     private static unsafe readonly {{csRemoveDelegateName}}Type {{csRemoveDelegateName}}Delegate = new {{csRemoveDelegateName}}Type({{csRemoveDelegateName}});
+                    [AOT.MonoPInvokeCallback(typeof({{csRemoveDelegateName}}Type))]
                     private static unsafe System.IntPtr {{csRemoveDelegateName}}(System.IntPtr thiz, System.IntPtr rhs)
                     {
                         {{csType.GetFullyQualifiedName()}} left = ({{csType.GetFullyQualifiedName()}})ObjectHandleUtility.GetObjectFromHandle(thiz)!;

--- a/Reinterop/Interop.cs
+++ b/Reinterop/Interop.cs
@@ -162,6 +162,7 @@ namespace Reinterop
                     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
                     private unsafe delegate {{interopReturnTypeString}} {{baseName}}Type({{interopParameterList}});
                     private static unsafe readonly {{baseName}}Type {{baseName}}Delegate = new {{baseName}}Type({{baseName}});
+                    [AOT.MonoPInvokeCallback(typeof({{baseName}}Type))]
                     private static unsafe {{interopReturnTypeString}} {{baseName}}({{interopParameterList}})
                     {
                         {{implementation.Replace(Environment.NewLine, Environment.NewLine + "  ")}}
@@ -242,6 +243,7 @@ namespace Reinterop
                     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
                     private unsafe delegate {{interopReturnTypeString}} {{baseName}}Type({{interopParameterList}});
                     private static unsafe readonly {{baseName}}Type {{baseName}}Delegate = new {{baseName}}Type({{baseName}});
+                    [AOT.MonoPInvokeCallback(typeof({{baseName}}Type))]
                     private static unsafe {{interopReturnTypeString}} {{baseName}}({{interopParameterList}})
                     {
                         {{implementation.Replace(Environment.NewLine, Environment.NewLine + "  ")}}

--- a/Reinterop/MethodsImplementedInCpp.cs
+++ b/Reinterop/MethodsImplementedInCpp.cs
@@ -207,6 +207,7 @@ namespace Reinterop
                     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
                     private unsafe delegate IntPtr {{baseName}}Type(IntPtr thiz);
                     private static unsafe readonly {{baseName}}Type {{baseName}}Delegate = new {{baseName}}Type({{baseName}});
+                    [AOT.MonoPInvokeCallback(typeof({{baseName}}Type))]
                     private static unsafe IntPtr {{baseName}}(IntPtr thiz)
                     {
                         return ({{csWrapperType.GetParameterConversionFromInteropType("thiz")}}).NativeImplementation;


### PR DESCRIPTION
IL2CPP is needed for Oculus. The log message, 

`17:10:07.121  7460  7595 E Unity         : NotSupportedException: To marshal a managed method, please add an attribute named 'MonoPInvokeCallback' to the method definition. The method we're attempting to marshal is: Reinterop.ReinteropInitializer::CesiumForUnity_Cesium3DTileset_CallDestroy_x7aQMuJcEpatC9689ghI4A
17:10:07.121  7460  7595 E Unity         : at System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegateInternal (System.Delegate d) [0x00000] in <00000000000000000000000000000000>:0 
17:10:07.121  7460  7595 E Unity         : at System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate[TDelegate] (TDelegate d) [0x00000] in <00000000000000000000000000000000>:0 
17:10:07.121  7460  7595 E Unity         : at Reinterop.ReinteropInitializer..cctor () [0x00000] in <00000000000000000000000000000000>:0 
17:10:07.121  7460  7595 E Unity         : at CesiumForUnity.Cesium3DTileset.CreateImplementation () [0x00000] in <00000000000000000000000000000000>:0 
17:10:07.121  7460  7595 E Unity         : at CesiumForUnity.Cesium3DTileset..ctor () [0x00000] in <00000000000000000000000000000000>:0 
17:10:07.121  7460  7595 E Unity         : Rethrow as TypeInitializationException: The type initializer for 'Reinterop.ReinteropInitializer' threw an exception.
17:10:07.121  7460  7595 E Unity         : at CesiumForUnity.Cesium3
17:10:07.123   750   970 I SDM           : HWDeviceDRM::UpdateMixerAttributes: Mixer WxH 1920x1832-1 for Virtual
17:10:07.123   750   970 I SDM           : HWVirtualDRM::SetDisplayAttributes: New WB Resolution: 1920x1832 cur_mode_index 5
17:10:07.123   750   970 I SDM           : DisplayVirtual::SetActiveConfig: Virtual display resolution changed to[1920x1832]
17:10:07.123   750   970 I SDM           : DisplayBase::SetFrameBufferConfig: New framebuffer resolution (1920x1832)
17:10:07.123   750   970 I SDM           : HWCDisplay::SetFrameBufferConfig: New framebuffer resolution (1920x1832)
17:10:07.126  1935  2805 I [OAO] ShellOverlayApp: 0xc0524bd0 msg: overlayCommand:`

Adding the attribute fixed the error. Also, learned that to regenerate the changes, it is necessary to delete the `build` folder as well.
