### PR TITLE
Use `OnValidate` to prevent constant editor changes to `CesiumGlobeAnchor`

### DIFF
--- a/Editor/CesiumGeoreferenceEditor.cs
+++ b/Editor/CesiumGeoreferenceEditor.cs
@@ -29,20 +29,6 @@ namespace CesiumForUnity
         private SerializedProperty _ecefY;
         private SerializedProperty _ecefZ;
 
-        // These variables store the values from the previous frame. This is used to compare
-        // to the current serialized values, whether they were changed this frame via user input
-        // or by other means (undo, pasting component values).
-        private CesiumGeoreferenceOriginAuthority
-            _previousOriginAuthority = CesiumGeoreferenceOriginAuthority.LongitudeLatitudeHeight;
-
-        private double _previousLatitude = 0.0;
-        private double _previousLongitude = 0.0;
-        private double _previousHeight = 0.0;
-
-        private double _previousEcefX = 0.0;
-        private double _previousEcefY = 0.0;
-        private double _previousEcefZ = 0.0;
-
         private void OnEnable()
         {
             this._georeference = (CesiumGeoreference)this.target;
@@ -57,8 +43,6 @@ namespace CesiumForUnity
             this._ecefX = this.serializedObject.FindProperty("_ecefX");
             this._ecefY = this.serializedObject.FindProperty("_ecefY");
             this._ecefZ = this.serializedObject.FindProperty("_ecefZ");
-
-            this.UpdateSavedPropertyValues();
         }
 
         public override void OnInspectorGUI()
@@ -75,9 +59,6 @@ namespace CesiumForUnity
             this.DrawEarthCenteredEarthFixedProperties();
 
             this.serializedObject.ApplyModifiedProperties();
-
-            this.UpdateGeoreference();
-            this.UpdateSavedPropertyValues();
         }
 
         private void DrawInspectorButtons()
@@ -203,48 +184,6 @@ namespace CesiumForUnity
             EditorGUILayout.PropertyField(this._ecefZ, ecefZContent);
 
             EditorGUI.EndDisabledGroup();
-        }
-
-        private bool OriginAuthorityChanged()
-        {
-            return this._previousOriginAuthority != this.originAuthority;
-        }
-
-        private bool LongitudeLatitudeHeightChanged()
-        {
-            return this._previousLatitude != this._latitude.doubleValue ||
-                this._previousLongitude != this._longitude.doubleValue ||
-                this._previousHeight != this._height.doubleValue;
-        }
-
-        private bool EarthCenteredEarthFixedChanged()
-        {
-            return this._previousEcefX != this._ecefX.doubleValue ||
-                this._previousEcefY != this._ecefY.doubleValue ||
-                this._previousEcefZ != this._ecefZ.doubleValue;
-        }
-
-        private void UpdateGeoreference()
-        {
-            if (this.OriginAuthorityChanged() ||
-                this.LongitudeLatitudeHeightChanged() ||
-                this.EarthCenteredEarthFixedChanged())
-            {
-                this._georeference.UpdateOrigin();
-            }
-        }
-
-        private void UpdateSavedPropertyValues()
-        {
-            this._previousOriginAuthority = this._georeference.originAuthority;
-
-            this._previousLatitude = this._georeference.latitude;
-            this._previousLongitude = this._georeference.longitude;
-            this._previousHeight = this._georeference.height;
-
-            this._previousEcefX = this._georeference.ecefX;
-            this._previousEcefY = this._georeference.ecefY;
-            this._previousEcefZ = this._georeference.ecefZ;
         }
     }
 }

--- a/Editor/CesiumGlobeAnchorEditor.cs
+++ b/Editor/CesiumGlobeAnchorEditor.cs
@@ -35,23 +35,6 @@ namespace CesiumForUnity
         private SerializedProperty _unityY;
         private SerializedProperty _unityZ;
 
