### PR TITLE
Support multiple arrays of types in the same namespace.

### DIFF
--- a/CesiumForUnity/ConfigureReinterop.cs
+++ b/CesiumForUnity/ConfigureReinterop.cs
@@ -194,5 +194,7 @@ internal partial class ConfigureReinterop
         {
             GameObject goFromArray = gos[i];
         }
+
+        CesiumGeoreference[] georeferences = UnityEngine.Object.FindObjectsOfType<CesiumGeoreference>();
     }
 }

--- a/Reinterop/CppType.cs
+++ b/Reinterop/CppType.cs
@@ -206,8 +206,8 @@ namespace Reinterop
 
         public void AddForwardDeclarationsToSet(ISet<string> forwardDeclarations)
         {
-            // Primitives do not need to be forward declared
-            if (Kind == InteropTypeKind.Primitive)
+            // Primitives and generic parameters do not need to be forward declared
+            if (Kind == InteropTypeKind.Primitive || Kind == InteropTypeKind.GenericParameter)
                 return;
 
             string template = "";

--- a/Reinterop/Interop.cs
+++ b/Reinterop/Interop.cs
@@ -254,6 +254,7 @@ namespace Reinterop
 
         public static string GetUniqueNameForType(CSharpType type)
         {
+            string name = type.Symbol.Name;
             string genericTypeHash = "";
             INamedTypeSymbol? named = type.Symbol as INamedTypeSymbol;
             if (named != null && named.IsGenericType)
@@ -261,7 +262,14 @@ namespace Reinterop
                 genericTypeHash = HashParameters(null, named.TypeArguments);
             }
 
-            return $"{type.GetFullyQualifiedNamespace().Replace(".", "_")}_{type.Symbol.Name}{genericTypeHash}";
+            IArrayTypeSymbol? arraySymbol = type.Symbol as IArrayTypeSymbol;
+            if (arraySymbol != null)
+            {
+                name = "Array1";
+                genericTypeHash = HashParameters(null, new[] { arraySymbol.ElementType });
+            }
+
+            return $"{type.GetFullyQualifiedNamespace().Replace(".", "_")}_{name}{genericTypeHash}";
         }
 
         public static void GenerateForType(CppGenerationContext context, TypeToGenerate item, GeneratedResult result)

--- a/Reinterop/Methods.cs
+++ b/Reinterop/Methods.cs
@@ -68,7 +68,7 @@ namespace Reinterop
                             template <{{string.Join(", ", method.TypeParameters.Select(parameter => "typename " + parameter.Name))}}>
                             {{modifiers}}{{genericReturn.GetFullyQualifiedName()}} {{method.Name}}({{genericParametersString}}){{afterModifiers}};
                             """,
-                        TypeDeclarationsReferenced: genericMethod.Parameters.Select(p => CppType.FromCSharp(context, p.Type))
+                        TypeDeclarationsReferenced: new[] { genericReturn }.Concat(genericMethod.Parameters.Select(p => CppType.FromCSharp(context, p.Type)))
                         ));
                 }
 


### PR DESCRIPTION
Fixes #40 

The problem was that, because in the Roslyn compiler array symbols have an empty `Name` property, the interop method generated for array properties didn't have any information about the element type name, only its namespace. So if we tried to access arrays of different types _in the same namespace_ we'd generate conflicting symbol names.

Also fixed a bug that would cause Reinterop to generate dodgy forward declarations for uninstantiated generic types (e.g. `List<T>` rather than `List<CesiumGeoreference>`. And another bug that made it fail to generate the forward declaration for the return type of a generic method.