### PR TITLE
Fix assets window crash

### DIFF
--- a/Editor/CesiumIonAssetsWindow.cs
+++ b/Editor/CesiumIonAssetsWindow.cs
@@ -65,8 +65,8 @@ namespace CesiumForUnity
         void OnGUI()
         {
             GUILayout.BeginHorizontal();
-            DrawAssetListPanel();
-            DrawAssetDescriptionPanel();
+            this.DrawAssetListPanel();
+            this.DrawAssetDescriptionPanel();
             GUILayout.EndHorizontal();
 
             // Force the window to repaint if the cursor is hovered over it.
@@ -158,7 +158,7 @@ namespace CesiumForUnity
             }
 
             int selectedId = this._assetsTreeState.lastClickedID;
-            if (selectedId <= 0)
+            if (selectedId <= 0 || selectedId > this._assetsTreeView.GetAssetsCount())
             {
                 return;
             }

--- a/Editor/IonAssetsMultiColumnHeader.cs
+++ b/Editor/IonAssetsMultiColumnHeader.cs
@@ -4,7 +4,8 @@ namespace CesiumForUnity
 {
     public class IonAssetsMultiColumnHeader : MultiColumnHeader
     {
-        IonAssetsTreeView _treeView;
+        private IonAssetsTreeView _treeView;
+        private int _lastSortedColumnIndex;
 
         public IonAssetsMultiColumnHeader(
             MultiColumnHeaderState state,
@@ -19,7 +20,7 @@ namespace CesiumForUnity
             MultiColumnHeaderState.Column column,
             int columnIndex)
         {
-            if (sortedColumnIndex == columnIndex)
+            if (this.sortedColumnIndex == columnIndex)
             {
                 if (column.sortedAscending)
                 {
@@ -27,9 +28,6 @@ namespace CesiumForUnity
                 }
                 else
                 {
-                    // Reset the sorting method.
-                    column.sortedAscending = true;
-
                     // Remove the sorting entirely.
                     sortedColumnIndex = -1;
                 }
@@ -37,12 +35,9 @@ namespace CesiumForUnity
             else
             {
                 sortedColumnIndex = columnIndex;
+                column.sortedAscending = true;
             }
-        }
 
-        protected override void OnSortingChanged()
-        {
-            base.OnSortingChanged();
             this._treeView.Refresh();
         }
     }

--- a/Editor/IonAssetsTreeView.cs
+++ b/Editor/IonAssetsTreeView.cs
@@ -97,7 +97,7 @@ namespace CesiumForUnity
     [ReinteropNativeImplementation("CesiumForUnityNative::IonAssetsTreeViewImpl", "IonAssetsTreeViewImpl.h")]
     public partial class IonAssetsTreeView : TreeView
     {
-        MultiColumnHeaderState _headerState;
+        private MultiColumnHeaderState _headerState;
 
         public IonAssetsTreeView(TreeViewState assetsTreeState)
             : base(assetsTreeState)
@@ -170,7 +170,8 @@ namespace CesiumForUnity
         private partial string GetAssetDescription(int index);
         private partial string GetAssetAttribution(int index);
 
-        public IonAssetDetails GetAssetDetails(int treeId) {
+        public IonAssetDetails GetAssetDetails(int treeId)
+        {
             int index = treeId - 1;
             string name = GetAssetName(index);
             string type = GetAssetType(index);
@@ -196,7 +197,13 @@ namespace CesiumForUnity
 
         protected override void SearchChanged(string newSearch)
         {
-            Refresh();
+            this.Refresh();
+            this.SetSelection(new List<int>());
+        }
+
+        protected override bool CanMultiSelect(TreeViewItem item)
+        {
+            return false;
         }
 
         public partial void AddAssetToLevel(int index);


### PR DESCRIPTION
This fixes #167. The reason is that using the search bar changes the size of the underlying `TreeViewItem` list, resulting in an out-of-bounds access error if a high-index asset was selected before that. There's a check for that now, but for robustness, I also made it so that whenever the search bar is used, the selection is cleared.