-        private bool _previousDetectTransformChanges = false;
-
-        private CesiumGlobeAnchorPositionAuthority 
-            _previousPositionAuthority = CesiumGlobeAnchorPositionAuthority.None;
-
-        private double _previousLatitude = 0.0;
-        private double _previousLongitude = 0.0;
-        private double _previousHeight = 0.0;
-
-        private double _previousEcefX = 0.0;
-        private double _previousEcefY = 0.0;
-        private double _previousEcefZ = 0.0;
-
-        private double _previousUnityX = 0.0;
-        private double _previousUnityY = 0.0;
-        private double _previousUnityZ = 0.0;
-
         private void OnEnable()
         {
             this._globeAnchor = (CesiumGlobeAnchor)this.target;
@@ -90,10 +73,6 @@ namespace CesiumForUnity
             DrawUnityPositionProperties();
 
             this.serializedObject.ApplyModifiedProperties();
-            
-            this.UpdateGlobeAnchor();
-            this.UpdateSavedPropertyValues();
-
         }
 
         private void DrawGlobeAnchorProperties()
@@ -252,111 +231,6 @@ namespace CesiumForUnity
             EditorGUILayout.PropertyField(this._unityZ, unityZContent);
 
             EditorGUI.EndDisabledGroup();
-        }
-
-        private bool DetectTransformChangesChanged()
-        {
-            return this._previousDetectTransformChanges != this._detectTransformChanges.boolValue;
-        }
-
-        private bool PositionAuthorityChanged()
-        {
-            return this._previousPositionAuthority != this.positionAuthority;
-        }
-
-        private bool LongitudeLatitudeHeightChanged()
-        {
-            return this._previousLatitude != this._latitude.doubleValue ||
-                this._previousLongitude != this._longitude.doubleValue ||
-                this._previousHeight != this._height.doubleValue;
-        }
-
-        private bool EarthCenteredEarthFixedChanged()
-        {
-            return this._previousEcefX != this._ecefX.doubleValue ||
-                this._previousEcefY != this._ecefY.doubleValue ||
-                this._previousEcefZ != this._ecefZ.doubleValue;
-        }
-
-        private bool UnityPositionChanged()
-        {
-            return this._previousUnityX != this._unityX.doubleValue ||
-                this._previousUnityY != this._unityY.doubleValue ||
-                this._previousUnityZ != this._unityZ.doubleValue;
-        }
-
-        private void UpdateGlobeAnchor()
-        {
-            if (this.DetectTransformChangesChanged())
-            {
-                // Explicitly set the flag so that the object starts or stops detecting.
-                this._globeAnchor.detectTransformChanges = this._globeAnchor.detectTransformChanges;
-            }
-
-            bool llhChanged = this.LongitudeLatitudeHeightChanged(),
-                 ecefChanged = this.EarthCenteredEarthFixedChanged(),
-                 unityChanged = this.UnityPositionChanged();
-
-            // If all coordinates were changed, either this CesiumGlobeAnchor was just
-            // created, or a "Paste component values" action was done or undone on the
-            // object. In any case, all the values were applied in ApplyModifiedProperties(), so
-            // just update everything in one go.
-            if(llhChanged && ecefChanged && unityChanged)
-            {
-                this._globeAnchor.positionAuthority = this._globeAnchor.positionAuthority;
-                return;
-            }
-
-            // Otherwise, the coordinates were changed via user input. It is only possible
-            // for the user to change one property field at a time, and setting one type of
-            // coordinates makes the anchor recompute the others, so only one set of
-            // coordinates needs to be checked.
-            if (llhChanged)
-            {
-                this._globeAnchor.SetPositionLongitudeLatitudeHeight(
-                    this._longitude.doubleValue,
-                    this._latitude.doubleValue,
-                    this._height.doubleValue);
-            } 
-            else if (ecefChanged)
-            {
-                this._globeAnchor.SetPositionEarthCenteredEarthFixed(
-                    this._ecefX.doubleValue,
-                    this._ecefY.doubleValue,
-                    this._ecefZ.doubleValue);
-            } else if (unityChanged)
-            {
-                this._globeAnchor.SetPositionUnity(
-                    this._unityX.doubleValue,
-                    this._unityY.doubleValue,
-                    this._unityZ.doubleValue);
-            }
-
-            // This only checks for changes to the position authority via the Editor; it will
-            // not override the position authority set by changing the coordinate values themselves.
-            if (this.PositionAuthorityChanged())
-            {
-                this._globeAnchor.positionAuthority = this.positionAuthority;
-            }
-        }
-
-        private void UpdateSavedPropertyValues()
-        {
-            this._previousDetectTransformChanges = this._globeAnchor.detectTransformChanges;
-
-            this._previousPositionAuthority = this._globeAnchor.positionAuthority;
-
-            this._previousLatitude = this._globeAnchor.latitude;
-            this._previousLongitude = this._globeAnchor.longitude;
-            this._previousHeight = this._globeAnchor.height;
-
-            this._previousEcefX = this._globeAnchor.ecefX;
-            this._previousEcefY = this._globeAnchor.ecefY;
-            this._previousEcefZ = this._globeAnchor.ecefZ;
-
-            this._previousUnityX = this._globeAnchor.unityX;
-            this._previousUnityY = this._globeAnchor.unityY;
-            this._previousUnityZ = this._globeAnchor.unityZ;
         }
     }
 }

