### PR TITLE
Fix metadata changelog entry + add missing documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,15 +9,16 @@
 - Marked the `longitude`, `latitude`, and `height` properties on `CesiumGlobeAnchor` as obsolete. Use the `longitudeLatitudeHeight` property instead.
 - Marked the `ecefX`, `ecefY`, and `ecefZ` properties on `CesiumGlobeAnchor` as obsolete. Use the `positionGlobeFixed` property instead.
 - Marked `SetPositionLongitudeLatitudeHeight` and `SetPositionEarthCenteredEarthFixed` methods on `CesiumGlobeAnchor` as obsolete. Set the `longitudeLatitudeHeight` or `positionGlobeFixed` property instead.
+- Replaced `MetadataProperty` with `CesiumFeature`. Metadata features are now separated based on feature tables where properties can be accessed by name.
+- Replaced `CesiumMetadata.GetProperties` with `CesiumMetadata.GetFeatures`, which returns an array of `CesiumFeature`s.
 
 ##### Additions :tada:
 
 - Added support for rendering point clouds (`pnts`).
-- Metadata features are now separated based on feature tables. Properties can now be accessed by name.
 - `CesiumGlobeAnchor` now stores a precise, globe-relative orientation and scale in addition to position.
 - Added `localToGlobeFixedMatrix`, `longitudeLatitudeHeight`, `positionGlobeFixed`, `rotationGlobeFixed`, `rotationEastUpNorth`, `scaleGlobeFixed`, and `scaleEastUpNorth` properties to `CesiumGlobeAnchor`.
 - Added the `Restart` method to `CesiumGlobeAnchor`, which can be use to reinitialize the component from its serialized values.
-- Copy all response headers from UnityWebRequest to enable caching.
+- Enabled caching of UnityWebRequests by copying all response headers.
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
 - Marked the `longitude`, `latitude`, and `height` properties on `CesiumGlobeAnchor` as obsolete. Use the `longitudeLatitudeHeight` property instead.
 - Marked the `ecefX`, `ecefY`, and `ecefZ` properties on `CesiumGlobeAnchor` as obsolete. Use the `positionGlobeFixed` property instead.
 - Marked `SetPositionLongitudeLatitudeHeight` and `SetPositionEarthCenteredEarthFixed` methods on `CesiumGlobeAnchor` as obsolete. Set the `longitudeLatitudeHeight` or `positionGlobeFixed` property instead.
-- Replaced `MetadataProperty` with `CesiumFeature`. Metadata features are now separated based on feature tables where properties can be accessed by name.
+- Replaced `MetadataProperty` with `CesiumFeature`. Metadata features are now separated based on feature tables where properties are accessed by name.
 - Replaced `CesiumMetadata.GetProperties` with `CesiumMetadata.GetFeatures`, which returns an array of `CesiumFeature`s.
 
 ##### Additions :tada:

