### PR TITLE
Add CesiumOribitalFrustum

### DIFF
--- a/Runtime/CesiumOrbitalFrustum.cs
+++ b/Runtime/CesiumOrbitalFrustum.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+using Unity.Mathematics;
+using System;
+
+namespace CesiumForUnity
+{
+    public class CesiumOrbitalFrustum : MonoBehaviour
+    {
+        public static CesiumOrbitalFrustum Instance { get; set; }
+
+        [SerializeField]
+        private int viewPortPixelWidth = 1920;
+        public int ViewPortPixelWidth { get => viewPortPixelWidth; set => viewPortPixelWidth = value; }
+        [SerializeField]
+        [Range(1, 180)]
+        private double verticalFov = 60;
+        public double VerticalFov { get => verticalFov; set => verticalFov = value; }
+        [SerializeField]
+        [Range(1, 180)]
+        private double aspectRatio = 1.775193798;
+        public double AspectRatio { get => aspectRatio; set => aspectRatio = value; }
+        [SerializeField]
+        private double3 cartographicPosition { get; set; } = new double3(0, 0, 4_000_000);
+        public double3 CartographicPosition { get => cartographicPosition; set => cartographicPosition = value; } 
+
+        private void Awake()
+        {
+            if (Instance != null)
+            {
+                Debug.LogError($"Duplicate singleton: CesiumCameraProvider");
+                return;
+            }
+
+            Instance = this;
+        }
+
+        public void SetCartographicPosition(double3 cartographicPositionDegrees)
+        {
+            CartographicPosition = cartographicPositionDegrees;
+        }
+    }
+}

--- a/Runtime/CesiumOrbitalFrustum.cs.meta
+++ b/Runtime/CesiumOrbitalFrustum.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28e049293c4a00644974167070a18b77
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -56,6 +56,13 @@ namespace CesiumForUnity
             Vector3 u = t.up;
             Vector3 f = t.forward;
 
+            CesiumOrbitalFrustum frustum = new CesiumOrbitalFrustum();
+            frustum = CesiumOrbitalFrustum.Instance;
+            double3 cartographic = frustum.CartographicPosition;
+            double viewPortPixelWidth = frustum.ViewPortPixelWidth;
+            double verticalFov = frustum.VerticalFov;
+            double aspectRatio = frustum.AspectRatio;
+
             Vector4 v = new Vector4(1.0f, 0.0f, 1.0f, 0.0f);
 
             t.position = new Vector3();


### PR DESCRIPTION
* add frustum for ar mapping applications where Camera.main does not make sense
* consider the following image where you are sharing a map. In this case the Camera.main(Red) is your head. You are sharing the map so it must load tiles even if you look away, in this case it is useful to have a logical camera(Blue) that defines the map area that needs to render.
* this is useful in mapping applications where the frustum is static and the globe rotates and scales underneath it.
* this implementation is specifically an orbital frustum, it may make sense to just have a frustum and define the frustum movements on the client side.
![frustum](https://user-images.githubusercontent.com/13579475/217332936-d524bc7d-57cc-4a02-856a-66417891f498.jpg)
