### PR TITLE
Change overlay texture wrap mode to "clamp"

### DIFF
--- a/CesiumForUnity/ConfigureReinterop.cs
+++ b/CesiumForUnity/ConfigureReinterop.cs
@@ -55,6 +55,7 @@ internal partial class ConfigureReinterop
         Texture2D texture2D = new Texture2D(256, 256, TextureFormat.RGBA32, false, false);
         texture2D.LoadRawTextureData(IntPtr.Zero, 0);
         texture2D.Apply(true, true);
+        texture2D.wrapMode = TextureWrapMode.Clamp;
         Texture texture = texture2D;
 
         Mesh mesh = new Mesh();

--- a/CesiumForUnityNative/src/UnityPrepareRendererResources.cpp
+++ b/CesiumForUnityNative/src/UnityPrepareRendererResources.cpp
@@ -33,6 +33,7 @@
 #include <DotNet/UnityEngine/Quaternion.h>
 #include <DotNet/UnityEngine/Resources.h>
 #include <DotNet/UnityEngine/Texture.h>
+#include <DotNet/UnityEngine/TextureWrapMode.h>
 #include <DotNet/UnityEngine/Transform.h>
 #include <DotNet/UnityEngine/Vector2.h>
 #include <DotNet/UnityEngine/Vector3.h>
@@ -393,6 +394,7 @@ void* UnityPrepareRendererResources::prepareRasterInMainThread(
     void* pLoadThreadResult) {
   auto pTexture = std::make_unique<UnityEngine::Texture>(
       TextureLoader::loadTexture(rasterTile.getImage()));
+  pTexture->wrapMode(UnityEngine::TextureWrapMode::Clamp);
   return pTexture.release();
 }
 


### PR DESCRIPTION
Otherwise it defaults to "wrap" and interpolation for pixels at the edges ends up pulling from the other side, creating a very obvious seam.

Fixes #37 