### PR TITLE
Reinterop: Fix code gen for non-static field access.

### DIFF
--- a/Reinterop~/Fields.cs
+++ b/Reinterop~/Fields.cs
@@ -101,9 +101,9 @@ namespace Reinterop
             if (!field.IsStatic)
             {
                 interopGetParameters = $"void* thiz";
-                interopGetParametersCall = $"{definition.Type.AsParameterType().GetConversionToInteropType(context, "thiz")}";
+                interopGetParametersCall = $"{definition.Type.AsParameterType().GetConversionToInteropType(context, "(*this)")}";
                 interopSetParameters = $"void* thiz, " + interopSetParameters;
-                interopSetParametersCall = $"{definition.Type.AsParameterType().GetConversionToInteropType(context, "thiz")}, {interopSetParametersCall}";
+                interopSetParametersCall = $"{definition.Type.AsParameterType().GetConversionToInteropType(context, "(*this)")}, {interopSetParametersCall}";
             }
 
             // Add the static fields for the get/set functions


### PR DESCRIPTION
This is a PR into #210, so merge that first.

Previously the generated C++ code for accessing non-static fields would not compile.