### PR TITLE
Add support for point clouds in Unity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v0.3.0
+
+##### Additions :tada:
+
+- Added support for rendering point clouds (`pnts`).
+
 ### v0.2.0
 
 ##### Breaking Changes :mega:

--- a/Editor/Cesium3DTilesetEditor.cs
+++ b/Editor/Cesium3DTilesetEditor.cs
@@ -444,10 +444,13 @@ namespace CesiumForUnity
 
             GUIContent createPhysicsMeshesContent = new GUIContent(
                 "Create Physics Meshes",
-                "Whether to generate physics meshes for this tileset.\n\n" +
+                "Whether to generate physics meshes for this tileset." +
+                "\n\n" +
                 "Disabling this option will improve the performance of tile loading, " +
                 "but it will no longer be possible to collide with the tileset since " +
-                "the physics meshes will not be created.");
+                "the physics meshes will not be created." +
+                "\n\n" +
+                "Physics meshes cannot be generated for primitives containing points.");
             EditorGUILayout.PropertyField(this._createPhysicsMeshes, createPhysicsMeshesContent);
         }
     }

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -92,6 +92,7 @@ void generateIndices(
     const Unity::Collections::NativeArray1<T>& dest,
     const int32_t count) {
   assert(dest.Length() == count);
+
   T* indices = static_cast<T*>(
       Unity::Collections::LowLevel::Unsafe::NativeArrayUnsafeUtility::
           GetUnsafeBufferPointerWithoutChecks(dest));

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -73,17 +73,31 @@ using namespace DotNet;
 namespace {
 
 template <typename TDest, typename TSource>
-void setTriangles(
+void setIndices(
     const Unity::Collections::NativeArray1<TDest>& dest,
     const AccessorView<TSource>& source) {
   assert(dest.Length() == source.size());
 
-  TDest* triangles = static_cast<TDest*>(
+  TDest* indices = static_cast<TDest*>(
       Unity::Collections::LowLevel::Unsafe::NativeArrayUnsafeUtility::
           GetUnsafeBufferPointerWithoutChecks(dest));
 
   for (int64_t i = 0; i < source.size(); ++i) {
-    triangles[i] = source[i];
+    indices[i] = source[i];
+  }
+}
+
+template <typename T>
+void generateIndices(
+    const Unity::Collections::NativeArray1<T>& dest,
+    const int32_t count) {
+  assert(dest.Length() == count);
+  T* indices = static_cast<T*>(
+      Unity::Collections::LowLevel::Unsafe::NativeArrayUnsafeUtility::
+          GetUnsafeBufferPointerWithoutChecks(dest));
+
+  for (int64_t i = 0; i < count; ++i) {
+    indices[i] = static_cast<T>(i);
   }
 }
 
@@ -249,11 +263,6 @@ void populateMeshDataArray(
         // Interleave all attributes into single stream.
         std::int32_t numberOfAttributes = 0;
         std::int32_t streamIndex = 0;
-
-        if (primitive.indices < 0) {
-          // TODO: support non-indexed primitives.
-          return;
-        }
 
         auto positionAccessorIt = primitive.attributes.find("POSITION");
         if (positionAccessorIt == primitive.attributes.end()) {
@@ -465,25 +474,38 @@ void populateMeshDataArray(
 
         int32_t indexCount = 0;
 
-        AccessorView<uint8_t> indices8(gltf, primitive.indices);
-        if (indices8.status() == AccessorViewStatus::Valid) {
-          indexCount = indices8.size();
-          meshData.SetIndexBufferParams(indexCount, IndexFormat::UInt16);
-          setTriangles(meshData.GetIndexData<std::uint16_t>(), indices8);
-        }
+        if (primitive.indices >= 0) {
+          AccessorView<uint8_t> indices8(gltf, primitive.indices);
+          if (indices8.status() == AccessorViewStatus::Valid) {
+            indexCount = indices8.size();
+            meshData.SetIndexBufferParams(indexCount, IndexFormat::UInt16);
+            setIndices(meshData.GetIndexData<std::uint16_t>(), indices8);
+          }
 
-        AccessorView<uint16_t> indices16(gltf, primitive.indices);
-        if (indices16.status() == AccessorViewStatus::Valid) {
-          indexCount = indices16.size();
-          meshData.SetIndexBufferParams(indexCount, IndexFormat::UInt16);
-          setTriangles(meshData.GetIndexData<std::uint16_t>(), indices16);
-        }
+          AccessorView<uint16_t> indices16(gltf, primitive.indices);
+          if (indices16.status() == AccessorViewStatus::Valid) {
+            indexCount = indices16.size();
+            meshData.SetIndexBufferParams(indexCount, IndexFormat::UInt16);
+            setIndices(meshData.GetIndexData<std::uint16_t>(), indices16);
+          }
 
-        AccessorView<uint32_t> indices32(gltf, primitive.indices);
-        if (indices32.status() == AccessorViewStatus::Valid) {
-          indexCount = indices32.size();
-          meshData.SetIndexBufferParams(indexCount, IndexFormat::UInt32);
-          setTriangles(meshData.GetIndexData<std::uint32_t>(), indices32);
+          AccessorView<uint32_t> indices32(gltf, primitive.indices);
+          if (indices32.status() == AccessorViewStatus::Valid) {
+            indexCount = indices32.size();
+            meshData.SetIndexBufferParams(indexCount, IndexFormat::UInt32);
+            setIndices(meshData.GetIndexData<std::uint32_t>(), indices32);
+          }
+        } else {
+          // Generate indices for primitives without them.
+          indexCount = positionView.size();
+
+          if (indexCount > std::numeric_limits<uint16_t>::max()) {
+            meshData.SetIndexBufferParams(indexCount, IndexFormat::UInt32);
+            generateIndices(meshData.GetIndexData<std::uint32_t>(), indexCount);
+          } else {
+            meshData.SetIndexBufferParams(indexCount, IndexFormat::UInt16);
+            generateIndices(meshData.GetIndexData<std::uint16_t>(), indexCount);
+          }
         }
 
         meshData.subMeshCount(1);
@@ -491,7 +513,14 @@ void populateMeshDataArray(
         // TODO: use sub-meshes for glTF primitives, instead of a separate mesh
         // for each.
         SubMeshDescriptor subMeshDescriptor{};
-        subMeshDescriptor.topology = MeshTopology::Triangles;
+
+        if (primitive.mode == MeshPrimitive::Mode::POINTS) {
+          subMeshDescriptor.topology = MeshTopology::Points;
+          primitiveInfo.containsPoints = true;
+        } else {
+          subMeshDescriptor.topology = MeshTopology::Triangles;
+        }
+
         subMeshDescriptor.indexStart = 0;
         subMeshDescriptor.indexCount = indexCount;
         subMeshDescriptor.baseVertex = 0;
@@ -501,12 +530,6 @@ void populateMeshDataArray(
         subMeshDescriptor.vertexCount = 0;
 
         meshData.SetSubMesh(0, subMeshDescriptor, MeshUpdateFlags::Default);
-
-        // if (createPhysicsMeshes) {
-        //   UnityEngine::MeshCollider meshCollider =
-        //       primitiveGameObject.AddComponent<UnityEngine::MeshCollider>();
-        //   meshCollider.sharedMesh(unityMesh);
-        // }
       });
 }
 
@@ -582,6 +605,8 @@ UnityPrepareRendererResources::prepareInLoadThread(
 
             const UnityEngine::MeshDataArray& meshDataArray =
                 workerResult.meshDataResult.meshDataArray;
+            const std::vector<CesiumPrimitiveInfo>& primitiveInfos =
+                workerResult.meshDataResult.primitiveInfos;
 
             // Create meshes and populate them from the MeshData created in
             // the worker thread. Sadly, this must be done in the main
@@ -620,36 +645,43 @@ UnityPrepareRendererResources::prepareInLoadThread(
             if (shouldCreatePhysicsMeshes) {
               // Baking physics meshes takes awhile, so do that in a
               // worker thread.
-              std::int32_t len = meshes.Length();
-              std::vector<std::int32_t> instanceIDs(meshes.Length());
+              const std::int32_t len = meshes.Length();
+              std::vector<std::int32_t> instanceIDs;
               for (int32_t i = 0; i < len; ++i) {
-                instanceIDs[i] = meshes[i].GetInstanceID();
+                // Don't attempt to bake a physics mesh from a point cloud.
+                if (primitiveInfos[i].containsPoints) {
+                  continue;
+                }
+                instanceIDs.push_back(meshes[i].GetInstanceID());
               }
 
-              return asyncSystem.runInWorkerThread(
-                  [workerResult = std::move(workerResult),
-                   instanceIDs = std::move(instanceIDs),
-                   meshes = std::move(meshes)]() mutable {
-                    for (std::int32_t instanceID : instanceIDs) {
-                      UnityEngine::Physics::BakeMesh(instanceID, false);
-                    }
+              if (instanceIDs.size() > 0) {
+                return asyncSystem.runInWorkerThread(
+                    [workerResult = std::move(workerResult),
+                     instanceIDs = std::move(instanceIDs),
+                     meshes = std::move(meshes)]() mutable {
+                      for (std::int32_t instanceID : instanceIDs) {
+                        UnityEngine::Physics::BakeMesh(instanceID, false);
+                      }
 
-                    LoadThreadResult* pResult = new LoadThreadResult{
-                        std::move(meshes),
-                        std::move(workerResult.meshDataResult.primitiveInfos)};
-                    return TileLoadResultAndRenderResources{
-                        std::move(workerResult.tileLoadResult),
-                        pResult};
-                  });
-            } else {
-              LoadThreadResult* pResult = new LoadThreadResult{
-                  std::move(meshes),
-                  std::move(workerResult.meshDataResult.primitiveInfos)};
-              return asyncSystem.createResolvedFuture(
-                  TileLoadResultAndRenderResources{
-                      std::move(workerResult.tileLoadResult),
-                      pResult});
+                      LoadThreadResult* pResult = new LoadThreadResult{
+                          std::move(meshes),
+                          std::move(
+                              workerResult.meshDataResult.primitiveInfos)};
+                      return TileLoadResultAndRenderResources{
+                          std::move(workerResult.tileLoadResult),
+                          pResult};
+                    });
+              }
             }
+
+            LoadThreadResult* pResult = new LoadThreadResult{
+                std::move(meshes),
+                std::move(workerResult.meshDataResult.primitiveInfos)};
+            return asyncSystem.createResolvedFuture(
+                TileLoadResultAndRenderResources{
+                    std::move(workerResult.tileLoadResult),
+                    pResult});
           });
 }
 
@@ -754,11 +786,6 @@ void* UnityPrepareRendererResources::prepareInMainThread(
         if (unityMesh == nullptr) {
           // This indicates Unity destroyed the mesh already, which really
           // shouldn't happen.
-          return;
-        }
-
-        if (primitive.indices < 0) {
-          // TODO: support non-indexed primitives.
           return;
         }
 
@@ -1015,7 +1042,8 @@ void* UnityPrepareRendererResources::prepareInMainThread(
 
         meshFilter.sharedMesh(unityMesh);
 
-        if (createPhysicsMeshes) {
+        if (createPhysicsMeshes &&
+            primitive.mode != MeshPrimitive::Mode::POINTS) {
           // This should not trigger mesh baking for physics, because the meshes
           // were already baked in the worker thread.
           UnityEngine::MeshCollider meshCollider =

--- a/native~/Runtime/src/UnityPrepareRendererResources.h
+++ b/native~/Runtime/src/UnityPrepareRendererResources.h
@@ -12,6 +12,12 @@ namespace CesiumForUnityNative {
  */
 struct CesiumPrimitiveInfo {
   /**
+   * @brief Whether or not the primitive's mode is set to POINTS.
+   * This affects whether or not it can be baked into a physics mesh.
+   */
+  bool containsPoints = false;
+
+  /**
    * @brief Maps a texture coordinate index i (TEXCOORD_<i>) to the
    * corresponding Unity texture coordinate index.
    */


### PR DESCRIPTION
This PR builds off of https://github.com/CesiumGS/cesium-native/pull/591 and adds support for rendering point clouds (`pnts` content) in Unity.

Some screenshots:
| Melbourne Point Cloud |
| ----------------------- |
| ![image](https://user-images.githubusercontent.com/32226860/216457205-027bb6c0-76c1-4d9a-ab5c-5aeb54216727.png) |

| Mount St. Helen | Church |
| ------------------ | -------- |
| ![image](https://user-images.githubusercontent.com/32226860/216456898-e94f4a5b-3c9e-4f1d-aa14-79951b526cab.png) | ![image](https://user-images.githubusercontent.com/32226860/216458302-6e08b2f4-fc55-4ac4-98e2-031655b227f4.png) |

[CesiumJS sandcastle with the above models for reference](https://sandcastle.cesium.com/?src=3D%20Tiles%20Point%20Cloud%20Shading.html)