### PR TITLE
Fix editor camera bug + remove modal function on TextMeshPro window

### DIFF
--- a/Editor/TextMeshProPromptWindow.cs
+++ b/Editor/TextMeshProPromptWindow.cs
@@ -20,7 +20,8 @@ namespace CesiumForUnity
             position.y = (Screen.height / 2);
             currentWindow.position = position;
 
-            currentWindow.ShowModalUtility();
+            currentWindow.Show();
+            currentWindow.Focus();
         }
 
         private void OnEnable()

--- a/native~/Runtime/src/CameraManager.cpp
+++ b/native~/Runtime/src/CameraManager.cpp
@@ -92,7 +92,7 @@ std::vector<ViewState> CameraManager::getAllCameras(const GameObject& context) {
   SceneView lastActiveEditorView = SceneView::lastActiveSceneView();
   if (lastActiveEditorView != nullptr) {
     Camera editorCamera = lastActiveEditorView.camera();
-    if (camera != nullptr) {
+    if (editorCamera != nullptr) {
       result.emplace_back(
           unityCameraToViewState(pCoordinateSystem, editorCamera));
     }


### PR DESCRIPTION
Just two one-line changes:

1. A typo in `CameraManager.cpp` was preventing the editor camera from being properly added to the list of `ViewState`s. When there was no `Camera` in the scene itself, nothing would render.
2. The TextMeshPro prompt window I added doesn't let the user click anything until its button was pressed or until it was closed. This became unideal when working on the sample scenes, because those scenes contain the `TextMeshPro` components already, so it already prompts the user to import the package. We should keep the window regardless because users can use Cesium in scenes without `TextMeshPro`, but we shouldn't hold the rest of the Editor hostage.