### PR TITLE
Round feature IDs.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 - Fixed a bug that prevented caching of 3D Tiles and overlay requests.
 - Fixed a bug that could cause the Cesium ion Token Troubleshooting panel to crash the Unity Editor.
 - Added a workaround for a crash in the Burst Compiler (bcl.exe) in Unity 2022.2 when using il2cpp.
+- Fixed a bug that could cause incorrect metadata to be associated with a feature, especially in Draco-encoded tiles.
 
 ### v0.2.0
 


### PR DESCRIPTION
Rather than truncating them. To account for error potentially introduced by Draco encoding. Same problem (and solution) as in Unreal: https://github.com/CesiumGS/cesium-unreal/pull/576

Fixes #232 