### PR TITLE
Call GlobeAnchor.Sync when the parent transform changes.

### DIFF
--- a/Runtime/CesiumGlobeAnchor.cs
+++ b/Runtime/CesiumGlobeAnchor.cs
@@ -469,6 +469,11 @@ namespace CesiumForUnity
             this.StartOrStopDetectingTransformChanges();
         }
 
+        private void OnTransformParentChanged()
+        {
+            this.Sync();
+        }
+
 #endregion
 
 #region Coroutines


### PR DESCRIPTION
Fixes #137

Unity does have an event just for reparenting, so this was a little simpler than I expected.