### PR TITLE
Change some public members to internal on CesiumCreditSystem, add some doc comments

### DIFF
--- a/Runtime/Cesium3DTilesetLoadFailureDetails.cs
+++ b/Runtime/Cesium3DTilesetLoadFailureDetails.cs
@@ -1,5 +1,8 @@
 namespace CesiumForUnity
 {
+    /// <summary>
+    /// The type of <see cref="Cesium3DTileset"/> load that encountered an error.
+    /// </summary>
     public enum Cesium3DTilesetLoadType
     {
         /**
@@ -16,6 +19,9 @@ namespace CesiumForUnity
         TilesetJson
     }
 
+    /// <summary>
+    /// Holds details of a <see cref="Cesium3DTileset"/> load failure.
+    /// </summary>
     public struct Cesium3DTilesetLoadFailureDetails
     {
         /**

--- a/Runtime/CesiumBingMapsRasterOverlay.cs
+++ b/Runtime/CesiumBingMapsRasterOverlay.cs
@@ -5,6 +5,9 @@ using UnityEngine;
 
 namespace CesiumForUnity
 {
+    /// <summary>
+    /// The available styles of the <see cref="CesiumBingMapsRasterOverlay"/>.
+    /// </summary>
     public enum BingMapsStyle
     {
         Aerial,
@@ -17,6 +20,10 @@ namespace CesiumForUnity
         CollinsBart
     }
 
+    /// <summary>
+    /// A raster overlay that directly accesses Bing Maps. If you're using Bing Maps
+    /// via Cesium ion, use the <see cref="CesiumIonRasterOverlay"/> component instead.
+    /// </summary>
     [ReinteropNativeImplementation(
         "CesiumForUnityNative::CesiumBingMapsRasterOverlayImpl",
         "CesiumBingMapsRasterOverlayImpl.h")]
@@ -25,6 +32,9 @@ namespace CesiumForUnity
         [SerializeField]
         private string _bingMapsKey = "";
 
+        /// <summary>
+        /// The Bing Maps API key to use.
+        /// </summary>
         public string bingMapsKey
         {
             get => this._bingMapsKey;
@@ -38,6 +48,9 @@ namespace CesiumForUnity
         [SerializeField]
         private BingMapsStyle _mapStyle = BingMapsStyle.Aerial;
 
+        /// <summary>
+        /// The map style to use.
+        /// </summary>
         public BingMapsStyle mapStyle
         {
             get => this._mapStyle;
@@ -48,7 +61,10 @@ namespace CesiumForUnity
             }
         }
 
+        /// <inheritdoc/>
         protected override partial void AddToTileset(Cesium3DTileset tileset);
+
+        /// <inheritdoc/>
         protected override partial void RemoveFromTileset(Cesium3DTileset tileset);
     }
 }

--- a/Runtime/CesiumCreditSystem.cs
+++ b/Runtime/CesiumCreditSystem.cs
@@ -14,6 +14,9 @@ using UnityEngine.InputSystem.UI;
 
 namespace CesiumForUnity
 {
+    /// <summary>
+    /// Manages credits / attribution for <see cref="Cesium3DTileset"/> and <see cref="CesiumRasterOverlay"/>.
+    /// </summary>
     [ReinteropNativeImplementation("CesiumForUnityNative::CesiumCreditSystemImpl", "CesiumCreditSystemImpl.h")]
     public partial class CesiumCreditSystem : MonoBehaviour, IPointerClickHandler
     {
@@ -28,7 +31,7 @@ namespace CesiumForUnity
         // when they are presented on-screen.
         private string _defaultDelimiter = " \u2022 ";
 
-        public string defaultDelimiter
+        internal string defaultDelimiter
         {
             get => this._defaultDelimiter;
         }
@@ -36,7 +39,7 @@ namespace CesiumForUnity
         private Shader _defaultSpriteShader = null!;
 
         private int _numImages = 0;
-        public int numberOfImages
+        internal int numberOfImages
         {
             get => this._numImages;
         }
@@ -79,7 +82,7 @@ namespace CesiumForUnity
 
         private partial void Update();
 
-        public void OnPointerClick(PointerEventData eventData)
+        void IPointerClickHandler.OnPointerClick(PointerEventData eventData)
         {
             int linkIndex;
             if (_popupGameObject.activeSelf)
@@ -124,7 +127,7 @@ namespace CesiumForUnity
             }
         }
 
-        public void SetCreditsText(string popupCredits, string onScreenCredits)
+        internal void SetCreditsText(string popupCredits, string onScreenCredits)
         {
             _popupText = popupCredits;
             _onScreenText = onScreenCredits;
@@ -134,7 +137,7 @@ namespace CesiumForUnity
 
         const string base64Prefix = "data:image/png;base64,";
 
-        public IEnumerator LoadImage(string url)
+        internal IEnumerator LoadImage(string url)
         {
             // Each image is identified by its index.
             int imageId = _numImages;

--- a/Runtime/CesiumGeoreference.cs
+++ b/Runtime/CesiumGeoreference.cs
@@ -27,6 +27,29 @@ namespace CesiumForUnity
         EarthCenteredEarthFixed
     }
 
+    /// <summary>
+    /// Controls how global geospatial coordinates are mapped to coordinates in the Unity scene.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Internally, Cesium uses a global Earth-centered,
+    /// Earth-fixed (ECEF) ellipsoid-centered coordinate system, where the ellipsoid
+    /// is usually the World Geodetic System 1984(WGS84) ellipsoid. This is a
+    /// right - handed system centered at the Earth's center of mass, where +X is in
+    /// the direction of the intersection of the Equator and the Prime Meridian(zero
+    /// degrees longitude), +Y is in the direction of the intersection of the Equator
+    /// and +90 degrees longitude, and +Z is through the North Pole.
+    /// </para>
+    /// <para>
+    /// This component controls how this coordinate system is mapped into the Unity world.
+    /// </para>
+    /// <para>
+    /// This component should be added to a GameObject that is a parent of all GameObjects
+    /// with the <see cref="Cesium3DTileset"/> or <see cref="CesiumGlobeAnchor"/> components.
+    /// See the documentation for these component types to learn how they are affected by
+    /// the <see cref="CesiumGeoreference"/>.
+    /// </para>
+    /// </remarks>
     [ExecuteInEditMode]
     [ReinteropNativeImplementation("CesiumForUnityNative::CesiumGeoreferenceImpl", "CesiumGeoreferenceImpl.h")]
     public partial class CesiumGeoreference : MonoBehaviour


### PR DESCRIPTION
These member didn't need to be part of the public API, but:

1. There were used by Reinterop. These can be internal instead. Or,
2. These were implementations of interface members. These can use explicit interface implementation instead.