### PR TITLE
Remove -nullable, fix warnings.

### DIFF
--- a/Editor/CesiumEditorUtility.cs
+++ b/Editor/CesiumEditorUtility.cs
@@ -142,7 +142,7 @@ namespace CesiumForUnity
             }
         }
 
-        public static Cesium3DTileset? FindFirstTileset()
+        public static Cesium3DTileset FindFirstTileset()
         {
             Cesium3DTileset[] tilesets =
                 UnityEngine.Object.FindObjectsOfType<Cesium3DTileset>(true);
@@ -158,7 +158,7 @@ namespace CesiumForUnity
             return null;
         }
 
-        public static Cesium3DTileset? FindFirstTilesetWithAssetID(long assetID)
+        public static Cesium3DTileset FindFirstTilesetWithAssetID(long assetID)
         {
             Cesium3DTileset[] tilesets =
                 UnityEngine.Object.FindObjectsOfType<Cesium3DTileset>(true);
@@ -174,7 +174,7 @@ namespace CesiumForUnity
             return null;
         }
 
-        public static CesiumGeoreference? FindFirstGeoreference()
+        public static CesiumGeoreference FindFirstGeoreference()
         {
             CesiumGeoreference[] georeferences =
                UnityEngine.Object.FindObjectsOfType<CesiumGeoreference>(true);
@@ -193,7 +193,7 @@ namespace CesiumForUnity
         public static Cesium3DTileset CreateTileset(string name, long assetID)
         {
             // Find a georeference in the scene, or create one if none exists.
-            CesiumGeoreference? georeference = CesiumEditorUtility.FindFirstGeoreference();
+            CesiumGeoreference georeference = CesiumEditorUtility.FindFirstGeoreference();
             if (georeference == null)
             {
                 GameObject georeferenceGameObject =
@@ -332,7 +332,7 @@ namespace CesiumForUnity
 
         public static void PlaceSubSceneAtCameraPosition(CesiumSubScene subscene)
         {
-            CesiumGeoreference? georeference =
+            CesiumGeoreference georeference =
                 subscene.gameObject.GetComponentInParent<CesiumGeoreference>();
             if (georeference == null)
             {

--- a/Editor/CesiumEditorWindow.cs
+++ b/Editor/CesiumEditorWindow.cs
@@ -9,7 +9,7 @@ namespace CesiumForUnity
     [ReinteropNativeImplementation("CesiumForUnityNative::CesiumEditorWindowImpl", "CesiumEditorWindowImpl.h")]
     public partial class CesiumEditorWindow : EditorWindow
     {
-        public static CesiumEditorWindow? currentWindow = null;
+        public static CesiumEditorWindow currentWindow = null;
 
         [MenuItem("Cesium/Cesium")]
         public static void ShowWindow()

--- a/Editor/CesiumIonAsset.cs
+++ b/Editor/CesiumIonAsset.cs
@@ -18,8 +18,8 @@ namespace CesiumForUnity
         }
 
         private AssetType _type = AssetType.Null;
-        private Cesium3DTileset? _tileset;
-        private CesiumRasterOverlay? _overlay;
+        private Cesium3DTileset _tileset;
+        private CesiumRasterOverlay _overlay;
 
         public CesiumIonAsset()
         {
@@ -38,12 +38,12 @@ namespace CesiumForUnity
             this._overlay = overlay;
         }
 
-        public Cesium3DTileset? tileset
+        public Cesium3DTileset tileset
         {
             get => this._type == AssetType.Tileset ? this._tileset : null;
         }
 
-        public CesiumRasterOverlay? overlay
+        public CesiumRasterOverlay overlay
         {
             get => this._type == AssetType.Overlay ? this._overlay : null;
         }
@@ -114,7 +114,7 @@ namespace CesiumForUnity
 
                 if (this._type == AssetType.Overlay)
                 {
-                    CesiumIonRasterOverlay? ionOverlay = this._overlay as CesiumIonRasterOverlay;
+                    CesiumIonRasterOverlay ionOverlay = this._overlay as CesiumIonRasterOverlay;
                     return ionOverlay != null ? ionOverlay.ionAccessToken : "";
                 }
 
@@ -129,7 +129,7 @@ namespace CesiumForUnity
 
                 if (this._type == AssetType.Overlay)
                 {
-                    CesiumIonRasterOverlay? ionOverlay = this._overlay as CesiumIonRasterOverlay;
+                    CesiumIonRasterOverlay ionOverlay = this._overlay as CesiumIonRasterOverlay;
                     if (ionOverlay != null)
                     {
                         ionOverlay.ionAccessToken = value;
@@ -150,7 +150,7 @@ namespace CesiumForUnity
 
                 if (this._type == AssetType.Overlay && this._overlay != null)
                 {
-                    CesiumIonRasterOverlay? ionOverlay = this._overlay as CesiumIonRasterOverlay;
+                    CesiumIonRasterOverlay ionOverlay = this._overlay as CesiumIonRasterOverlay;
                     return ionOverlay != null ? ionOverlay.ionAssetID : 0;
                 }
 
@@ -182,7 +182,7 @@ namespace CesiumForUnity
 
             if (this._type == AssetType.Overlay && this._overlay != null)
             {
-                CesiumIonRasterOverlay? ionOverlay = this._overlay as CesiumIonRasterOverlay;
+                CesiumIonRasterOverlay ionOverlay = this._overlay as CesiumIonRasterOverlay;
                 return ionOverlay != null;
             }
 

--- a/Editor/CesiumIonAssetsWindow.cs
+++ b/Editor/CesiumIonAssetsWindow.cs
@@ -8,7 +8,7 @@ namespace CesiumForUnity
 {
     public class CesiumIonAssetsWindow : EditorWindow
     {
-        public static CesiumIonAssetsWindow? currentWindow = null;
+        public static CesiumIonAssetsWindow currentWindow = null;
 
         [MenuItem("Cesium/Cesium ion Assets")]
         public static void ShowWindow()

--- a/Editor/CompileCesiumForUnityNative.cs
+++ b/Editor/CompileCesiumForUnityNative.cs
@@ -36,14 +36,14 @@ namespace CesiumForUnity
         {
             public BuildTarget Platform = BuildTarget.StandaloneWindows64;
             public BuildTargetGroup PlatformGroup = BuildTargetGroup.Standalone;
-            public string? Cpu = null;
+            public string Cpu = null;
             public string SourceDirectory = "";
             public string BuildDirectory = "build";
             public string GeneratedDirectoryName = "generated-Unknown";
             public string Configuration = "RelWithDebInfo";
             public string InstallDirectory = "";
             public bool CleanBuild = false;
-            public string? Toolchain;
+            public string Toolchain;
             public List<string> ExtraConfigureArgs = new List<string>();
             public List<string> ExtraBuildArgs = new List<string>();
         }
@@ -125,11 +125,11 @@ namespace CesiumForUnity
         /// </summary>
         private void OnPreprocessAsset()
         {
-            LibraryToBuild? libraryToBuild;
+            LibraryToBuild libraryToBuild;
             if (!importsInProgress.TryGetValue(assetPath, out libraryToBuild))
                 return;
 
-            PluginImporter? importer = this.assetImporter as PluginImporter;
+            PluginImporter importer = this.assetImporter as PluginImporter;
             if (importer == null)
                 return;
 
@@ -164,11 +164,11 @@ namespace CesiumForUnity
             // So reapply here as well.
             foreach (string imported in importedAssets)
             {
-                LibraryToBuild? libraryToBuild;
+                LibraryToBuild libraryToBuild;
                 if (!importsInProgress.TryGetValue(imported, out libraryToBuild))
                     continue;
 
-                PluginImporter? importer = AssetImporter.GetAtPath(imported) as PluginImporter;
+                PluginImporter importer = AssetImporter.GetAtPath(imported) as PluginImporter;
                 if (importer == null)
                     continue;
 
@@ -217,7 +217,7 @@ namespace CesiumForUnity
             }
         }
 
-        public static LibraryToBuild GetLibraryToBuild(BuildSummary summary, string? cpu = null)
+        public static LibraryToBuild GetLibraryToBuild(BuildSummary summary, string cpu = null)
         {
             return GetLibraryToBuild(new PlatformToBuild()
             {
@@ -228,7 +228,7 @@ namespace CesiumForUnity
             }, cpu);
         }
 
-        public static LibraryToBuild GetLibraryToBuild(PlatformToBuild platform, string? cpu = null)
+        public static LibraryToBuild GetLibraryToBuild(PlatformToBuild platform, string cpu = null)
         {
             string sourceFilename = GetSourceFilePathName();
             string packagePath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(sourceFilename), $".."));
@@ -397,7 +397,7 @@ namespace CesiumForUnity
         {
             // CMake can't deal with back slashes (Windows) in the ANDROID_NDK_ROOT environment variable.
             // So replace them with forward slashes.
-            string? ndkRoot = environment.ContainsKey("ANDROID_NDK_ROOT") ? environment["ANDROID_NDK_ROOT"] : null;
+            string ndkRoot = environment.ContainsKey("ANDROID_NDK_ROOT") ? environment["ANDROID_NDK_ROOT"] : null;
 #if UNITY_ANDROID
             if (ndkRoot == null)
             {
@@ -423,7 +423,7 @@ namespace CesiumForUnity
                 environment["ANDROID_NDK_ROOT"] = ndkRoot.Replace('\\', '/');
         }
 
-        private static string GetSourceFilePathName([CallerFilePath] string? callerFilePath = null)
+        private static string GetSourceFilePathName([CallerFilePath] string callerFilePath = null)
         {
             return callerFilePath == null ? "" : callerFilePath;
         }

--- a/Editor/ConfigureReinterop.cs
+++ b/Editor/ConfigureReinterop.cs
@@ -98,8 +98,6 @@ namespace CesiumForUnity
             string.Equals("stringA", "stringB");
             string.IsNullOrEmpty("value");
 
-            IonAssetsColumn column = IonAssetsColumn.Name;
-
             Rect r = new Rect(0, 0, 50, 50);
             GUI.Label(r, "Label");
 

--- a/Editor/IonTokenTroubleshootingWindow.cs
+++ b/Editor/IonTokenTroubleshootingWindow.cs
@@ -199,7 +199,7 @@ namespace CesiumForUnity
 
             // If this is a tileset, close any existing windows associated with its
             // overlays. Overlays won't appear until the tileset is working anyway.
-            Cesium3DTileset? tilesetAsset = ionAsset.tileset;
+            Cesium3DTileset tilesetAsset = ionAsset.tileset;
             if (tilesetAsset != null)
             {
                 CesiumRasterOverlay[] rasterOverlays =
@@ -219,7 +219,7 @@ namespace CesiumForUnity
 
             // If this is a raster overlay and this panel is already open for its attached
             // tileset, don't open the panel for the overlay for the same reason as above.
-            CesiumRasterOverlay? overlayAsset = ionAsset.overlay;
+            CesiumRasterOverlay overlayAsset = ionAsset.overlay;
             if (overlayAsset != null)
             {
                 Cesium3DTileset tileset

--- a/Editor/SelectIonTokenWindow.cs
+++ b/Editor/SelectIonTokenWindow.cs
@@ -15,7 +15,7 @@ namespace CesiumForUnity
     [ReinteropNativeImplementation("CesiumForUnityNative::SelectIonTokenWindowImpl", "SelectIonTokenWindowImpl.h")]
     public partial class SelectIonTokenWindow : EditorWindow
     {
-        public static SelectIonTokenWindow? currentWindow = null;
+        public static SelectIonTokenWindow currentWindow = null;
 
         public static void ShowWindow()
         {

--- a/Editor/csc.rsp
+++ b/Editor/csc.rsp
@@ -1,1 +1,1 @@
-﻿-nullable
+﻿

--- a/Reinterop~/CSharpObjectHandleUtility.cs
+++ b/Reinterop~/CSharpObjectHandleUtility.cs
@@ -11,7 +11,7 @@ namespace Reinterop
     {
         public static void Generate(GeneratorExecutionContext context)
         {
-            context.AddSource("ObjectHandle", Source);
+            context.AddSource("ObjectHandleUtility", Source);
         }
 
         public const string Source =
@@ -24,7 +24,7 @@ namespace Reinterop
                 [Reinterop]
                 internal static class ObjectHandleUtility
                 {
-                    public static IntPtr CreateHandle(object? o)
+                    public static IntPtr CreateHandle(object o)
                     {
                         if (o == null)
                             return IntPtr.Zero;
@@ -49,7 +49,7 @@ namespace Reinterop
                         GCHandle.FromIntPtr(handle).Free();
                     }
 
-                    public static object? GetObjectFromHandle(IntPtr handle)
+                    public static object GetObjectFromHandle(IntPtr handle)
                     {
                         if (handle == IntPtr.Zero)
                             return null;
@@ -57,13 +57,13 @@ namespace Reinterop
                         return GCHandle.FromIntPtr(handle).Target;
                     }
 
-                    public static object? GetObjectAndFreeHandle(IntPtr handle)
+                    public static object GetObjectAndFreeHandle(IntPtr handle)
                     {
                         if (handle == IntPtr.Zero)
                             return null;
 
                         GCHandle gcHandle = GCHandle.FromIntPtr(handle);
-                        object? result = gcHandle.Target;
+                        object result = gcHandle.Target;
                         gcHandle.Free();
                         return result;
                     }

--- a/Reinterop~/ExposeToCppSyntaxWalker.cs
+++ b/Reinterop~/ExposeToCppSyntaxWalker.cs
@@ -122,7 +122,7 @@ namespace Reinterop
             this.AddProperty(property, containingType);
         }
 
-        private TypeToGenerate AddType(ITypeSymbol type)
+        public TypeToGenerate AddType(ITypeSymbol type)
         {
             // Drop the nullability ("?") from the type if present.
             if (type.NullableAnnotation == NullableAnnotation.Annotated && type.OriginalDefinition != null)
@@ -224,7 +224,7 @@ namespace Reinterop
             return generationItem;
         }
 
-        private TypeToGenerate AddMethod(IMethodSymbol symbol)
+        public TypeToGenerate AddMethod(IMethodSymbol symbol)
         {
             TypeToGenerate item = this.AddType(symbol.ContainingType);
             item.Methods.Add(symbol);
@@ -240,7 +240,7 @@ namespace Reinterop
             return item;
         }
 
-        private TypeToGenerate AddProperty(IPropertySymbol symbol, ITypeSymbol? containingType = null)
+        public TypeToGenerate AddProperty(IPropertySymbol symbol, ITypeSymbol? containingType = null)
         {
             if (containingType == null)
                 containingType = symbol.ContainingType;
@@ -254,7 +254,7 @@ namespace Reinterop
             return item;
         }
 
-        private void AddEvent(IEventSymbol symbol)
+        public void AddEvent(IEventSymbol symbol)
         {
             TypeToGenerate item = this.AddType(symbol.ContainingType);
             item.Events.Add(symbol);
@@ -263,7 +263,7 @@ namespace Reinterop
             this.AddType(symbol.Type);
         }
 
-        private TypeToGenerate AddField(IFieldSymbol symbol)
+        public TypeToGenerate AddField(IFieldSymbol symbol)
         {
             TypeToGenerate item = this.AddType(symbol.ContainingType);
             item.Fields.Add(symbol);
@@ -274,7 +274,7 @@ namespace Reinterop
             return item;
         }
 
-        private TypeToGenerate AddConstructor(IMethodSymbol symbol)
+        public TypeToGenerate AddConstructor(IMethodSymbol symbol)
         {
             TypeToGenerate item = this.AddType(symbol.ContainingType);
             item.Constructors.Add(symbol);

--- a/Reinterop~/RoslynSourceGenerator.cs
+++ b/Reinterop~/RoslynSourceGenerator.cs
@@ -113,12 +113,7 @@ namespace Reinterop
 
                 if (type != null)
                 {
-                    TypeToGenerate item;
-                    if (!walker.GenerationItems.TryGetValue(type, out item))
-                    {
-                        item = new TypeToGenerate(type);
-                        walker.GenerationItems.Add(type, item);
-                    }
+                    TypeToGenerate item = walker.AddType(type);
 
                     item.ImplementationClassName = implClassName;
                     item.ImplementationHeaderName = implHeaderName;
@@ -134,6 +129,13 @@ namespace Reinterop
                             IMethodSymbol? symbol = semanticModel.GetDeclaredSymbol(methodSyntax) as IMethodSymbol;
                             if (symbol != null)
                             {
+                                walker.AddType(symbol.ReturnType);
+
+                                foreach (IParameterSymbol parameter in symbol.Parameters)
+                                {
+                                    walker.AddType(parameter.Type);
+                                }
+
                                 item.MethodsImplementedInCpp.Add(symbol);
                             }
                         }

--- a/Reinterop~/TypeToGenerate.cs
+++ b/Reinterop~/TypeToGenerate.cs
@@ -12,7 +12,7 @@ namespace Reinterop
             this.Properties = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
             this.Fields = new HashSet<IFieldSymbol>(SymbolEqualityComparer.Default);
             this.Events = new HashSet<IEventSymbol>(SymbolEqualityComparer.Default);
-            this.EnumValues = new List<IFieldSymbol>();
+            this.EnumValues = new HashSet<IFieldSymbol>(SymbolEqualityComparer.Default);
             this.Interfaces = new List<TypeToGenerate>();
             this.MethodsImplementedInCpp = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
         }
@@ -23,7 +23,7 @@ namespace Reinterop
         public HashSet<IPropertySymbol> Properties;
         public HashSet<IFieldSymbol> Fields;
         public HashSet<IEventSymbol> Events;
-        public List<IFieldSymbol> EnumValues;
+        public HashSet<IFieldSymbol> EnumValues;
         public TypeToGenerate? BaseClass;
         public List<TypeToGenerate> Interfaces;
         public HashSet<IMethodSymbol> MethodsImplementedInCpp;

--- a/Runtime/Cesium3DTileset.cs
+++ b/Runtime/Cesium3DTileset.cs
@@ -15,7 +15,7 @@ namespace CesiumForUnity
     {
         public delegate void TilesetLoadFailureDelegate(
             Cesium3DTilesetLoadFailureDetails details);
-        public static event TilesetLoadFailureDelegate? OnCesium3DTilesetLoadFailure;
+        public static event TilesetLoadFailureDelegate OnCesium3DTilesetLoadFailure;
 
         public static void
             BroadcastCesium3DTilesetLoadFailure(Cesium3DTilesetLoadFailureDetails details)
@@ -236,9 +236,9 @@ namespace CesiumForUnity
         }
 
         [SerializeField]
-        private Material? _opaqueMaterial = null;
+        private Material _opaqueMaterial = null;
 
-        public Material? opaqueMaterial
+        public Material opaqueMaterial
         {
             get => this._opaqueMaterial;
             set

--- a/Runtime/CesiumGeoreference.cs
+++ b/Runtime/CesiumGeoreference.cs
@@ -122,7 +122,7 @@ namespace CesiumForUnity
         }
 
         [Tooltip("An event raised when the georeference changes.")]
-        public event Action? changed;
+        public event Action changed;
 
         private void OnValidate()
         {

--- a/Runtime/CesiumGlobeAnchor.cs
+++ b/Runtime/CesiumGlobeAnchor.cs
@@ -396,7 +396,7 @@ namespace CesiumForUnity
 
         private void UpdateGlobePosition(CesiumGlobeAnchorPositionAuthority previousAuthority)
         {
-            CesiumGeoreference? georeference = this.gameObject.GetComponentInParent<CesiumGeoreference>();
+            CesiumGeoreference georeference = this.gameObject.GetComponentInParent<CesiumGeoreference>();
             if (georeference == null)
                 throw new InvalidOperationException("CesiumGlobeAnchor is not nested inside a game object with a CesiumGeoreference.");
 

--- a/Runtime/CesiumOriginShift.cs
+++ b/Runtime/CesiumOriginShift.cs
@@ -44,7 +44,7 @@ namespace CesiumForUnity
 
         private void UpdateFromEcef(CesiumGeoreference georeference, CesiumVector3 ecef)
         {
-            CesiumSubScene? closestLevel = null;
+            CesiumSubScene closestLevel = null;
             double distanceSquaredToClosest = double.MaxValue;
 
             // Are we inside a sub-level?

--- a/Runtime/CesiumRasterOverlay.cs
+++ b/Runtime/CesiumRasterOverlay.cs
@@ -9,7 +9,7 @@ namespace CesiumForUnity
         public delegate void RasterOverlayLoadFailureDelegate(
             CesiumRasterOverlayLoadFailureDetails details);
         public static event
-            RasterOverlayLoadFailureDelegate? OnCesiumRasterOverlayLoadFailure;
+            RasterOverlayLoadFailureDelegate OnCesiumRasterOverlayLoadFailure;
 
         public static void BroadcastCesiumRasterOverlayLoadFailure(
             CesiumRasterOverlayLoadFailureDetails details)
@@ -87,7 +87,7 @@ namespace CesiumForUnity
 
         public void AddToTileset()
         {
-            Cesium3DTileset? tileset = this.gameObject.GetComponent<Cesium3DTileset>();
+            Cesium3DTileset tileset = this.gameObject.GetComponent<Cesium3DTileset>();
             if (tileset == null)
                 return;
 
@@ -96,7 +96,7 @@ namespace CesiumForUnity
 
         public void RemoveFromTileset()
         {
-            Cesium3DTileset? tileset = this.gameObject.GetComponent<Cesium3DTileset>();
+            Cesium3DTileset tileset = this.gameObject.GetComponent<Cesium3DTileset>();
             if (tileset == null)
                 return;
 

--- a/Runtime/CesiumRuntimeSettings.cs
+++ b/Runtime/CesiumRuntimeSettings.cs
@@ -11,7 +11,7 @@ namespace CesiumForUnity
         private static readonly string _filePath =
             "Assets/Settings/Resources/CesiumRuntimeSettings.asset";
 
-        private static CesiumRuntimeSettings? _instance;
+        private static CesiumRuntimeSettings _instance;
 
         public static CesiumRuntimeSettings instance
         {

--- a/Runtime/CesiumSubScene.cs
+++ b/Runtime/CesiumSubScene.cs
@@ -155,7 +155,7 @@ namespace CesiumForUnity
         private void OnEnable()
         {
             // When this sub-scene is enabled, all others are disabled.
-            CesiumGeoreference? georeference = this.GetComponentInParent<CesiumGeoreference>();
+            CesiumGeoreference georeference = this.GetComponentInParent<CesiumGeoreference>();
             if (georeference == null)
                 throw new InvalidOperationException(
                     "CesiumSubScene is not nested inside a game object with a CesiumGeoreference.");
@@ -203,7 +203,7 @@ namespace CesiumForUnity
 
             if (this.isActiveAndEnabled)
             {
-                CesiumGeoreference? georeference = this.GetComponentInParent<CesiumGeoreference>();
+                CesiumGeoreference georeference = this.GetComponentInParent<CesiumGeoreference>();
                 if (georeference == null)
                     throw new InvalidOperationException("CesiumSubScene is not nested inside a game object with a CesiumGeoreference.");
               

--- a/Runtime/csc.rsp
+++ b/Runtime/csc.rsp
@@ -1,1 +1,1 @@
-﻿-nullable
+﻿


### PR DESCRIPTION
We had a bunch of compiler warnings caused by the `-nullable` option. I really like the idea of explicit nullability, but C#'s implementation - with its inability to follow methods called by the constructor in order to confirm non-null initialization - is kind of a hassle. It's also a hassle in apps built on Unity because constructors are often unable to do the actual initialization, requiring everything to be nullable, defeating the purpose. So I've disabled it for now and removed the uses of `?` in the code base. Also fixed a problem in Reinterop where parameters to methods implemented in C++ were not necessarily available from C++.