### PR TITLE
Fix tile artifact in release builds by explicitly marshalling bools as uint8.

### DIFF
--- a/Reinterop/CppType.cs
+++ b/Reinterop/CppType.cs
@@ -362,7 +362,14 @@ namespace Reinterop
         /// </summary>
         public CppType AsInteropType()
         {
-            if (this.Kind == InteropTypeKind.Primitive)
+            if (this == Boolean)
+            {
+                // C++ doesn't specify the size of a bool, and C# uses
+                // different sizes in different contexts. So we explicitly
+                // marshal bools as uint8_t.
+                return UInt8;
+            }
+            else if (this.Kind == InteropTypeKind.Primitive)
                 return this;
             else if (this.Kind == InteropTypeKind.BlittableStruct)
                 return this.AsSimpleType();
@@ -378,6 +385,11 @@ namespace Reinterop
         /// </summary>
         public string GetConversionToInteropType(CppGenerationContext context, string variableName)
         {
+            if (this == Boolean)
+            {
+                return $"{variableName} ? 1 : 0";
+            }
+
             switch (this.Kind)
             {
                 case InteropTypeKind.ClassWrapper:
@@ -406,6 +418,11 @@ namespace Reinterop
 
         public string GetConversionFromInteropType(CppGenerationContext context, string variableName)
         {
+            if (this == Boolean)
+            {
+                return $"!!{variableName}";
+            }
+
             switch (this.Kind)
             {
                 case InteropTypeKind.ClassWrapper:


### PR DESCRIPTION
Fixes #32 

Marshalling boolean values is tricky because the C++ standard explicitly avoids saying how big a `bool` is, and C#'s idea of a bool (a two byte signed integer) is unusual as well. This was causing our attempt to pass `false` for the "linear" flag when creating a texture to actually pass random memory that may or may not be interpreted as false. So we would sometimes get sRGB textures, and sometimes get linear ones.

The solution implemented in this PR is to always pass bools between environments as uint8_t with a value of 1 (true) or 0 (false). Some background: https://www.mono-project.com/docs/advanced/pinvoke/#boolean-members