### PR TITLE
Update package.json with some more details

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "changelogUrl": "https://github.com/CesiumGS/cesium-unity/blob/main/CHANGES.md",
   "documentationUrl": "https://cesium.com/learn/unity/",
+  "licensesUrl": "https://github.com/CesiumGS/cesium-unity/blob/main/LICENSE",
   "dependencies": {
     "com.unity.textmeshpro": "3.0.0",
     "com.unity.mathematics": "1.2.0",


### PR DESCRIPTION
Author information makes our package show up under Cesium in the package manager, instead of under "Other". Changelog and documentation URLs make the corresponding links in the package manager go where we want them to.