--- a/Editor/CesiumSubSceneEditor.cs
+++ b/Editor/CesiumSubSceneEditor.cs
@@ -32,20 +32,6 @@ namespace CesiumForUnity
         private SerializedProperty _ecefY;
         private SerializedProperty _ecefZ;
 
-        // These variables store the values from the previous frame. This is used to compare
-        // to the current serialized values, whether they were changed this frame via user input
-        // or by other means (undo, pasting component values).
-        private CesiumGeoreferenceOriginAuthority
-            _previousOriginAuthority = CesiumGeoreferenceOriginAuthority.LongitudeLatitudeHeight;
-
-        private double _previousLatitude = 0.0;
-        private double _previousLongitude = 0.0;
-        private double _previousHeight = 0.0;
-
-        private double _previousEcefX = 0.0;
-        private double _previousEcefY = 0.0;
-        private double _previousEcefZ = 0.0;
-
         private void OnEnable()
         {
             this._subScene = (CesiumSubScene)this.target;
@@ -63,8 +49,6 @@ namespace CesiumForUnity
             this._ecefX = this.serializedObject.FindProperty("_ecefX");
             this._ecefY = this.serializedObject.FindProperty("_ecefY");
             this._ecefZ = this.serializedObject.FindProperty("_ecefZ");
-
-            this.UpdateSavedPropertyValues();
         }
 
         public override void OnInspectorGUI()
@@ -81,9 +65,6 @@ namespace CesiumForUnity
             DrawEarthCenteredEarthFixedProperties();
 
             this.serializedObject.ApplyModifiedProperties();
-
-            this.UpdateSubScene();
-            this.UpdateSavedPropertyValues();
         }
 
         private void DrawToolbarButton()
@@ -215,48 +196,6 @@ namespace CesiumForUnity
             EditorGUILayout.PropertyField(this._ecefZ, ecefZContent);
 
             EditorGUI.EndDisabledGroup();
-        }
-
-        private bool OriginAuthorityChanged()
-        {
-            return this._previousOriginAuthority != this.originAuthority;
-        }
-
-        private bool LongitudeLatitudeHeightChanged()
-        {
-            return this._previousLatitude != this._latitude.doubleValue ||
-                this._previousLongitude != this._longitude.doubleValue ||
-                this._previousHeight != this._height.doubleValue;
-        }
-
-        private bool EarthCenteredEarthFixedChanged()
-        {
-            return this._previousEcefX != this._ecefX.doubleValue ||
-                this._previousEcefY != this._ecefY.doubleValue ||
-                this._previousEcefZ != this._ecefZ.doubleValue;
-        }
-
-        private void UpdateSubScene()
-        {
-            if (this.OriginAuthorityChanged() ||
-                this.LongitudeLatitudeHeightChanged() ||
-                this.EarthCenteredEarthFixedChanged())
-            {
-                this._subScene.UpdateOrigin();
-            }
-        }
-
-        private void UpdateSavedPropertyValues()
-        {
-            this._previousOriginAuthority = this._subScene.originAuthority;
-
-            this._previousLatitude = this._subScene.latitude;
-            this._previousLongitude = this._subScene.longitude;
-            this._previousHeight = this._subScene.height;
-
-            this._previousEcefX = this._subScene.ecefX;
-            this._previousEcefY = this._subScene.ecefY;
-            this._previousEcefZ = this._subScene.ecefZ;
         }
     }
 }

--- a/Runtime/CesiumGlobeAnchor.cs
+++ b/Runtime/CesiumGlobeAnchor.cs
@@ -457,6 +457,16 @@ namespace CesiumForUnity
 
         #region Unity Messages
 
