### PR TITLE
stop using System::String to set shader variables

### DIFF
--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -140,12 +140,13 @@ namespace CesiumForUnity
             MeshRenderer meshRenderer = new MeshRenderer();
             GameObject meshGameObject = meshRenderer.gameObject;
             meshRenderer.material = UnityEngine.Object.Instantiate(meshRenderer.material);
-            meshRenderer.material.SetTexture("name", texture2D);
-            meshRenderer.material.SetFloat("name", 1.0f); 
-            meshRenderer.material.SetVector("name", new Vector4());
+            int id = Shader.PropertyToID("name");
+            meshRenderer.material.SetTexture(id, texture2D);
+            meshRenderer.material.SetFloat(id, 1.0f); 
+            meshRenderer.material.SetVector(id, new Vector4());
             meshRenderer.material.DisableKeyword("keywordName");
             meshRenderer.material.EnableKeyword("keywordName");
-            meshRenderer.material.GetTexture("name");
+            meshRenderer.material.GetTexture(id);
             var ids = new List<int>();
             meshRenderer.material.GetTexturePropertyNameIDs(ids);
             for (int i = 0; i < ids.Count; ++i)

--- a/native~/Runtime/src/CesiumShaderProperties.cpp
+++ b/native~/Runtime/src/CesiumShaderProperties.cpp
@@ -1,0 +1,52 @@
+#include <CesiumShaderProperties.h>
+
+#include <DotNet/UnityEngine/Shader.h>
+
+using namespace DotNet::UnityEngine;
+
+namespace CesiumForUnityNative {
+
+CesiumShaderProperties::CesiumShaderProperties() {
+  baseColorFactorID = Shader::PropertyToID(System::String("_baseColorFactor"));
+  metallicRoughnessFactorID =
+      Shader::PropertyToID(System::String("_metallicRoughnessFactor"));
+  baseColorTextureID = Shader::PropertyToID(System::String("_baseColorTexture"));
+  baseColorTextureCoordinateIndexID =
+      Shader::PropertyToID(System::String("_baseColorTextureCoordinateIndex"));
+  metallicRoughnessTextureID =
+      Shader::PropertyToID(System::String("_metallicRoughnessTexture"));
+  metallicRoughnessTextureCoordinateIndexID = Shader::PropertyToID(
+      System::String("_metallicRoughnessTextureCoordinateIndex"));
+  normalMapTextureID = Shader::PropertyToID(System::String("_normalMapTexture"));
+  normalMapTextureCoordinateIndexID =
+      Shader::PropertyToID(System::String("_normalMapTextureCoordinateIndex"));
+  normalMapScaleID = Shader::PropertyToID(System::String("_normalMapScale"));
+  occlusionTextureID = Shader::PropertyToID(System::String("_occlusionTexture"));
+  occlusionTextureCoordinateIndexID =
+      Shader::PropertyToID(System::String("_occlusionTextureCoordinateIndex"));
+  occlusionStrengthID =
+      Shader::PropertyToID(System::String("_occlusionStrength"));
+  emissiveFactorID = Shader::PropertyToID(System::String("_emissiveFactor"));
+  emissiveTextureID = Shader::PropertyToID(System::String("_emissiveTexture"));
+  emissiveTextureCoordinateIndexID =
+      Shader::PropertyToID(System::String("_emissiveTextureCoordinateIndex"));
+
+  overlayTextureCoordinateIndexID = {
+      Shader::PropertyToID(System::String("_overlay0TextureCoordinateIndex")),
+      Shader::PropertyToID(System::String("_overlay1TextureCoordinateIndex")),
+      Shader::PropertyToID(System::String("_overlay2TextureCoordinateIndex")),
+      Shader::PropertyToID(System::String("_overlay3TextureCoordinateIndex"))};
+
+  overlayTextureID = {
+      Shader::PropertyToID(System::String("_overlay0Texture")),
+      Shader::PropertyToID(System::String("_overlay1Texture")),
+      Shader::PropertyToID(System::String("_overlay2Texture")),
+      Shader::PropertyToID(System::String("_overlay3Texture"))};
+
+  overlayTranslationAndScaleID = {
+      Shader::PropertyToID(System::String("_overlay0TranslationAndScale")),
+      Shader::PropertyToID(System::String("_overlay1TranslationAndScale")),
+      Shader::PropertyToID(System::String("_overlay2TranslationAndScale")),
+      Shader::PropertyToID(System::String("_overlay3TranslationAndScale"))};
+}
+} // namespace CesiumForUnityNative

