### PR TITLE
Add settings to CesiumRuntimeSettings to control the cache

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 ##### Additions :tada:
 
 - Added support for Unity's built-in render pipeline.
+- Added setting in CesiumRuntimeSettings to configure the maximum number of items to keep in the Sqlite cache.
+- Added setting in CesiumRuntimeSettings to configure the number of requests to the cache database before pruning.
 
 ##### Fixes :wrench:
 

--- a/Runtime/CesiumRuntimeSettings.cs
+++ b/Runtime/CesiumRuntimeSettings.cs
@@ -157,5 +157,26 @@ namespace CesiumForUnity
             }
             #endif
         }
+
+        [SerializeField]
+        private int _requestsPerCachePrune = 10000;
+
+        /// <summary>
+        ///  The number of requests to handle before each prune of old cached results from the database.
+        /// </summary>
+        public static int requestsPerCachePrune
+        {
+            get => instance._requestsPerCachePrune;
+        }
+
+        [SerializeField]
+        private ulong  _maxItems = 4096;
+        /// <summary>
+        /// the maximum number of items should be kept in the Sqlite database after pruning.
+        /// </summary>
+        public static ulong maxItems
+        {
+            get => instance._maxItems;
+        }
     }
 }

--- a/Runtime/CesiumRuntimeSettings.cs
+++ b/Runtime/CesiumRuntimeSettings.cs
@@ -159,6 +159,7 @@ namespace CesiumForUnity
         }
 
         [SerializeField]
+        [Tooltip("The number of requests to handle before each prune of old cached results from the database. Must restart Unity to apply changes.")]
         private int _requestsPerCachePrune = 10000;
 
         /// <summary>
@@ -170,9 +171,10 @@ namespace CesiumForUnity
         }
 
         [SerializeField]
+        [Tooltip("The maximum number of items should be kept in the Sqlite database after pruning. Must restart Unity to apply changes.")]
         private ulong  _maxItems = 4096;
         /// <summary>
-        /// the maximum number of items should be kept in the Sqlite database after pruning.
+        /// The maximum number of items should be kept in the Sqlite database after pruning.
         /// </summary>
         public static ulong maxItems
         {

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -416,6 +416,8 @@ namespace CesiumForUnity
             string.IsNullOrEmpty("value");
 
             string token = CesiumRuntimeSettings.defaultIonAccessToken;
+            int requestsPerCachePrune = CesiumRuntimeSettings.requestsPerCachePrune;
+            ulong maxItems = CesiumRuntimeSettings.maxItems;
 
             Cesium3DTilesetLoadFailureDetails tilesetDetails
                 = new Cesium3DTilesetLoadFailureDetails(tileset, Cesium3DTilesetLoadType.Unknown, 0, "");

--- a/native~/Runtime/src/UnityTilesetExternals.cpp
+++ b/native~/Runtime/src/UnityTilesetExternals.cpp
@@ -9,6 +9,7 @@
 #include <CesiumAsync/SqliteCache.h>
 
 #include <DotNet/CesiumForUnity/CesiumCreditSystem.h>
+#include <DotNet/CesiumForUnity/CesiumRuntimeSettings.h>
 #include <DotNet/System/String.h>
 #include <DotNet/UnityEngine/Application.h>
 
@@ -42,10 +43,18 @@ const std::shared_ptr<CachingAssetAccessor>& getAssetAccessor() {
         UnityEngine::Application::temporaryCachePath().ToStlString();
     std::string cacheDBPath = tempPath + "/cesium-request-cache.sqlite";
 
+    int32_t requestsPerCachePrune =
+        CesiumForUnity::CesiumRuntimeSettings::requestsPerCachePrune();
+    uint64_t maxItems = CesiumForUnity::CesiumRuntimeSettings::maxItems();
+
     pAccessor = std::make_shared<CachingAssetAccessor>(
         spdlog::default_logger(),
         std::make_shared<UnityAssetAccessor>(),
-        std::make_shared<SqliteCache>(spdlog::default_logger(), cacheDBPath));
+        std::make_shared<SqliteCache>(
+            spdlog::default_logger(),
+            cacheDBPath,
+            maxItems),
+        requestsPerCachePrune);
   }
   return pAccessor;
 }


### PR DESCRIPTION
The settings are set in the scriptable object Assets/CesiumSettings/Resources/CesiumRuntimeSettings.asset.