### PR TITLE
Fix macOS build, further restrict allowed characters in headers.

### DIFF
--- a/native~/Shared/src/UnityAssetAccessor.cpp
+++ b/native~/Shared/src/UnityAssetAccessor.cpp
@@ -92,13 +92,14 @@ private:
   UnityAssetResponse _response;
 };
 
-std::string replaceInvalidChars(std::string& input) {
+std::string replaceInvalidChars(const std::string& input) {
+  std::string result(input.size(), '?');
   std::transform(
       input.cbegin(),
       input.cend(),
-      input.begin(),
-      [](unsigned char c) { return (c >= 0 && c < 128) ? c : '?'; });
-  return input;
+      result.begin(),
+      [](unsigned char c) { return (c >= 32 && c <= 126) ? c : '?'; });
+  return result;
 }
 
 } // namespace


### PR DESCRIPTION
I merged #160 before I realized macOS / Clang have a problem a problem with it. So this PR fixes that. Also I think only printable ASCII characters are allowed in header values, so I updated the replacement logic accordingly.