### PR TITLE
Improve support for blittable structs.

### DIFF
--- a/Reinterop/ExposeToCppSyntaxWalker.cs
+++ b/Reinterop/ExposeToCppSyntaxWalker.cs
@@ -145,6 +145,19 @@ namespace Reinterop
                     if (invokeMethod != null)
                         this.AddMethod(invokeMethod);
                 }
+
+                // If this is a blittable struct, we need to generate all the field types, too.
+                if (type.TypeKind != TypeKind.Enum && Interop.IsBlittableStruct(this._semanticModel.Compilation, type))
+                {
+                    ImmutableArray<ISymbol> members = type.GetMembers();
+                    foreach (ISymbol member in members)
+                    {
+                        IFieldSymbol? field = member as IFieldSymbol;
+                        if (field == null)
+                            continue;
+                        AddType(field.Type);
+                    }
+                }
             }
 
             // If this type is an enumeration, add all of the enum values if we haven't already.


### PR DESCRIPTION
This PR don't affect the current code generation, but is necessary to start using `MeshData` and `MeshDataArray`.

Improvements:

* Generate a C++ type for each of the non-primitive fields in the blittable struct. Previously we were trying to use them without generating them, which of course didn't work.
* For automatic properties in a blittable struct (i.e. `string Foo { get; set; }`), use the name of the property as the field name in C++. Previously it would try to use the auto-generated backing fields, which have names which are not valid C++ or C# identifiers, such as `<foo>k__BackingField`.
* Allow calling of methods on blittable structs.
* Don't get caught in endless recursion and cause a stack overflow when calling `IsBlittableStruct` on a struct contains itself. This can happen with enums and with static fields with constant values of the struct's type.