### PR TITLE
Update the georeference transform in Awake.

### DIFF
--- a/CesiumForUnity/CesiumGeoreference.cs
+++ b/CesiumForUnity/CesiumGeoreference.cs
@@ -65,5 +65,6 @@ namespace CesiumForUnity
         private partial void RecalculateOrigin();
 
         private partial void OnValidate();
+        private partial void Awake();
     }
 }

--- a/CesiumForUnityNative/src/CesiumGeoreferenceImpl.cpp
+++ b/CesiumForUnityNative/src/CesiumGeoreferenceImpl.cpp
@@ -43,3 +43,7 @@ void CesiumGeoreferenceImpl::OnValidate(
     const DotNet::CesiumForUnity::CesiumGeoreference& georeference) {
   georeference.UpdateOrigin();
 }
+
+void CesiumGeoreferenceImpl::Awake(const DotNet::CesiumForUnity::CesiumGeoreference& georeference) {
+  georeference.UpdateOrigin();
+}

--- a/CesiumForUnityNative/src/CesiumGeoreferenceImpl.h
+++ b/CesiumForUnityNative/src/CesiumGeoreferenceImpl.h
@@ -19,6 +19,7 @@ public:
       const DotNet::CesiumForUnity::CesiumGeoreference& georeference);
   void
   OnValidate(const DotNet::CesiumForUnity::CesiumGeoreference& georeference);
+  void Awake(const DotNet::CesiumForUnity::CesiumGeoreference& georeference);
 
   const CesiumGeospatial::LocalHorizontalCoordinateSystem&
   getCoordinateSystem() const {


### PR DESCRIPTION
So that the transform is recomputed _after_ the values are deserialized in a built game.

Fixes #33