### PR TITLE
Add ability to exclude tiles by implementing a C# class.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Additions :tada:
+
+- Added `CesiumTileExcluder` abstract class. By deriving from this class and adding an instance of your derived class to your game object, you can implement custom rules for excluding certain tiles in a Cesium3DTileset from loading and rendering.
+
 ### v0.3.1
 
 ##### Fixes :wrench:

--- a/Reinterop~/Fields.cs
+++ b/Reinterop~/Fields.cs
@@ -43,28 +43,8 @@ namespace Reinterop
             if (field.IsStatic)
                 return;
 
-            string fieldName = field.Name;
-            bool isPrivate = field.DeclaredAccessibility != Accessibility.Public;
-
-            // If this is a backing field for an automatic property, use the property name instead.
-            IPropertySymbol? autoProperty = field.AssociatedSymbol as IPropertySymbol;
-            
-            // Unfortunately, the above will only work if the C# compiler is looking at the source code for the property.
-            // So for backing fields in referenced assemblies, we need to do this more manually.
-            if (autoProperty == null && fieldName.EndsWith("__BackingField"))
-            {
-                Match match = new Regex("<(.+)>k__BackingField").Match(fieldName);
-                if (match.Success && match.Groups.Count > 1)
-                {
-                    autoProperty = CSharpTypeUtility.FindMember(field.ContainingType, match.Groups[1].Value) as IPropertySymbol;
-                }
-            }
-
-            if (autoProperty != null)
-            {
-                fieldName = autoProperty.Name;
-                isPrivate = autoProperty.DeclaredAccessibility != Accessibility.Public;
-            }
+            string fieldName = CSharpTypeUtility.GetFieldName(field);
+            bool isPrivate = CSharpTypeUtility.GetFieldIsPrivate(field);
 
             CppType fieldType = CppType.FromCSharp(context, field.Type);
 