--- a/Runtime/CesiumFeature.cs
+++ b/Runtime/CesiumFeature.cs
@@ -31,100 +31,111 @@ namespace CesiumForUnity
     [ReinteropNativeImplementation("CesiumForUnityNative::CesiumFeatureImpl", "CesiumFeatureImpl.h")]
     public partial class CesiumFeature
     {
-        public string className {get; set;}
-        public string featureTableName {get; set;}
-        public string[] properties {get; set;}
+        /// <summary>
+        /// The name of the class that this CesiumFeature conforms to.
+        /// </summary>
+        public string className { get; internal set; }
 
         /// <summary>
-        /// Gets the value of this property as a signed byte, or a default value if
-        /// the property value cannot be converted to that type.
+        /// The name of the feature table containing the values of this CesiumFeature's properties.
+        /// </summary>
+        public string featureTableName { get; internal set; }
+
+        /// <summary>
+        /// The names of the properties that exist in this CesiumFeature.
+        /// </summary>
+        public string[] properties { get; internal set; }
+
+        /// <summary>
+        /// Gets the value of the specified property as a signed byte. Returns the default 
+        /// value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="defaultValue">The default value.</param>
         public partial sbyte GetInt8(string property, sbyte defaultValue);
 
         /// <summary>
-        /// Gets the value of this property as a byte, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property as a byte. Returns the default value
+        /// if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="defaultValue">The default value.</param>
         public partial byte GetUInt8(string property, byte defaultValue);
 
         /// <summary>
-        /// Gets the value of this property as a signed, 16-bit integer, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property as a signed 16-bit integer. Returns
+        /// the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="defaultValue">The default value.</param>
         public partial Int16 GetInt16(string property, Int16 defaultValue);
 
         /// <summary>
-        /// Gets the value of this property as an unsigned, 16-bit integer, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property as an unsigned 16-bit integer. Returns
+        /// the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="defaultValue">The default value.</param>
         public partial UInt16 GetUInt16(string property, UInt16 defaultValue);
 
         /// <summary>
-        /// Gets the value of this property as a signed, 32-bit integer, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property as a signed 32-bit integer. Returns
+        /// the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="defaultValue">The default value.</param>
         public partial Int32 GetInt32(string property, Int32 defaultValue);
 
         /// <summary>
-        /// Gets the value of this property as an unsigned, 32-bit integer, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property as an unsigned 32-bit integer.
+        /// Returns the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="defaultValue">The default value.</param>
         public partial UInt32 GetUInt32(string property, UInt32 defaultValue);
 
         /// <summary>
-        /// Gets the value of this property as a signed, 64-bit integer, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property as a signed 64-bit integer. Returns
+        /// the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="defaultValue">The default value.</param>
         public partial Int64 GetInt64(string property, Int64 defaultValue);
 
         /// <summary>
-        /// Gets the value of this property as an unsigned, 64-bit integer, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property as an unsigned 64-bit integer. Returns
+        /// the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="defaultValue">The default value.</param>
         public partial UInt64 GetUInt64(string property, UInt64 defaultValue);
 
         /// <summary>
-        /// Gets the value of this property as a 32-bit floating-point number, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property as a 32-bit floating-point number.
+        /// Returns the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="defaultValue">The default value.</param>
         public partial float GetFloat32(string property, float defaultValue);
 
         /// <summary>
-        /// Gets the value of this property as a 64-bit floating-point number, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property as a 64-bit floating-point number.
+        /// Returns the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="defaultValue">The default value.</param>
         public partial double GetFloat64(string property, double defaultValue);
 
         /// <summary>
-        /// Gets the value of this property as a boolean value, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property as a boolean value. Returns the default
+        /// value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="defaultValue">The default value.</param>
         public partial Boolean GetBoolean(string property, Boolean defaultValue);
 
         /// <summary>
-        /// Gets the value of this property as a string, or a default value if
+        /// Gets the value of the specified property as a string. Returns the default value if
         /// the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
@@ -132,8 +143,8 @@ namespace CesiumForUnity
         public partial String GetString(string property, String defaultValue);
 
         /// <summary>
-        /// Gets the value of this property from an array as a signed byte, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property from an array as a signed byte. 
+        /// Returns the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="index">The index of the component.</param>
@@ -141,8 +152,8 @@ namespace CesiumForUnity
         public partial sbyte GetComponentInt8(string property, int index, sbyte defaultValue);
 
         /// <summary>
-        /// Gets the value of this property from an array as a byte, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property from an array as a byte.
+        /// Returns the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="index">The index of the component.</param>
@@ -150,7 +161,8 @@ namespace CesiumForUnity
         public partial byte GetComponentUInt8(string property, int index, byte defaultValue);
 
         /// <summary>
-        /// Gets the value of this property from an array as a signed, 16-bit integer, or a default value if
+        /// Gets the value of the specified property from an array as a signed 16-bit integer.
+        /// Returns the default value if
         /// the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
@@ -159,8 +171,8 @@ namespace CesiumForUnity
         public partial Int16 GetComponentInt16(string property, int index, Int16 defaultValue);
 
         /// <summary>
-        /// Gets the value of this property from an array as an unsigned, 16-bit integer, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property from an array as an unsigned 16-bit integer.
+        /// Returns the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="index">The index of the component.</param>
@@ -168,8 +180,8 @@ namespace CesiumForUnity
         public partial UInt16 GetComponentUInt16(string property, int index, UInt16 defaultValue);
 
         /// <summary>
-        /// Gets the value of this property from an array as a signed, 32-bit integer, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property from an array as a signed 32-bit integer.
+        /// Returns the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="index">The index of the component.</param>
@@ -177,8 +189,8 @@ namespace CesiumForUnity
         public partial Int32 GetComponentInt32(string property, int index, Int32 defaultValue);
 
         /// <summary>
-        /// Gets the value of this property from an array as an unsigned, 32-bit integer, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property from an array as an unsigned 32-bit integer.
+        /// Returns the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="index">The index of the component.</param>
@@ -186,8 +198,8 @@ namespace CesiumForUnity
         public partial UInt32 GetComponentUInt32(string property, int index, UInt32 defaultValue);
 
         /// <summary>
-        /// Gets the value of this property from an array as a signed, 64-bit integer, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property from an array as a signed 64-bit integer.
+        /// Returns the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="index">The index of the component.</param>
@@ -195,8 +207,8 @@ namespace CesiumForUnity
         public partial Int64 GetComponentInt64(string property, int index, Int64 defaultValue);
 
         /// <summary>
-        /// Gets the value of this property from an array as an unsigned, 64-bit integer, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property from an array as an unsigned 64-bit integer.
+        /// Returns the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="index">The index of the component.</param>
@@ -204,8 +216,8 @@ namespace CesiumForUnity
         public partial UInt64 GetComponentUInt64(string property, int index, UInt64 defaultValue);
 
         /// <summary>
-        /// Gets the value of this property from an array as a 32-bit floating-point number, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property from an array as a 32-bit floating-point number.
+        /// Returns the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="index">The index of the component.</param>
@@ -213,8 +225,9 @@ namespace CesiumForUnity
         public partial float GetComponentFloat32(string property, int index, float defaultValue);
 
         /// <summary>
-        /// Gets the value of this property from an array as a 64-bit floating-point number, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property property from an array as a 64-bit 
+        /// floating-point number. Returns the default value if the property value cannot 
+        /// be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="index">The index of the component.</param>
@@ -222,8 +235,8 @@ namespace CesiumForUnity
         public partial double GetComponentFloat64(string property, int index, double defaultValue);
 
         /// <summary>
-        /// Gets the value of this property from an array as a boolean value, or a default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property property from an array as a boolean value.
+        /// Returns the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="index">The index of the component.</param>
@@ -231,7 +244,7 @@ namespace CesiumForUnity
         public partial Boolean GetComponentBoolean(string property, int index, Boolean defaultValue);
 
         /// <summary>
-        /// Gets the value of this property from an array as a string, or a default value if
+        /// Gets the value of the specified property from an array as a string. Returns the default value if
         /// the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
@@ -252,15 +265,15 @@ namespace CesiumForUnity
         public partial MetadataType GetComponentType(string property);
 
         /// <summary>
-        /// Gets the type of this property.
+        /// Gets the type of the specified property.
         /// <param name="property">The name of the property.</param>
         /// </summary>
         public partial MetadataType GetMetadataType(string property);
 
         /// <summary>
-        /// Determines if the property value is normalized.
+        /// Determines if the specified property's value is normalized.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         public partial bool IsNormalized(string property);
-   }
+    }
 }

