### PR TITLE
Generate smooth normals when normals are missing 

### DIFF
--- a/Editor/Cesium3DTilesetEditor.cs
+++ b/Editor/Cesium3DTilesetEditor.cs
@@ -34,7 +34,7 @@ namespace CesiumForUnity
         private SerializedProperty _opaqueMaterial;
         //private SerializedProperty _useLodTransitions;
         //private SerializedProperty _lodTransitionLength;
-        private SerializedProperty _generateSmoothNormals;
+        // private SerializedProperty _generateSmoothNormals;
 
         private SerializedProperty _showTilesInHierarchy;
         private SerializedProperty _suspendUpdate;
@@ -79,8 +79,8 @@ namespace CesiumForUnity
             //this._useLodTransitions = this.serializedObject.FindProperty("_useLodTransitions");
             //this._lodTransitionLength =
             //    this.serializedObject.FindProperty("_lodTransitionLength");
-            this._generateSmoothNormals =
-                this.serializedObject.FindProperty("_generateSmoothNormals");
+            // this._generateSmoothNormals =
+            //     this.serializedObject.FindProperty("_generateSmoothNormals");
 
             this._showTilesInHierarchy =
                 this.serializedObject.FindProperty("_showTilesInHierarchy");
@@ -401,15 +401,15 @@ namespace CesiumForUnity
             //EditorGUILayout.PropertyField(this._lodTransitionLength, lodTransitionLengthContent);
             //EditorGUI.EndDisabledGroup();
 
-            GUIContent generateSmoothNormalsContent = new GUIContent(
-                "Generate Smooth Normals",
-                "Whether to generate smooth normals when normals are missing in the glTF." +
-                "\n\n" +
-                "According to the glTF spec: \"When normals are not specified, client " +
-                "implementations should calculate flat normals.\" However, calculating flat " +
-                "normals requires duplicating vertices. This option allows the glTFs to be " +
-                "rendered with smooth normals instead when the original glTF is missing normals.");
-            EditorGUILayout.PropertyField(this._generateSmoothNormals, generateSmoothNormalsContent);
+            // GUIContent generateSmoothNormalsContent = new GUIContent(
+            //     "Generate Smooth Normals",
+            //     "Whether to generate smooth normals when normals are missing in the glTF." +
+            //     "\n\n" +
+            //     "According to the glTF spec: \"When normals are not specified, client " +
+            //     "implementations should calculate flat normals.\" However, calculating flat " +
+            //     "normals requires duplicating vertices. This option allows the glTFs to be " +
+            //     "rendered with smooth normals instead when the original glTF is missing normals.");
+            // EditorGUILayout.PropertyField(this._generateSmoothNormals, generateSmoothNormalsContent);
         }
 
         private void DrawDebugProperties()

--- a/Runtime/Cesium3DTileset.cs
+++ b/Runtime/Cesium3DTileset.cs
@@ -488,27 +488,27 @@ namespace CesiumForUnity
         //    }
         //}
 
-        [SerializeField]
-        private bool _generateSmoothNormals = false;
+        // [SerializeField]
+        // private bool _generateSmoothNormals = false;
 
-        /// <summary>
-        /// Whether to generate smooth normals when normals are missing in the glTF.
-        /// </summary>
-        /// <remarks>
-        /// According to the glTF spec: "When normals are not specified, client
-        /// implementations should calculate flat normals." However, calculating flat
-        /// normals requires duplicating vertices. This option allows the glTFs to be rendered
-        /// with smooth normals instead when the original glTF is missing normals.
-        /// </remarks>
-        public bool generateSmoothNormals
-        {
-            get => this._generateSmoothNormals;
-            set
-            {
-                this._generateSmoothNormals = value;
-                this.RecreateTileset();
-            }
-        }
+        // /// <summary>
+        // /// Whether to generate smooth normals when normals are missing in the glTF.
+        // /// </summary>
+        // /// <remarks>
+        // /// According to the glTF spec: "When normals are not specified, client
+        // /// implementations should calculate flat normals." However, calculating flat
+        // /// normals requires duplicating vertices. This option allows the glTFs to be rendered
+        // /// with smooth normals instead when the original glTF is missing normals.
+        // /// </remarks>
+        // public bool generateSmoothNormals
+        // {
+        //     get => this._generateSmoothNormals;
+        //     set
+        //     {
+        //         this._generateSmoothNormals = value;
+        //         this.RecreateTileset();
+        //     }
+        // }
 
         [SerializeField]
         private bool _suspendUpdate = false;

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -239,7 +239,7 @@ namespace CesiumForUnity
             tileset.culledScreenSpaceError = tileset.culledScreenSpaceError;
             //tileset.useLodTransitions = tileset.useLodTransitions;
             //tileset.lodTransitionLength = tileset.lodTransitionLength;
-            tileset.generateSmoothNormals = tileset.generateSmoothNormals;
+            // tileset.generateSmoothNormals = tileset.generateSmoothNormals;
             tileset.createPhysicsMeshes = tileset.createPhysicsMeshes;
             tileset.suspendUpdate = tileset.suspendUpdate;
             tileset.previousSuspendUpdate = tileset.previousSuspendUpdate;

--- a/native~/Runtime/src/Cesium3DTilesetImpl.cpp
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.cpp
@@ -404,7 +404,8 @@ void Cesium3DTilesetImpl::LoadTileset(
   options.tileCacheUnloadTimeLimit = 5.0;
 
   TilesetContentOptions contentOptions{};
-  contentOptions.generateMissingNormalsSmooth = tileset.generateSmoothNormals();
+  contentOptions.generateMissingNormalsSmooth = true;
+  // .. = tileset.generateSmoothNormals();
 
   options.contentOptions = contentOptions;
 


### PR DESCRIPTION
Previously we did not always generate normals when they were missing. Presumably Unity was generating normals for us in that case but potentially gets confused with the model transform we give our tiles. In particular, Unity and glTF have opposite handedness - while the conversion between the two is still possible in the form of a matrix, Unity only provides us the ability to individually set translation, rotation, and scale. The only workaround then, was to invert the change-of-handedness matrix to make it a valid rotation matrix, and use a negative scale so the handedness would be corrected in the final matrix.

Unfortunately, it seems like Unity may have been using the rotation without the scale when auto-generating normals for our tiles (after all one would think scale _shouldn't_ affect rotation!). After this change, we _always_ generate smooth normals in Cesium Native when normals are missing - so it is no longer an option on the tileset.