### PR TITLE
Remove references to non-existent input axes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v0.4.0
+
+##### Fixes :wrench:
+
+- Fixed a bug where `CesiumCameraController` tried to access non-existent inputs in the legacy input system.
+
 ### v0.3.1
 
 ##### Fixes :wrench:

--- a/Runtime/CesiumCameraController.cs
+++ b/Runtime/CesiumCameraController.cs
@@ -168,7 +168,7 @@ namespace CesiumForUnity
 
         #region Input configuration
 
-        #if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM
         InputAction lookAction;
         InputAction moveAction;
         InputAction moveUpAction;
@@ -225,7 +225,7 @@ namespace CesiumForUnity
             speedResetAction.Enable();
             toggleDynamicSpeedAction.Enable();
         }
-        #endif
+#endif
 
         #endregion
 
@@ -309,9 +309,9 @@ namespace CesiumForUnity
             this.InitializeController();
             this.CreateMaxSpeedCurve();
 
-            #if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM
             this.ConfigureInputs();
-            #endif
+#endif
         }
 
         #endregion
@@ -371,7 +371,7 @@ namespace CesiumForUnity
 
         private void HandlePlayerInputs()
         {
-            #if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM
             Vector2 lookDelta;
             Vector2 moveDelta;
             lookDelta = lookAction.ReadValue<Vector2>();
@@ -414,12 +414,9 @@ namespace CesiumForUnity
             bool inputSpeedReset = speedResetAction.ReadValue<float>() > 0.5f;
 
             bool toggleDynamicSpeed = toggleDynamicSpeedAction.ReadValue<float>() > 0.5f;
-            #else
+#else
             float inputRotateHorizontal = Input.GetAxis("Mouse X");
-            inputRotateHorizontal += Input.GetAxis("Controller Right Stick X");
-
             float inputRotateVertical = Input.GetAxis("Mouse Y");
-            inputRotateVertical += Input.GetAxis("Controller Right Stick Y");
 
             float inputForward = Input.GetAxis("Vertical");
             float inputRight = Input.GetAxis("Horizontal");
@@ -431,7 +428,7 @@ namespace CesiumForUnity
 
             bool toggleDynamicSpeed =
                 Input.GetKeyDown("g") || Input.GetKeyDown("joystick button 1");
-            #endif
+#endif
 
             Vector3 movementInput = new Vector3(inputRight, inputUp, inputForward);
 
@@ -640,7 +637,7 @@ namespace CesiumForUnity
             }
 
             // Raycast along the camera's view (forward) vector.
-            float raycastDistance = 
+            float raycastDistance =
                 Mathf.Clamp(this._maxSpeed * 3.0f, 0.0f, this._maxRaycastDistance);
 
             // If the raycast does not hit, then only override speed if the height


### PR DESCRIPTION
A forum user reported that the DynamicCamera threw runtime errors that said “Input Axis Controller Right Stick X is not setup” ([post here](https://community.cesium.com/t/runtime-error-input-axis-controller-right-stick-x-is-not-setup/22941/3)). This is because "Controller Right Stick X" and its Y counterpart are not built-in Unity variables. They appear in Unity's `FreeCamera.cs` script, but that script is actually creating the input mappings for that axis itself, which I didn't realize when I was referencing it for the input names.

There's no public Unity API to bind new inputs to `InputManager` at runtime. If a user wants to support camera movement with their controller, they'll have to create the input mapping itself. But this just involves duplicating the "Mouse X" and "Mouse Y" entries and configuring the duplicate entries for a controller joystick. See [here](https://www.reddit.com/r/Unity3D/comments/hgx88m/mouse_look_andor_right_stick_controller/) for more detail.