--- a/Runtime/CesiumFeature.cs
+++ b/Runtime/CesiumFeature.cs
@@ -25,6 +25,9 @@ namespace CesiumForUnity
         Array
     }
 
+    /// <summary>
+    /// Allows access to a particular feature of <see cref="CesiumMetadata"/>.
+    /// </summary>
     [ReinteropNativeImplementation("CesiumForUnityNative::CesiumFeatureImpl", "CesiumFeatureImpl.h")]
     public partial class CesiumFeature
     {

--- a/Runtime/CesiumFeature.cs
+++ b/Runtime/CesiumFeature.cs
@@ -162,8 +162,7 @@ namespace CesiumForUnity
 
         /// <summary>
         /// Gets the value of the specified property from an array as a signed 16-bit integer.
-        /// Returns the default value if
-        /// the property value cannot be converted to that type.
+        /// Returns the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="index">The index of the component.</param>
@@ -244,8 +243,8 @@ namespace CesiumForUnity
         public partial Boolean GetComponentBoolean(string property, int index, Boolean defaultValue);
 
         /// <summary>
-        /// Gets the value of the specified property from an array as a string. Returns the default value if
-        /// the property value cannot be converted to that type.
+        /// Gets the value of the specified property from an array as a string. Returns 
+        /// the default value if the property value cannot be converted to that type.
         /// </summary>
         /// <param name="property">The name of the property.</param>
         /// <param name="index">The index of the component.</param>


### PR DESCRIPTION
The change recorded in #194 wasn't properly categorized as a breaking change. There was also some missing documentation for the `CesiumFeature` class. This PR addresses both issues.

@joseph-kaile can you review for correctness?