--- a/Runtime/Cesium3DTile.cs
+++ b/Runtime/Cesium3DTile.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace CesiumForUnity
 {
-    [ReinteropNativeImplementation("CesiumForUnityNative::Cesium3DTileImpl", "Cesium3DTileImpl.h")]
+    [ReinteropNativeImplementation("CesiumForUnityNative::Cesium3DTileImpl", "Cesium3DTileImpl.h", staticOnly: true)]
     public partial class Cesium3DTile
     {
         internal CesiumGeoreference _georeference;

--- a/Runtime/Cesium3DTile.cs
+++ b/Runtime/Cesium3DTile.cs
@@ -1,0 +1,26 @@
+﻿
+using Reinterop;
+using System;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace CesiumForUnity
+{
+    [ReinteropNativeImplementation("CesiumForUnityNative::Cesium3DTileImpl", "Cesium3DTileImpl.h")]
+    public partial class Cesium3DTile
+    {
+        internal CesiumGeoreference _georeference;
+        internal IntPtr _pTile;
+
+        /// <summary>
+        /// Gets the axis-aligned bounding box of this tile. If this tile came from a <see cref="CesiumTileExcluder"/>,
+        /// the bounding box is expressed in the local coordinates of the excluder's game object.
+        /// </summary>
+        public Bounds bounds
+        {
+            get => Cesium3DTile.getBounds(this._pTile, this._georeference.ecefToLocalMatrix);
+        }
+
+        private static partial Bounds getBounds(IntPtr pTile, double4x4 ecefToLocalMatrix);
+    }
+}

--- a/Runtime/Cesium3DTile.cs.meta
+++ b/Runtime/Cesium3DTile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c5908fec2a372f849b8673b15de1b95d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/CesiumTileExcluder.cs
+++ b/Runtime/CesiumTileExcluder.cs
@@ -1,0 +1,28 @@
+﻿using UnityEngine;
+
+namespace CesiumForUnity
+{
+    [ExecuteInEditMode]
+    public abstract partial class CesiumTileExcluder : MonoBehaviour
+    {
+        internal Cesium3DTile _tile = null;
+
+        /// <summary>
+        /// Determines whether the given tile should be excluded from loading and rendering.
+        /// </summary>
+        /// <param name="tile">The tile to check. This instance is only valid for the duration of this call.</param>
+        /// <returns>True if the tile should be excluded, false if the tile should be loaded and rendered.</returns>
+        public abstract bool ShouldExclude(Cesium3DTile tile);
+
+        protected virtual void OnEnable()
+        {
+            this._tile = new Cesium3DTile();
+            this._tile._georeference = GetComponentInParent<CesiumGeoreference>();
+        }
+
+        protected virtual void OnDisable()
+        {
+            this._tile = null;
+        }
+    }
+}

--- a/Runtime/CesiumTileExcluder.cs.meta
+++ b/Runtime/CesiumTileExcluder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2bf9828a0b1ac34aa1881467475a6e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -452,6 +452,13 @@ namespace CesiumForUnity
             globeAnchor._lastLocalToWorld = new Matrix4x4();
             globeAnchor.UpdateGeoreferenceIfNecessary();
 
+            CesiumTileExcluder[] excluders = go.GetComponentsInParent<CesiumTileExcluder>();
+            CesiumTileExcluder excluder = excluders[0];
+            excluder.ShouldExclude(null);
+            excluder._tile._georeference = null;
+            excluder._tile._pTile = IntPtr.Zero;
+            excluder._tile = null;
+
 #if UNITY_EDITOR
             SceneView sv = SceneView.lastActiveSceneView;
             sv.pivot = sv.pivot;

--- a/native~/Runtime/src/Cesium3DTileImpl.cpp
+++ b/native~/Runtime/src/Cesium3DTileImpl.cpp
@@ -1,0 +1,31 @@
+#include "Cesium3DTileImpl.h"
+
+#include "UnityTransforms.h"
+
+#include <Cesium3DTilesSelection/Tile.h>
+
+#include <DotNet/Unity/Mathematics/double4x4.h>
+#include <DotNet/UnityEngine/Bounds.h>
+
+using namespace Cesium3DTilesSelection;
+using namespace CesiumGeometry;
+
+namespace CesiumForUnityNative {
+
+DotNet::UnityEngine::Bounds Cesium3DTileImpl::getBounds(
+    void* pTileVoid,
+    const DotNet::Unity::Mathematics::double4x4& ecefToLocalMatrix) {
+  const Tile* pTile = static_cast<const Tile*>(pTileVoid);
+  const BoundingVolume& bv = pTile->getBoundingVolume();
+  OrientedBoundingBox obb = getOrientedBoundingBoxFromBoundingVolume(bv);
+  obb = obb.transform(UnityTransforms::fromUnity(ecefToLocalMatrix));
+  AxisAlignedBox aabb = obb.toAxisAligned();
+  return DotNet::UnityEngine::Bounds::Construct(
+      UnityTransforms::toUnity(aabb.center),
+      DotNet::UnityEngine::Vector3{
+          float(aabb.lengthX),
+          float(aabb.lengthY),
+          float(aabb.lengthZ)});
+}
+
+} // namespace CesiumForUnityNative

--- a/native~/Runtime/src/Cesium3DTileImpl.h
+++ b/native~/Runtime/src/Cesium3DTileImpl.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace DotNet::Unity::Mathematics {
+struct double4x4;
+}
+
+namespace DotNet::UnityEngine {
+struct Bounds;
+}
+
+namespace CesiumForUnityNative {
+
+class Cesium3DTileImpl {
+public:
+  static DotNet::UnityEngine::Bounds getBounds(
+      void* pTileVoid,
+      const DotNet::Unity::Mathematics::double4x4& ecefToLocalMatrix);
+};
+
+} // namespace CesiumForUnityNative

--- a/native~/Runtime/src/UnityTileExcluderAdaptor.cpp
+++ b/native~/Runtime/src/UnityTileExcluderAdaptor.cpp
@@ -1,0 +1,21 @@
+#include "UnityTileExcluderAdaptor.h"
+
+#include <DotNet/CesiumForUnity/Cesium3DTile.h>
+#include <DotNet/CesiumForUnity/CesiumTileExcluder.h>
+
+namespace CesiumForUnityNative {
+
+UnityTileExcluderAdaptor::UnityTileExcluderAdaptor(
+    const DotNet::CesiumForUnity::CesiumTileExcluder& excluder,
+    const DotNet::CesiumForUnity::CesiumGeoreference& georeference)
+    : _excluder(excluder), _tile(excluder._tile()) {
+  this->_tile._georeference(georeference);
+}
+
+bool UnityTileExcluderAdaptor::shouldExclude(
+    const Cesium3DTilesSelection::Tile& tile) const noexcept {
+  this->_tile._pTile(const_cast<Cesium3DTilesSelection::Tile*>(&tile));
+  return this->_excluder.ShouldExclude(this->_tile);
+}
+
+} // namespace CesiumForUnityNative

--- a/native~/Runtime/src/UnityTileExcluderAdaptor.h
+++ b/native~/Runtime/src/UnityTileExcluderAdaptor.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <Cesium3DTilesSelection/ITileExcluder.h>
+
+#include <DotNet/CesiumForUnity/Cesium3DTile.h>
+#include <DotNet/CesiumForUnity/CesiumTileExcluder.h>
+
+namespace DotNet::CesiumForUnity {
+class CesiumGeoreference;
+} // namespace DotNet::CesiumForUnity
+
+namespace CesiumForUnityNative {
+
+class UnityTileExcluderAdaptor : public Cesium3DTilesSelection::ITileExcluder {
+public:
+  UnityTileExcluderAdaptor(
+      const DotNet::CesiumForUnity::CesiumTileExcluder& excluder,
+      const DotNet::CesiumForUnity::CesiumGeoreference& georeference);
+
+  virtual bool shouldExclude(
+      const Cesium3DTilesSelection::Tile& tile) const noexcept override;
+
+private:
+  DotNet::CesiumForUnity::CesiumTileExcluder _excluder;
+  DotNet::CesiumForUnity::Cesium3DTile _tile;
+};
+
+} // namespace CesiumForUnityNative


### PR DESCRIPTION
Depends on CesiumGS/cesium-native#608

Added `CesiumTileExcluder`, which is a C# version of cesium-native's `ITileExcluder`.

The idea is that we can add a C# class like this to our project:

```csharp
using CesiumForUnity;
using UnityEngine;

[RequireComponent(typeof(BoxCollider))]
public class CesiumBoxExcluder : CesiumTileExcluder
{
    private BoxCollider _box;

    protected override void OnEnable()
    {
        base.OnEnable();

        this._box = GetComponent<BoxCollider>();
    }
    public override bool ShouldExclude(Cesium3DTile tile)
    {
        return !this._box.bounds.Intersects(tile.bounds);
    }
}
```

And then add an instance of this class as a component on the `Cesium3DTileset` or any of its parents, up to and including the `CesiumGeoreference`.

With that in place, cesium-native will call the `ShouldExclude` method for each tile that it is considering loading or rendering. This will happen a _lot_, so this method needs to be fast. Return true to skip loading and rendering that tile. Return false to load it and render it as normal.

In the implementation above, a user-defined BoxCollider is also attached to the same GameObject as the CesiumBoxExcluder. Any tiles that intersect this BoxCollider are loaded and rendered, others are not. So tiles that are entirely outside of the box are ignored. The given tile's `bounds` property is an axis-aligned bounding box in the same coordinate system as the `CesiumBoxExcluder`, so it's easy to do tests like this.

In this screenshot, the BoxCollider is the green box in the middle of Melbourne. All of the visible tiles are at least partially inside the box:

![image](https://user-images.githubusercontent.com/924374/225528568-647a9bb8-58c1-4635-b0dc-c24713b7ff95.png)

If we disable the CesiumBoxExcluder, all the tiles load as normal:

![image](https://user-images.githubusercontent.com/924374/225528858-5986386f-7413-434f-8050-37d5ff1bc61c.png)

Also in this PR: Extended Reinterop to allow constructors of blittable value types to be called from C++. On the C++ side, these are exposed as `Constrct` methods rather than C++ constructors so that brace initialization can continue to be used to initialize fields without calling into C#.


