### PR TITLE
Add `staticOnly` flag to `ReinteropNativeImplementation` attribute

### DIFF
--- a/Editor/IonTokenTroubleshootingWindow.cs
+++ b/Editor/IonTokenTroubleshootingWindow.cs
@@ -114,7 +114,8 @@ namespace CesiumForUnity
 
     [ReinteropNativeImplementation(
         "CesiumForUnityNative::IonTokenTroubleshootingWindowImpl",
-        "IonTokenTroubleshootingWindowImpl.h")]
+        "IonTokenTroubleshootingWindowImpl.h",
+        staticOnly: true)]
     public partial class IonTokenTroubleshootingWindow : EditorWindow
     {
         private static List<IonTokenTroubleshootingWindow> _existingWindows =
@@ -257,7 +258,6 @@ namespace CesiumForUnity
             this._assetTokenDetails = new TokenTroubleshootingDetails();
             this._defaultTokenDetails = new TokenTroubleshootingDetails();
             this._assetDetails = new AssetTroubleshootingDetails();
-            this.CreateImplementation();
         }
 
         private partial void GetTroubleshootingDetails();

--- a/Reinterop~/CSharpReinteropNativeImplementationAttribute.cs
+++ b/Reinterop~/CSharpReinteropNativeImplementationAttribute.cs
@@ -27,9 +27,12 @@ namespace Reinterop
 
                     public readonly string HeaderName;
 
-                    public ReinteropNativeImplementationAttribute(string implementationClassName, string headerName) {
+                    public readonly bool StaticOnly;
+
+                    public ReinteropNativeImplementationAttribute(string implementationClassName, string headerName, bool staticOnly = false) {
                         this.ImplementationClassName = implementationClassName;
                         this.HeaderName = headerName;
+                        this.StaticOnly = staticOnly;
                     }
                 }
             }

--- a/Reinterop~/MethodsImplementedInCpp.cs
+++ b/Reinterop~/MethodsImplementedInCpp.cs
@@ -19,7 +19,7 @@ namespace Reinterop
             CppType objectHandleType = CppObjectHandle.GetCppType(context);
 
             // We only need a C++ instance if any partial methods are non-static
-            bool needsInstance = item.ImplementationStaticOnly != false && item.MethodsImplementedInCpp.Any(m => !m.IsStatic);
+            bool needsInstance = !item.ImplementationStaticOnly && item.MethodsImplementedInCpp.Any(m => !m.IsStatic);
             result.CSharpPartialMethodDefinitions.needsInstance = needsInstance;
 
             if (needsInstance)
@@ -405,7 +405,7 @@ namespace Reinterop
             {
                 modifiers += " static";
             }
