### PR TITLE
Don't let DllNotFoundException crash everything.

### DIFF
--- a/Editor/CesiumEditorUtility.cs
+++ b/Editor/CesiumEditorUtility.cs
@@ -84,7 +84,14 @@ namespace CesiumForUnity
 
         static void UpdateIonSession()
         {
-            CesiumIonSession.Ion().Tick();
+            try
+            {
+                CesiumIonSession.Ion().Tick();
+            }
+            catch (DllNotFoundException)
+            {
+                // Don't let a missing / out-of-sync native DLL crash everything.
+            }
         }
 
         static void


### PR DESCRIPTION
This avoids DllNotFoundException log spam when building for the Editor before the native DLL has been fixed. On macOS, at least, this may be cause CI builds to fail.