### PR TITLE
Run the build with .NET 7.

### DIFF
--- a/Build~/Build~.csproj
+++ b/Build~/Build~.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>Build</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Since that's the only one installed on CI. Not sure why it used to work with .NET 6.