### PR TITLE
Fix crash when opening the token troubleshooting panel.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 ##### Fixes :wrench:
 
 - Recategorized the Cesium tileset shaders from the `Shader Graphs` shader category to the new `Cesium` shader category. 
+- Fixed a bug that could cause the Cesium ion Token Troubleshooting panel to crash the Unity Editor.
 
 ### v0.2.0
 

--- a/native~/Editor/src/IonTokenTroubleshootingWindowImpl.cpp
+++ b/native~/Editor/src/IonTokenTroubleshootingWindowImpl.cpp
@@ -64,7 +64,7 @@ void getTokenTroubleShootingDetails(
 
             // Query the tokens using the user's connection (_not_ the token
             // connection created above).
-            CesiumIonSessionImpl ionSession = CesiumIonSessionImpl::ion();
+            CesiumIonSessionImpl& ionSession = CesiumIonSessionImpl::ion();
             ionSession.Resume(CesiumForUnity::CesiumIonSession::Ion());
 
             const std::optional<CesiumIonClient::Connection>& userConnection =


### PR DESCRIPTION
Fixes #207

The problem was that:

```cpp
CesiumIonSessionImpl ionSession = CesiumIonSessionImpl::ion();
```

makes a copy of the `CesiumIonSessionImpl`. That's fine for the generated C# wrappers, because for those an instance acts like a reference. But the Impl classes play by the normal C++ rules. So we're calling `Resume` on a stack-allocated `CesiumIonSessionImpl` instance which will be destroyed when it goes out of scope at the end of the lambda.

The `Resume` method, in turn, may return quickly and synchronously if the ion session is already connected or connecting, in which case there will be no problem. And that will likely be the case if the Cesium panel is already open.

But if that panel isn't open, and this is the first thing attempting to use Cesium ion, then `Resume` will start an async operation and expect that `this` will continue to be valid until that operation completes. But it won't be valid, because `this` points to a stack-allocated temporary. So we crash.

The simple fix is to avoid making a stack-allocated copy of `CesiumIonSessionImpl`.