--- a/native~/Runtime/src/CesiumShaderProperties.h
+++ b/native~/Runtime/src/CesiumShaderProperties.h
@@ -1,0 +1,73 @@
+#pragma once
+#include <DotNet/System/String.h>
+
+#include <cstdint>
+#include <vector>
+
+using namespace DotNet;
+
+namespace CesiumForUnityNative {
+class CesiumShaderProperties {
+public:
+  CesiumShaderProperties();
+  const int32_t getBaseColorFactorID() const { return baseColorFactorID; }
+  const int32_t getMetallicRoughnessFactorID() const {
+    return metallicRoughnessFactorID;
+  }
+  const int32_t getBaseColorTextureID() const { return baseColorTextureID; }
+  const int32_t getBaseColorTextureCoordinateIndexID() const {
+    return baseColorTextureCoordinateIndexID;
+  }
+  const int32_t getMetallicRoughnessTextureID() const {
+    return metallicRoughnessTextureID;
+  }
+  const int32_t getMetallicRoughnessTextureCoordinateIndexID() const {
+    return metallicRoughnessTextureCoordinateIndexID;
+  }
+  const int32_t getNormalMapTextureID() const { return normalMapTextureID; }
+  const int32_t getNormalMapTextureCoordinateIndexID() const {
+    return normalMapTextureCoordinateIndexID;
+  }
+  const int32_t getNormalMapScaleID() const { return normalMapScaleID; }
+  const int32_t getOcclusionTextureID() const { return occlusionTextureID; }
+  const int32_t getOcclusionTextureCoordinateIndexID() const {
+    return occlusionTextureCoordinateIndexID;
+  }
+  const int32_t getOcclusionStrengthID() const { return occlusionStrengthID; }
+  const int32_t getEmissiveFactorID() const { return emissiveFactorID; }
+  const int32_t getEmissiveTextureID() const { return emissiveTextureID; }
+  const int32_t getEmissiveTextureCoordinateIndexID() const {
+    return emissiveTextureCoordinateIndexID;
+  }
+
+  const int32_t getOverlayTextureCoordinateIndexID(int32_t index) {
+    return overlayTextureCoordinateIndexID[index];
+  }
+  const int32_t getOverlayTextureID(int32_t index) { return overlayTextureID[index];
+  }
+  const int32_t getOverlayTranslationAndScaleID(int32_t index) {
+    return overlayTranslationAndScaleID[index];
+  }
+
+private:
+  int32_t baseColorFactorID;
+  int32_t metallicRoughnessFactorID;
+  int32_t baseColorTextureID;
+  int32_t baseColorTextureCoordinateIndexID;
+  int32_t metallicRoughnessTextureID;
+  int32_t metallicRoughnessTextureCoordinateIndexID;
+  int32_t normalMapTextureID;
+  int32_t normalMapTextureCoordinateIndexID;
+  int32_t normalMapScaleID;
+  int32_t occlusionTextureID;
+  int32_t occlusionTextureCoordinateIndexID;
+  int32_t occlusionStrengthID;
+  int32_t emissiveFactorID;
+  int32_t emissiveTextureID;
+  int32_t emissiveTextureCoordinateIndexID;
+
+  std::vector<int32_t> overlayTextureCoordinateIndexID;
+  std::vector<int32_t> overlayTextureID;
+  std::vector<int32_t> overlayTranslationAndScaleID;
+};
+} // namespace CesiumForUnityNative

--- a/native~/Runtime/src/UnityPrepareRendererResources.h
+++ b/native~/Runtime/src/UnityPrepareRendererResources.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Cesium3DTilesSelection/IPrepareRendererResources.h>
+#include <CesiumShaderProperties.h>
 
 #include <DotNet/UnityEngine/GameObject.h>
 
@@ -98,6 +99,7 @@ public:
 
 private:
   ::DotNet::UnityEngine::GameObject _tileset;
+  CesiumShaderProperties _shaderProperty;
 };
 
 } // namespace CesiumForUnityNative


### PR DESCRIPTION
I'm seeing mucho garbage creation from using the Dotnet::System::String class. This pr address creating many new strings when setting shader variables, it is also more desirable to use ids anyways.

Usually string [interning ](https://learn.microsoft.com/en-us/dotnet/api/system.string.intern?view=net-7.0) would save us from the garbage creation but it only works with string literals. 

I would suggest not creating any .NET strings at all if we could help it.

Why am I nitpicking GC? Keeping runtime allocations low are critically important for low power devices like a hololens2 as there is noticeable frame rate drop when the garbage collector runs. Ideally, there would be 0 runtime allocations, aside from resource creation that can't be helped like, meshes, and textures. Although we should probably be pooling the meshes as well instead of creating/destroying.

using [shader id](https://docs.unity3d.com/ScriptReference/Shader.PropertyToID.html#:~:text=Using%20property%20identifiers%20is%20more%20efficient%20than%20passing%20strings%20to%20all%20material%20property%20functions.%20For%20example%20if%20you%20are%20calling%20Material.SetColor%20a%20lot%2C%20or%20using%20MaterialPropertyBlock%2C%20then%20it%20is%20better%20to%20get%20the%20identifiers%20of%20the%20properties%20you%20need%20just%20once.)'s is more performant than using strings. 
![StringGC](https://user-images.githubusercontent.com/13579475/220481935-21185aa1-6d15-4bd1-b92b-de8713952faf.PNG)
