### PR TITLE
Add missing window title to UI

### DIFF
--- a/Editor/SelectIonTokenWindow.cs
+++ b/Editor/SelectIonTokenWindow.cs
@@ -21,7 +21,7 @@ namespace CesiumForUnity
         {
             if (currentWindow == null)
             {
-                currentWindow = GetWindow<SelectIonTokenWindow>();
+                currentWindow = GetWindow<SelectIonTokenWindow>("Select Cesium ion Token");
             }
 
             currentWindow.Show();

--- a/Runtime/CesiumGeoreference.cs
+++ b/Runtime/CesiumGeoreference.cs
@@ -232,14 +232,14 @@ namespace CesiumForUnity
         /// Transform a Unity world direction to a direction in Earth-Centered, Earth-Fixed (ECEF) coordinates.
         /// </summary>
         /// <param name="unityWorldDirection">The Unity world direction to convert.</param>
-        /// <returns>The ECEF direction in meters.</returns>
+        /// <returns>The ECEF direction.</returns>
         public partial CesiumVector3
             TransformUnityWorldDirectionToEarthCenteredEarthFixed(CesiumVector3 unityWorldDirection);
 
         /// <summary>
-        /// Transform an Earth-Centered, Earth-Fixed position to Unity world coordinates.
+        /// Transform an Earth-Centered, Earth-Fixed direction to Unity world coordinates.
         /// </summary>
-        /// <param name="earthCenteredEarthFixedDirection">The direction in ECEF coordinates, in meters.</param>
+        /// <param name="earthCenteredEarthFixedDirection">The direction in ECEF coordinates.</param>
         /// <returns>The corresponding Unity world direction.</returns>
         public partial CesiumVector3
             TransformEarthCenteredEarthFixedDirectionToUnityWorld(CesiumVector3 earthCenteredEarthFixedDirection);


### PR DESCRIPTION
Really small fix, the `Select Cesium ion Token` window was missing its title, and the default title that was showing was `CesiumForUnity.SelectIonTokenWindow`, which was unideal.

I also noticed some typos in the `CesiumGeoreference` documentation, so I included that in the same commit.