### PR TITLE
Check for successful Reinterop init before calling into C++ static methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,11 +18,11 @@
 - `CesiumGlobeAnchor` now stores a precise, globe-relative orientation and scale in addition to position.
 - Added `localToGlobeFixedMatrix`, `longitudeLatitudeHeight`, `positionGlobeFixed`, `rotationGlobeFixed`, `rotationEastUpNorth`, `scaleGlobeFixed`, and `scaleEastUpNorth` properties to `CesiumGlobeAnchor`.
 - Added the `Restart` method to `CesiumGlobeAnchor`, which can be use to reinitialize the component from its serialized values.
-- Enabled caching of UnityWebRequests by copying all response headers.
+- Moved the Cesium tileset shaders from the `Shader Graphs` shader category to the new `Cesium` shader category.
 
 ##### Fixes :wrench:
 
-- Recategorized the Cesium tileset shaders from the `Shader Graphs` shader category to the new `Cesium` shader category. 
+- Fixed a bug that prevented caching of 3D Tiles and overlay requests.
 - Fixed a bug that could cause the Cesium ion Token Troubleshooting panel to crash the Unity Editor.
 - Added a workaround for a crash in the Burst Compiler (bcl.exe) in Unity 2022.2 when using il2cpp.
 

--- a/Reinterop~/MethodsImplementedInCpp.cs
+++ b/Reinterop~/MethodsImplementedInCpp.cs
@@ -413,6 +413,10 @@ namespace Reinterop
                         throw new NotImplementedException("The native implementation is missing so {{method.Name}} cannot be invoked. This may be caused by a missing call to CreateImplementation in one of your constructors, or it may be that the entire native implementation shared library is missing or out of date.");
                     """;
             }
+            else
+            {
+                implementationCheck = "Reinterop.ReinteropInitializer.Initialize();";
+            }
 
             if (method.IsOverride)
                 modifiers += " override";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.cesium.unity",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "displayName": "Cesium for Unity",
   "description": "Cesium for Unity brings the 3D geospatial ecosystem to Unity. By combining a high-accuracy full-scale WGS84 globe, open APIs and open standards for spatial indexing such as 3D Tiles, and cloud-based real-world content from [Cesium ion](https://cesium.com/cesium-ion) with Unity, this plugin enables 3D geospatial workflows and applications in Unity.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fixes #230

Actually I'm not totally sure it does, because I can't reproduce #230, but I can see how it might happen. This PR makes sure reinterop is initialized before calling into any static C++ methods. If the C# and C++ code are out of sync, the initialization will throw an exception, rather than calling a function pointer using possibly the wrong signature and crashing.