-            else
+            else if (!item.ImplementationStaticOnly)
             {
                 implementationCheck =
                     $$"""

--- a/Reinterop~/RoslynSourceGenerator.cs
+++ b/Reinterop~/RoslynSourceGenerator.cs
@@ -104,6 +104,7 @@ namespace Reinterop
 
                 var implClassName = (args[0]?.Expression as LiteralExpressionSyntax)?.Token.ValueText;
                 var implHeaderName = (args[1]?.Expression as LiteralExpressionSyntax)?.Token.ValueText;
+                var implStaticOnly = args.Count > 2 ? (args[2]?.Expression as LiteralExpressionSyntax)?.Token.ValueText : null;
 
                 // A C# class that is meant to be implemented in C++.
                 SemanticModel semanticModel = compilation.GetSemanticModel(attributeSyntax.SyntaxTree);
@@ -117,6 +118,13 @@ namespace Reinterop
 
                     item.ImplementationClassName = implClassName;
                     item.ImplementationHeaderName = implHeaderName;
+
+                    if (implStaticOnly == "true")
+                        item.ImplementationStaticOnly = true;
+                    else if (implStaticOnly == "false")
+                        item.ImplementationStaticOnly = false;
+                    else if (implStaticOnly != null)
+                        throw new Exception("Unknown value for \"staticOnly\" parameter. Must be true or false.");
 
                     foreach (MemberDeclarationSyntax memberSyntax in classSyntax.Members)
                     {

--- a/Reinterop~/RoslynSourceGenerator.cs
+++ b/Reinterop~/RoslynSourceGenerator.cs
@@ -104,7 +104,7 @@ namespace Reinterop
 
                 var implClassName = (args[0]?.Expression as LiteralExpressionSyntax)?.Token.ValueText;
                 var implHeaderName = (args[1]?.Expression as LiteralExpressionSyntax)?.Token.ValueText;
-                var implStaticOnly = args.Count > 2 ? (args[2]?.Expression as LiteralExpressionSyntax)?.Token.ValueText : null;
+                var implStaticOnly = args.Count > 2 ? (args[2]?.Expression as LiteralExpressionSyntax)?.Token.ValueText : "false";
 
                 // A C# class that is meant to be implemented in C++.
                 SemanticModel semanticModel = compilation.GetSemanticModel(attributeSyntax.SyntaxTree);

--- a/Reinterop~/TypeToGenerate.cs
+++ b/Reinterop~/TypeToGenerate.cs
@@ -40,6 +40,8 @@ namespace Reinterop
         /// </summary>
         public string? ImplementationHeaderName;
 
+        public bool ImplementationStaticOnly = true;
+
         public static Dictionary<ITypeSymbol, TypeToGenerate> Combine(IEnumerable<IEnumerable<TypeToGenerate>> listOfItems)
         {
             Dictionary<ITypeSymbol, TypeToGenerate> result = new Dictionary<ITypeSymbol, TypeToGenerate>(SymbolEqualityComparer.Default);
@@ -72,6 +74,8 @@ namespace Reinterop
                     {
                         // TODO: report conflicting implementation header name
                     }
+
+                    current.ImplementationStaticOnly = current.ImplementationStaticOnly && item.ImplementationStaticOnly;
 
                     foreach (IMethodSymbol method in item.Constructors)
                     {

--- a/Runtime/CesiumGlobeAnchor.cs
+++ b/Runtime/CesiumGlobeAnchor.cs
@@ -76,7 +76,7 @@ namespace CesiumForUnity
     /// </remarks>
     [ExecuteInEditMode]
     [DisallowMultipleComponent]
-    [ReinteropNativeImplementation("CesiumForUnityNative::CesiumGlobeAnchorImpl", "CesiumGlobeAnchorImpl.h")]
+    [ReinteropNativeImplementation("CesiumForUnityNative::CesiumGlobeAnchorImpl", "CesiumGlobeAnchorImpl.h", staticOnly: true)]
     public partial class CesiumGlobeAnchor : MonoBehaviour
     {
         #region User-editable properties

--- a/Runtime/CesiumGlobeAnchor.cs
+++ b/Runtime/CesiumGlobeAnchor.cs
@@ -612,7 +612,7 @@ namespace CesiumForUnity
                     this._lastPositionEcefZ
                 );
                 double3 newPosition = new double3(this._ecefX, this._ecefY, this._ecefZ);
-                CesiumGlobeAnchor.AdjustOrientation(this, oldPosition, newPosition);
+                this.AdjustOrientation(oldPosition, newPosition);
             }
 
             // Set the object's transform with the new position
@@ -630,7 +630,7 @@ namespace CesiumForUnity
         }
 
         // This is static so that CesiumGlobeAnchor does not need finalization.
-        private static partial void AdjustOrientation(CesiumGlobeAnchor anchor, double3 oldPositionEcef, double3 newPositionEcef);
+        private partial void AdjustOrientation(double3 oldPositionEcef, double3 newPositionEcef);
 
         #endregion
     }

--- a/Runtime/CesiumGlobeAnchor.cs
+++ b/Runtime/CesiumGlobeAnchor.cs
@@ -629,7 +629,6 @@ namespace CesiumForUnity
             this.positionAuthority = CesiumGlobeAnchorPositionAuthority.None;
         }
 
-        // This is static so that CesiumGlobeAnchor does not need finalization.
         private partial void AdjustOrientation(double3 oldPositionEcef, double3 newPositionEcef);
 
         #endregion

--- a/Runtime/CesiumWgs84Ellipsoid.cs
+++ b/Runtime/CesiumWgs84Ellipsoid.cs
@@ -7,7 +7,7 @@ namespace CesiumForUnity
     /// Holds static methods for ellipsoid math and transforming between geospatial coordinate systems
     /// using the World Geodetic System (WGS84) standard.
     /// </summary>
-    [ReinteropNativeImplementation("CesiumForUnityNative::CesiumWgs84EllipsoidImpl", "CesiumWgs84EllipsoidImpl.h")]
+    [ReinteropNativeImplementation("CesiumForUnityNative::CesiumWgs84EllipsoidImpl", "CesiumWgs84EllipsoidImpl.h", staticOnly: true)]
     public static partial class CesiumWgs84Ellipsoid
     {
         /// <summary>

--- a/native~/Editor/src/IonTokenTroubleshootingWindowImpl.cpp
+++ b/native~/Editor/src/IonTokenTroubleshootingWindowImpl.cpp
@@ -19,11 +19,6 @@ using namespace DotNet;
 
 namespace CesiumForUnityNative {
 
-IonTokenTroubleshootingWindowImpl::IonTokenTroubleshootingWindowImpl(
-    const DotNet::CesiumForUnity::IonTokenTroubleshootingWindow& window) {}
-
-IonTokenTroubleshootingWindowImpl::~IonTokenTroubleshootingWindowImpl() {}
-
 namespace {
 
 void getTokenTroubleShootingDetails(
@@ -112,6 +107,7 @@ void getAssetTroubleshootingDetails(
         details.loaded(true);
       });
 }
+
 } // namespace
 
 void IonTokenTroubleshootingWindowImpl::GetTroubleshootingDetails(

--- a/native~/Editor/src/IonTokenTroubleshootingWindowImpl.h
+++ b/native~/Editor/src/IonTokenTroubleshootingWindowImpl.h
@@ -11,21 +11,16 @@ namespace CesiumForUnityNative {
 class IonTokenTroubleshootingWindowImpl {
 
 public:
-  IonTokenTroubleshootingWindowImpl(
-      const DotNet::CesiumForUnity::IonTokenTroubleshootingWindow& window);
-  ~IonTokenTroubleshootingWindowImpl();
-
-  void GetTroubleshootingDetails(
+  static void GetTroubleshootingDetails(
       const DotNet::CesiumForUnity::IonTokenTroubleshootingWindow& window);
 
-  void AuthorizeToken(
+  static void AuthorizeToken(
       const DotNet::CesiumForUnity::IonTokenTroubleshootingWindow& window,
       DotNet::System::String token,
       bool isDefaultToken);
 
-  void SelectNewDefaultToken(
+  static void SelectNewDefaultToken(
       const DotNet::CesiumForUnity::IonTokenTroubleshootingWindow& window);
-
-private:
 };
+
 } // namespace CesiumForUnityNative


### PR DESCRIPTION
Before this PR, static partial methods would be delegated to a static method on a C++ class, and non-static partial methods would be delegated to an instance method on the C++ class. If there were any non-static methods at all, then a C++ instance would be created whenever a C# instance was, and the C# class would have a finalizer to ensure the C++ instance was eventually destroyed in order to avoid a memory leak.

This kind of made sense, but was inefficient in some cases. Sometimes, such as for `CesiumGlobeAnchor`, we don't want to have a C++ instance, because it would be costly to have a finalizer, and our C++ implementation doesn't have any state separate from the C# class anyway. But it's still useful to have partial instance methods so that the C++ code can access the state on the C# instance. This led us to kind of ugly workarounds, like declaring the partial method static but then passing the C# instance as the first parameter. And it would be all too easy for a future developer (probably future me) to add a non-static partial method to `CesiumGlobeAnchor` and suddenly make it finalizable, without realizing the cost.

This PR fixes both of those problems by adding a new parameter, `staticOnly` to the `[ReinteropNativeImplementation]` attribute. When set to true, Reinterop will _never_ create a C++ instance to back the C# one. Non-static partial methods are allowed, but will be implemented in C++ by a static method. The static method will receive the C# instance as its first parameter, just like all partial methods.

This way, we can write our partial methods in a more natural way, and there's no danger of accidentally making a class like `CesiumGlobeAnchor` finalizable without explicitly changing `staticOnly` to false.

I've applied this new parameter to `IonTokenTroubleshootingWindow`, `CesiumWgs84Ellipsoid`, and `CesiumGlobeAnchor`.