### PR TITLE
Use SafeHandles instead of raw IntPtrs to hold native implementation instances

### DIFF
--- a/Reinterop~/CodeGenerator.cs
+++ b/Reinterop~/CodeGenerator.cs
@@ -94,7 +94,7 @@ namespace Reinterop
                 if (partialMethods == null || partialMethods.Methods.Count == 0)
                     continue;
 
-                context.AddSource(partialMethods.Type.Symbol.Name + "-generated", partialMethods.ToSourceFileString());
+                context.AddSource(partialMethods.Type.Name + "-generated", partialMethods.ToSourceFileString());
             }
         }
 

--- a/Reinterop~/CustomDelegateGenerator.cs
+++ b/Reinterop~/CustomDelegateGenerator.cs
@@ -83,7 +83,7 @@ namespace Reinterop
                 genericTypeHash = Interop.HashParameters(null, named.TypeArguments);
             }
 
-            string csBaseName = $"{csType.GetFullyQualifiedNamespace().Replace(".", "_")}_{csType.Symbol.Name}{genericTypeHash}_CreateDelegate";
+            string csBaseName = $"{csType.GetFullyQualifiedNamespace().Replace(".", "_")}_{csType.Name}{genericTypeHash}_CreateDelegate";
             string invokeCallbackName = $"{csType.GetFullyQualifiedNamespace().Replace(".", "_")}_{item.Type.Name}{genericTypeHash}_InvokeCallback";
             string disposeCallbackName = $"{csType.GetFullyQualifiedNamespace().Replace(".", "_")}_{item.Type.Name}{genericTypeHash}_DisposeCallback";
 
@@ -107,16 +107,16 @@ namespace Reinterop
                 CSharpName: csBaseName + "Delegate",
                 CSharpContent:
                     $$"""
-                    private class {{csType.Symbol.Name}}{{genericTypeHash}}NativeFunction : System.IDisposable
+                    private class {{csType.Name}}{{genericTypeHash}}NativeFunction : System.IDisposable
                     {
                         private IntPtr _callbackFunction;
 
-                        public {{csType.Symbol.Name}}{{genericTypeHash}}NativeFunction(IntPtr callbackFunction)
+                        public {{csType.Name}}{{genericTypeHash}}NativeFunction(IntPtr callbackFunction)
                         {
                             _callbackFunction = callbackFunction;
                         }
 
-                        ~{{csType.Symbol.Name}}{{genericTypeHash}}NativeFunction()
+                        ~{{csType.Name}}{{genericTypeHash}}NativeFunction()
                         {
                             Dispose(false);
                         }
@@ -139,7 +139,7 @@ namespace Reinterop
                         public {{csReturnType.GetFullyQualifiedName()}} Invoke({{string.Join(", ", invokeParameters)}})
                         {
                             if (_callbackFunction == null)
-                                throw new System.ObjectDisposedException("{{csType.Symbol.Name}}");
+                                throw new System.ObjectDisposedException("{{csType.Name}}");
                     
                             {{csResultImplementation}}{{invokeCallbackName}}({{string.Join(", ", callInvokeInteropParameters)}});
                             {{csReturnImplementation}};
@@ -156,7 +156,7 @@ namespace Reinterop
                     [AOT.MonoPInvokeCallback(typeof({{csBaseName}}Type))]
                     private static unsafe IntPtr {{csBaseName}}(IntPtr callbackFunction)
                     {
-                        var receiver = new {{csType.Symbol.Name}}{{genericTypeHash}}NativeFunction(callbackFunction);
+                        var receiver = new {{csType.Name}}{{genericTypeHash}}NativeFunction(callbackFunction);
                         return Reinterop.ObjectHandleUtility.CreateHandle(new {{csType.GetFullyQualifiedName()}}(receiver.Invoke));
                     }
                     """

