### PR TITLE
Update georeference when placing origin

### DIFF
--- a/Editor/CesiumEditorUtility.cs
+++ b/Editor/CesiumEditorUtility.cs
@@ -299,6 +299,8 @@ namespace CesiumForUnity
                 positionECEF.y,
                 positionECEF.z);
 
+            georeference.UpdateOrigin();
+
             double3 newCameraForwardUnity =
                 georeference.TransformEarthCenteredEarthFixedDirectionToUnity(cameraForwardEcef);
 


### PR DESCRIPTION
The georeference wasn't being updated during `PlaceGeoreferenceHere`, so the globe-relative camera transform after the change was not being properly restored (especially noticeable when changing the georeference beyond the horizon). Previously this issue had not surfaced since the camera always ended up at Unity's origin - so it did not need the up-to-date georeference transform to compute the new position.