### PR TITLE
Limit time taken loading and unloading tiles on the main thread.

### DIFF
--- a/native~/Runtime/src/Cesium3DTilesetImpl.cpp
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.cpp
@@ -399,6 +399,10 @@ void Cesium3DTilesetImpl::LoadTileset(
             unityDetails);
       };
 
+  // Generous per-frame time limits for loading / unloading on main thread.
+  options.mainThreadLoadingTimeLimit = 5.0;
+  options.tileCacheUnloadTimeLimit = 5.0;
+
   TilesetContentOptions contentOptions{};
   contentOptions.generateMissingNormalsSmooth = tileset.generateSmoothNormals();
 


### PR DESCRIPTION
These numbers match the ones currently used in Unreal.

Fixes #113 