### PR TITLE
Add `showTilesInHierarchy` to `Cesium3DTileset` inspector

### DIFF
--- a/Editor/Cesium3DTilesetEditor.cs
+++ b/Editor/Cesium3DTilesetEditor.cs
@@ -36,6 +36,7 @@ namespace CesiumForUnity
         private SerializedProperty _lodTransitionLength;
         private SerializedProperty _generateSmoothNormals;
 
+        private SerializedProperty _showTilesInHierarchy;
         private SerializedProperty _suspendUpdate;
         private SerializedProperty _updateInEditor;
         private SerializedProperty _logSelectionStats;
@@ -81,6 +82,8 @@ namespace CesiumForUnity
             this._generateSmoothNormals =
                 this.serializedObject.FindProperty("_generateSmoothNormals");
 
+            this._showTilesInHierarchy =
+                this.serializedObject.FindProperty("_showTilesInHierarchy");
             this._suspendUpdate = this.serializedObject.FindProperty("_suspendUpdate");
             this._updateInEditor = this.serializedObject.FindProperty("_updateInEditor");
             this._logSelectionStats = this.serializedObject.FindProperty("_logSelectionStats");
@@ -392,6 +395,11 @@ namespace CesiumForUnity
         private void DrawDebugProperties()
         {
             GUILayout.Label("Debug", EditorStyles.boldLabel);
+
+            GUIContent showTilesInHierarchyContent = new GUIContent(
+                "Show Tiles In Hierarchy",
+                "Whether to show tiles as individual game objects in the hierarchy window.");
+            EditorGUILayout.PropertyField(this._showTilesInHierarchy, showTilesInHierarchyContent);
 
             GUIContent suspendUpdateContent = new GUIContent(
                 "Suspend Update",

--- a/Runtime/Cesium3DTileset.cs
+++ b/Runtime/Cesium3DTileset.cs
@@ -318,9 +318,6 @@ namespace CesiumForUnity
         }
 
         [SerializeField]
-        [Header("Debug")]
-        [Tooltip("Whether to show tiles as individual components in the hierarchy window.")]
-        [InspectorName("ShowTilesInHierarchy")]
         private bool _showTilesInHierarchy = false;
 
         public bool showTilesInHierarchy


### PR DESCRIPTION
Closes #85. This PR adds the `showTilesInHierarchy` property to the `Cesium3DTileset` inspector UI.