--- a/Reinterop~/Interop.cs
+++ b/Reinterop~/Interop.cs
@@ -326,7 +326,7 @@ namespace Reinterop
 
         public static string GetUniqueNameForType(CSharpType type)
         {
-            string name = type.Symbol.Name;
+            string name = type.Name;
             string genericTypeHash = "";
             INamedTypeSymbol? named = type.Symbol as INamedTypeSymbol;
             if (named != null && named.IsGenericType)

--- a/Runtime/Cesium3DTileset.cs
+++ b/Runtime/Cesium3DTileset.cs
@@ -39,8 +39,14 @@ namespace CesiumForUnity
     /// </remarks>
     [ExecuteInEditMode]
     [ReinteropNativeImplementation("CesiumForUnityNative::Cesium3DTilesetImpl", "Cesium3DTilesetImpl.h")]
-    public partial class Cesium3DTileset : MonoBehaviour
+    public partial class Cesium3DTileset : MonoBehaviour, IDisposable
     {
+        public void Dispose()
+        {
+            this.OnDisable();
+            this.DisposeImplementation();
+        }
+
         /// <summary>
         /// Encapsulates a method that receives details of a tileset load failure.
         /// </summary>

--- a/native~/Editor/src/CesiumEditorWindowImpl.cpp
+++ b/native~/Editor/src/CesiumEditorWindowImpl.cpp
@@ -33,9 +33,6 @@ CesiumEditorWindowImpl::CesiumEditorWindowImpl(
 
 CesiumEditorWindowImpl::~CesiumEditorWindowImpl() {}
 
-void CesiumEditorWindowImpl::JustBeforeDelete(
-    const DotNet::CesiumForUnity::CesiumEditorWindow& window) {}
-
 void CesiumEditorWindowImpl::AddAssetFromIon(
     const DotNet::CesiumForUnity::CesiumEditorWindow& window,
     DotNet::System::String name,

--- a/native~/Editor/src/CesiumEditorWindowImpl.h
+++ b/native~/Editor/src/CesiumEditorWindowImpl.h
@@ -20,9 +20,6 @@ public:
       const DotNet::CesiumForUnity::CesiumEditorWindow& window);
   ~CesiumEditorWindowImpl();
 
-  void
-  JustBeforeDelete(const DotNet::CesiumForUnity::CesiumEditorWindow& window);
-
   void AddAssetFromIon(
       const DotNet::CesiumForUnity::CesiumEditorWindow& window,
       DotNet::System::String name,

--- a/native~/Editor/src/CesiumIonSessionImpl.cpp
+++ b/native~/Editor/src/CesiumIonSessionImpl.cpp
@@ -51,9 +51,6 @@ CesiumIonSessionImpl::CesiumIonSessionImpl(
 
 CesiumIonSessionImpl::~CesiumIonSessionImpl() {}
 
-void CesiumIonSessionImpl::JustBeforeDelete(
-    const DotNet::CesiumForUnity::CesiumIonSession& session) {}
-
 bool CesiumIonSessionImpl::IsConnected(
     const DotNet::CesiumForUnity::CesiumIonSession& session) {
   return this->_connection.has_value();

--- a/native~/Editor/src/CesiumIonSessionImpl.h
+++ b/native~/Editor/src/CesiumIonSessionImpl.h
@@ -38,9 +38,6 @@ public:
   CesiumIonSessionImpl(const DotNet::CesiumForUnity::CesiumIonSession& session);
   ~CesiumIonSessionImpl();
 
-  void
-  JustBeforeDelete(const DotNet::CesiumForUnity::CesiumIonSession& session);
-
   bool IsConnected(const DotNet::CesiumForUnity::CesiumIonSession& session);
   bool IsConnecting(const DotNet::CesiumForUnity::CesiumIonSession& session);
   bool IsResuming(const DotNet::CesiumForUnity::CesiumIonSession& session);

--- a/native~/Editor/src/IonAssetsTreeViewImpl.cpp
+++ b/native~/Editor/src/IonAssetsTreeViewImpl.cpp
@@ -32,9 +32,6 @@ IonAssetsTreeViewImpl::IonAssetsTreeViewImpl(
 
 IonAssetsTreeViewImpl::~IonAssetsTreeViewImpl() {}
 
-void IonAssetsTreeViewImpl::JustBeforeDelete(
-    const DotNet::CesiumForUnity::IonAssetsTreeView& treeView) {}
-
 int IonAssetsTreeViewImpl::GetAssetsCount(
     const DotNet::CesiumForUnity::IonAssetsTreeView& treeView) {
   return this->_assets.size();

--- a/native~/Editor/src/IonAssetsTreeViewImpl.h
+++ b/native~/Editor/src/IonAssetsTreeViewImpl.h
@@ -21,9 +21,6 @@ public:
       const DotNet::CesiumForUnity::IonAssetsTreeView& treeView);
   ~IonAssetsTreeViewImpl();
 
-  void
-  JustBeforeDelete(const DotNet::CesiumForUnity::IonAssetsTreeView& treeView);
-
   int GetAssetsCount(const DotNet::CesiumForUnity::IonAssetsTreeView& treeView);
 
   void CellGUI(

--- a/native~/Editor/src/IonTokenTroubleshootingWindowImpl.cpp
+++ b/native~/Editor/src/IonTokenTroubleshootingWindowImpl.cpp
@@ -24,9 +24,6 @@ IonTokenTroubleshootingWindowImpl::IonTokenTroubleshootingWindowImpl(
 
 IonTokenTroubleshootingWindowImpl::~IonTokenTroubleshootingWindowImpl() {}
 
-void IonTokenTroubleshootingWindowImpl::JustBeforeDelete(
-    const DotNet::CesiumForUnity::IonTokenTroubleshootingWindow& window) {}
-
 namespace {
 
 void getTokenTroubleShootingDetails(

--- a/native~/Editor/src/IonTokenTroubleshootingWindowImpl.h
+++ b/native~/Editor/src/IonTokenTroubleshootingWindowImpl.h
@@ -15,9 +15,6 @@ public:
       const DotNet::CesiumForUnity::IonTokenTroubleshootingWindow& window);
   ~IonTokenTroubleshootingWindowImpl();
 
-  void JustBeforeDelete(
-      const DotNet::CesiumForUnity::IonTokenTroubleshootingWindow& window);
-
   void GetTroubleshootingDetails(
       const DotNet::CesiumForUnity::IonTokenTroubleshootingWindow& window);
 

--- a/native~/Editor/src/SelectIonTokenWindowImpl.cpp
+++ b/native~/Editor/src/SelectIonTokenWindowImpl.cpp
@@ -166,10 +166,7 @@ SelectIonTokenWindowImpl::SelectIonTokenWindowImpl(
                    .createPromise<std::optional<CesiumIonClient::Token>>()),
       _future(this->_promise->getFuture().share()) {}
 
-SelectIonTokenWindowImpl::~SelectIonTokenWindowImpl() {}
-
-void SelectIonTokenWindowImpl::JustBeforeDelete(
-    const DotNet::CesiumForUnity::SelectIonTokenWindow& window) {
+SelectIonTokenWindowImpl::~SelectIonTokenWindowImpl() {
   if (_promise) {
     this->_promise->resolve(std::nullopt);
   }

--- a/native~/Editor/src/SelectIonTokenWindowImpl.h
+++ b/native~/Editor/src/SelectIonTokenWindowImpl.h
@@ -33,9 +33,6 @@ public:
   ~SelectIonTokenWindowImpl();
 
   void
-  JustBeforeDelete(const DotNet::CesiumForUnity::SelectIonTokenWindow& window);
-
-  void
   RefreshTokens(const DotNet::CesiumForUnity::SelectIonTokenWindow& window);
 
   void CreateToken(const DotNet::CesiumForUnity::SelectIonTokenWindow& window);

--- a/native~/Runtime/src/Cesium3DTilesetImpl.cpp
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.cpp
@@ -53,11 +53,6 @@ Cesium3DTilesetImpl::Cesium3DTilesetImpl(
 
 Cesium3DTilesetImpl::~Cesium3DTilesetImpl() {}
 
-void Cesium3DTilesetImpl::JustBeforeDelete(
-    const DotNet::CesiumForUnity::Cesium3DTileset& tileset) {
-  this->OnDisable(tileset);
-}
-
 void Cesium3DTilesetImpl::Start(
     const DotNet::CesiumForUnity::Cesium3DTileset& tileset) {}
 

--- a/native~/Runtime/src/Cesium3DTilesetImpl.h
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.h
@@ -28,7 +28,6 @@ public:
   Cesium3DTilesetImpl(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
   ~Cesium3DTilesetImpl();
 
-  void JustBeforeDelete(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
   void Start(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
   void Update(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
   void OnValidate(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);

--- a/native~/Runtime/src/CesiumBingMapsRasterOverlayImpl.cpp
+++ b/native~/Runtime/src/CesiumBingMapsRasterOverlayImpl.cpp
@@ -23,9 +23,6 @@ CesiumBingMapsRasterOverlayImpl::CesiumBingMapsRasterOverlayImpl(
 
 CesiumBingMapsRasterOverlayImpl::~CesiumBingMapsRasterOverlayImpl() {}
 
-void CesiumBingMapsRasterOverlayImpl::JustBeforeDelete(
-    const ::DotNet::CesiumForUnity::CesiumBingMapsRasterOverlay& overlay) {}
-
 void CesiumBingMapsRasterOverlayImpl::AddToTileset(
     const ::DotNet::CesiumForUnity::CesiumBingMapsRasterOverlay& overlay,
     const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset) {

--- a/native~/Runtime/src/CesiumBingMapsRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumBingMapsRasterOverlayImpl.h
@@ -19,8 +19,6 @@ public:
       const DotNet::CesiumForUnity::CesiumBingMapsRasterOverlay& overlay);
   ~CesiumBingMapsRasterOverlayImpl();
 
-  void JustBeforeDelete(
-      const ::DotNet::CesiumForUnity::CesiumBingMapsRasterOverlay& overlay);
   void AddToTileset(
       const ::DotNet::CesiumForUnity::CesiumBingMapsRasterOverlay& overlay,
       const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset);

--- a/native~/Runtime/src/CesiumCreditSystemImpl.cpp
+++ b/native~/Runtime/src/CesiumCreditSystemImpl.cpp
@@ -37,9 +37,6 @@ CesiumCreditSystemImpl::CesiumCreditSystemImpl(
 
 CesiumCreditSystemImpl::~CesiumCreditSystemImpl() {}
 
-void CesiumCreditSystemImpl::JustBeforeDelete(
-    const CesiumForUnity::CesiumCreditSystem& creditSystem) {}
-
 void CesiumCreditSystemImpl::Update(
     const CesiumForUnity::CesiumCreditSystem& creditSystem) {
   if (!_pCreditSystem) {

--- a/native~/Runtime/src/CesiumCreditSystemImpl.h
+++ b/native~/Runtime/src/CesiumCreditSystemImpl.h
@@ -28,8 +28,6 @@ public:
       const DotNet::CesiumForUnity::CesiumCreditSystem& creditSystem);
   ~CesiumCreditSystemImpl();
 
-  void JustBeforeDelete(
-      const DotNet::CesiumForUnity::CesiumCreditSystem& creditSystem);
   void Update(const DotNet::CesiumForUnity::CesiumCreditSystem& creditSystem);
 
   const std::shared_ptr<Cesium3DTilesSelection::CreditSystem>&

--- a/native~/Runtime/src/CesiumGeoreferenceImpl.cpp
+++ b/native~/Runtime/src/CesiumGeoreferenceImpl.cpp
@@ -55,9 +55,6 @@ CesiumGeoreferenceImpl::CesiumGeoreferenceImpl(
 
 CesiumGeoreferenceImpl::~CesiumGeoreferenceImpl() {}
 
-void CesiumGeoreferenceImpl::JustBeforeDelete(
-    const DotNet::CesiumForUnity::CesiumGeoreference& georeference) {}
-
 void CesiumGeoreferenceImpl::RecalculateOrigin(
     const DotNet::CesiumForUnity::CesiumGeoreference& georeference) {
   LocalHorizontalCoordinateSystem coordinateSystem =

--- a/native~/Runtime/src/CesiumGeoreferenceImpl.h
+++ b/native~/Runtime/src/CesiumGeoreferenceImpl.h
@@ -19,8 +19,6 @@ public:
       const DotNet::CesiumForUnity::CesiumGeoreference& georeference);
   ~CesiumGeoreferenceImpl();
 
-  void JustBeforeDelete(
-      const DotNet::CesiumForUnity::CesiumGeoreference& georeference);
   void RecalculateOrigin(
       const DotNet::CesiumForUnity::CesiumGeoreference& georeference);
   void InitializeOrigin(

--- a/native~/Runtime/src/CesiumIonRasterOverlayImpl.cpp
+++ b/native~/Runtime/src/CesiumIonRasterOverlayImpl.cpp
@@ -24,9 +24,6 @@ CesiumIonRasterOverlayImpl::CesiumIonRasterOverlayImpl(
 
 CesiumIonRasterOverlayImpl::~CesiumIonRasterOverlayImpl() {}
 
-void CesiumIonRasterOverlayImpl::JustBeforeDelete(
-    const ::DotNet::CesiumForUnity::CesiumIonRasterOverlay& overlay) {}
-
 void CesiumIonRasterOverlayImpl::AddToTileset(
     const ::DotNet::CesiumForUnity::CesiumIonRasterOverlay& overlay,
     const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset) {

--- a/native~/Runtime/src/CesiumIonRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumIonRasterOverlayImpl.h
@@ -19,8 +19,6 @@ public:
       const DotNet::CesiumForUnity::CesiumIonRasterOverlay& overlay);
   ~CesiumIonRasterOverlayImpl();
 
-  void JustBeforeDelete(
-      const ::DotNet::CesiumForUnity::CesiumIonRasterOverlay& overlay);
   void AddToTileset(
       const ::DotNet::CesiumForUnity::CesiumIonRasterOverlay& overlay,
       const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset);

--- a/native~/Runtime/src/CesiumMetadataImpl.h
+++ b/native~/Runtime/src/CesiumMetadataImpl.h
@@ -32,8 +32,6 @@ class CesiumMetadataImpl {
 public:
   ~CesiumMetadataImpl(){};
   CesiumMetadataImpl(const DotNet::CesiumForUnity::CesiumMetadata& metadata){};
-  void
-  JustBeforeDelete(const DotNet::CesiumForUnity::CesiumMetadata& metadata){};
   void loadMetadata(
       int32_t instanceID,
       const CesiumGltf::Model* pModel,

--- a/native~/Runtime/src/CesiumTileMapServiceRasterOverlayImpl.cpp
+++ b/native~/Runtime/src/CesiumTileMapServiceRasterOverlayImpl.cpp
@@ -23,10 +23,6 @@ CesiumTileMapServiceRasterOverlayImpl::CesiumTileMapServiceRasterOverlayImpl(
 CesiumTileMapServiceRasterOverlayImpl::
     ~CesiumTileMapServiceRasterOverlayImpl() {}
 
-void CesiumTileMapServiceRasterOverlayImpl::JustBeforeDelete(
-    const ::DotNet::CesiumForUnity::CesiumTileMapServiceRasterOverlay&
-        overlay) {}
-
 void CesiumTileMapServiceRasterOverlayImpl::AddToTileset(
     const ::DotNet::CesiumForUnity::CesiumTileMapServiceRasterOverlay& overlay,
     const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset) {

--- a/native~/Runtime/src/CesiumTileMapServiceRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumTileMapServiceRasterOverlayImpl.h
@@ -19,9 +19,6 @@ public:
       const DotNet::CesiumForUnity::CesiumTileMapServiceRasterOverlay& overlay);
   ~CesiumTileMapServiceRasterOverlayImpl();
 
-  void JustBeforeDelete(
-      const ::DotNet::CesiumForUnity::CesiumTileMapServiceRasterOverlay&
-          overlay);
   void AddToTileset(
       const ::DotNet::CesiumForUnity::CesiumTileMapServiceRasterOverlay&
           overlay,

--- a/native~/Runtime/src/CesiumWebMapServiceRasterOverlayImpl.cpp
+++ b/native~/Runtime/src/CesiumWebMapServiceRasterOverlayImpl.cpp
@@ -22,10 +22,6 @@ CesiumWebMapServiceRasterOverlayImpl::CesiumWebMapServiceRasterOverlayImpl(
 
 CesiumWebMapServiceRasterOverlayImpl::~CesiumWebMapServiceRasterOverlayImpl() {}
 
-void CesiumWebMapServiceRasterOverlayImpl::JustBeforeDelete(
-    const ::DotNet::CesiumForUnity::CesiumWebMapServiceRasterOverlay& overlay) {
-}
-
 void CesiumWebMapServiceRasterOverlayImpl::AddToTileset(
     const ::DotNet::CesiumForUnity::CesiumWebMapServiceRasterOverlay& overlay,
     const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset) {

--- a/native~/Runtime/src/CesiumWebMapServiceRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumWebMapServiceRasterOverlayImpl.h
@@ -19,9 +19,6 @@ public:
       const DotNet::CesiumForUnity::CesiumWebMapServiceRasterOverlay& overlay);
   ~CesiumWebMapServiceRasterOverlayImpl();
 
-  void JustBeforeDelete(
-      const ::DotNet::CesiumForUnity::CesiumWebMapServiceRasterOverlay&
-          overlay);
   void AddToTileset(
       const ::DotNet::CesiumForUnity::CesiumWebMapServiceRasterOverlay& overlay,
       const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset);

--- a/native~/Runtime/src/MetadataPropertyImpl.h
+++ b/native~/Runtime/src/MetadataPropertyImpl.h
@@ -74,8 +74,6 @@ public:
   ~MetadataPropertyImpl(){};
   MetadataPropertyImpl(
       const DotNet::CesiumForUnity::MetadataProperty& property){};
-  void
-  JustBeforeDelete(const DotNet::CesiumForUnity::MetadataProperty& property){};
   DotNet::System::String
   GetPropertyName(const DotNet::CesiumForUnity::MetadataProperty& property);
   void SetProperty(

--- a/native~/Shared/src/NativeDownloadHandlerImpl.cpp
+++ b/native~/Shared/src/NativeDownloadHandlerImpl.cpp
@@ -7,9 +7,6 @@ namespace CesiumForUnityNative {
 NativeDownloadHandlerImpl::NativeDownloadHandlerImpl(
     const NativeDownloadHandler& handler) {}
 
-void NativeDownloadHandlerImpl::JustBeforeDelete(
-    const NativeDownloadHandler& handler) {}
-
 bool NativeDownloadHandlerImpl::ReceiveDataNative(
     const NativeDownloadHandler& handler,
     void* data,

--- a/native~/Shared/src/NativeDownloadHandlerImpl.h
+++ b/native~/Shared/src/NativeDownloadHandlerImpl.h
@@ -16,8 +16,6 @@ class NativeDownloadHandlerImpl {
 public:
   NativeDownloadHandlerImpl(
       const ::DotNet::CesiumForUnity::NativeDownloadHandler& handler);
-  void JustBeforeDelete(
-      const ::DotNet::CesiumForUnity::NativeDownloadHandler& handler);
   bool ReceiveDataNative(
       const ::DotNet::CesiumForUnity::NativeDownloadHandler& handler,
       void* data,


### PR DESCRIPTION
Fixes #17 

I had hoped this would reduce garbage collector pressure and finalization overhead, but I can't actually observe any difference. That's not too surprising because we don't create and destroy native-backed objects very often, and that's the only time this will affect anything.

Still, this is the right way to do things, and _could_ even fix an extremely rare race condition (so rare I've never seen it) where an object is garbage collected while its native code is still executing.