### PR TITLE
Support pre-existing mipmaps.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that prevented the use of pre-existing mipmaps, such as those loaded from KTX2.
+
 ### v0.3.1
 
 ##### Fixes :wrench:


### PR DESCRIPTION
After CesiumGS/cesium-native#607, KTX2 textures still didn't work right in Cesium for Unity. The problem was that KTX2 provides the smallest mipmap first and the largest (highest resolution) last, while Unity expects the opposite.

This PR changes the texture loading code to read the mip levels from the correct place.