### PR TITLE
Only run one Windows build at a time.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ on: [push]
 jobs:
   Windows:
     runs-on: windows-latest
+    # Only allow a single Windows build at a time, for Unity licensing reasons
+    concurrency: windows
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3


### PR DESCRIPTION
When we try to run a build and our build license server is out of floating licenses, the build will fail. So this PR uses Github Actions' [concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) to only allow one Windows job at a time to run across all branches. Others will sit in the "queued" state until they get a chance to run.

Ideally we'd allow multiple jobs to run at a time, up to our floating license limit. But GitHub Actions concurrency doesn't have that kind of flexibility, and I don't see an obvious way to implement it.