### PR TITLE
convert 'X-Cesium-Platform' to the rfc8187 format

### DIFF
--- a/native~/Shared/src/UnityAssetAccessor.cpp
+++ b/native~/Shared/src/UnityAssetAccessor.cpp
@@ -23,9 +23,7 @@
 #include <DotNet/UnityEngine/Networking/UploadHandler.h>
 #include <DotNet/UnityEngine/Networking/UploadHandlerRaw.h>
 
-#include <fstream>
 #include <sstream>
-
 
 using namespace CesiumAsync;
 using namespace CesiumUtility;

--- a/native~/Shared/src/UnityAssetAccessor.cpp
+++ b/native~/Shared/src/UnityAssetAccessor.cpp
@@ -41,7 +41,7 @@ std::string encodeUTF8toASCII(const std::string& input) {
       ss << c;
     } else {
       includePrefix = true;
-      ss << std::hex << static_cast<int>(c);
+      ss << "%" << std::hex << static_cast<int>(c);
     }
   }
   return includePrefix ? "utf-8''" + ss.str() : ss.str();

--- a/native~/Shared/src/UnityAssetAccessor.cpp
+++ b/native~/Shared/src/UnityAssetAccessor.cpp
@@ -23,11 +23,31 @@
 #include <DotNet/UnityEngine/Networking/UploadHandler.h>
 #include <DotNet/UnityEngine/Networking/UploadHandlerRaw.h>
 
+#include <fstream>
+#include <sstream>
+
+
 using namespace CesiumAsync;
 using namespace CesiumUtility;
 using namespace DotNet;
 
 namespace {
+
+std::string encodeUTF8toASCII(const std::string& input) {
+  std::ostringstream ss;
+  bool includePrefix = false;
+  for (const unsigned char c : input) {
+    if (c == 32) {
+      ss << "%20"; // replace spaces with %20
+    } else if (c < 128) {
+      ss << c;
+    } else {
+      includePrefix = true;
+      ss << std::hex << static_cast<int>(c);
+    }
+  }
+  return includePrefix ? "utf-8''" + ss.str() : ss.str();
+}
 
 class UnityAssetResponse : public IAssetResponse {
 public:
@@ -95,12 +115,12 @@ private:
 namespace CesiumForUnityNative {
 
 UnityAssetAccessor::UnityAssetAccessor()
-    : _cesiumPlatformHeader(
+    : _cesiumPlatformHeader(encodeUTF8toASCII(
           CesiumForUnity::Helpers::ToString(
               UnityEngine::Application::platform())
               .ToStlString() +
           " " + System::Environment::OSVersion().VersionString().ToStlString() +
-          " " + UnityEngine::Application::productName().ToStlString()),
+          " " + UnityEngine::Application::productName().ToStlString())),
       _cesiumVersionHeader(
           CesiumForUnityNative::Cesium::version + " " +
           CesiumForUnityNative::Cesium::commit) {}


### PR DESCRIPTION
Fixes #155 

Attempted to follow the format of https://www.rfc-editor.org/rfc/rfc8187. It adds utf-8 to the beginning, replaces spaces with %20 (assumes the spaces are unquoted), and replaces unicode character with the hex format.

![image](https://user-images.githubusercontent.com/97980867/207752503-e109ec59-fbf7-4dae-bc09-0b885bc7692d.png)