+        private void OnValidate()
+        {
+            CesiumGeoreference georeference = this.gameObject.GetComponentInParent<CesiumGeoreference>();
+            if (georeference != null && this._lastPropertiesAreValid)
+            {
+                this.StartOrStopDetectingTransformChanges();
+                this.Sync();
+            }
+        }
+
         private void Start()
         {
             this.Sync();
@@ -468,6 +478,11 @@ namespace CesiumForUnity
             // so if we only did it in Start, then in the Editor, transform change detection would stop
             // working whenever source files were changed.
             this.StartOrStopDetectingTransformChanges();
+        }
+
+        private void OnDisable()
+        {
+            this._lastPropertiesAreValid = false;
         }
 
         private void OnTransformParentChanged()

--- a/Runtime/CesiumSubScene.cs
+++ b/Runtime/CesiumSubScene.cs
@@ -224,6 +224,15 @@ namespace CesiumForUnity
             this.originAuthority = CesiumGeoreferenceOriginAuthority.LongitudeLatitudeHeight;
         }
 
+        private void OnValidate()
+        {
+            CesiumGeoreference georeference = this.GetComponentInParent<CesiumGeoreference>();
+            if (georeference != null)
+            {
+                this.UpdateOrigin();
+            }
+        }
+
         private void OnEnable()
         {
             // When this sub-scene is enabled, all others are disabled.


### PR DESCRIPTION
#163 unfortunately created a bug with `CesiumFlyToController` when the `DynamicCamera` is selected in the Editor. Because `CesiumGlobeAnchor` constantly changes its values, the editor misinterprets the changes as user input. It constantly recomputes its coordinates, leading to small changes from the previous frame, which the `CesiumFlyToController` interprets as user inputted movement. The changes to the `CesiumGlobeAnchor` while in flight will be incorrectly interpreted as user movement, and the flight will be interrupted.

We can't reliably distinguish the source of changes to a `SerializedObject` without `OnValidate`. In the past, I thought to check for some sort of "initialization" variable in `OnValidate` before calling other update functions. However, when I last tried it, the updates would still go through despite the environment reloading. I spent some time looking into why this happened, and I found:
- `OnValidate` in a `Monobehaviour` is reliably called before its `OnEnable` (though not necessarily before the `OnEnable` of other classes).
- When you load a new scene, private variables (such as `_lastPropertiesAreValid` in `CesiumGlobeAnchor`) are set to their initial values. This means that they will be properly "initialized" in `OnEnable` and won't incorrectly update in `OnValidate`.
- When you either recompile scripts or switch to play mode, the private variables are **not** reset to their initial values. `OnValidate` is still called before `OnEnable`, and this causes things to get wonky in between what you'd perceive as complete environment reloads. Perhaps this is because of `[ExecuteInEditMode`]; they seem to reuse the same `Monobehaviour` between these states, so the variables don't get reloaded. 
- `OnDisable` is always called before an environment switch. So the order of operations for a `Monobehaviour` in a scene is reliably `OnDisable` -> `OnValidate` -> `OnEnable`.

With this, I revisisted the `OnValidate` approach. The relevant functions are only called if the classes have been "initialized." This "initialization" state is reset whenever the object is disabled, so it shouldn't matter if it's the same `Monobehaviour` between environment reloads; it'll always reset. A summary of what I did to each class:
1. `CesiumGlobeAnchor`: I use `_lastPropertiesAreValid` as the "initialization" variable. This should prevent unnecessary changes as it's transitioning between the different Unity environments. I saw these incorrect changes happen to `DynamicCamera` because its z-rotation (roll) would get set to a non-zero value. After this PR, the roll stays zero when the scene is loaded, and is always reset to zero after play mode.
2. `CesiumGeoreference`: I added an `_initialized` variable to track when `InitializeOrigin` was called. `UpdateOrigin` will only call `RecalculateOrigin` if the origin was already initialized.
3. 'CesiumSubScene`: Calling `UpdateOrigin` has no consequences for the sub-scene itself, but it sometimes messes up the `CesiumGeoreference`. When sub-scenes get enabled before the georeference, they're calling `UpdateOrigin` on the georeference before it's initialized. But this should be addressed by the changes to `CesiumGeoreference` itself, so no additional work is needed in `CesiumSubScene`.