### PR TITLE
remove default credit system

### DIFF
--- a/native~/Runtime/src/UnityTilesetExternals.cpp
+++ b/native~/Runtime/src/UnityTilesetExternals.cpp
@@ -74,16 +74,11 @@ getCreditSystem(const CesiumForUnity::Cesium3DTileset& tileset) {
   CesiumForUnity::CesiumCreditSystem creditSystem =
       tilesetImpl.getCreditSystem();
 
-  // If the tileset does not already reference a credit system,
-  // get the default one.
-  if (creditSystem == nullptr) {
-    creditSystem = CesiumCreditSystemImpl::getDefaultCreditSystem();
-    tilesetImpl.setCreditSystem(creditSystem);
+  if (creditSystem != nullptr) {
+    CesiumCreditSystemImpl& creditSystemImpl =
+        creditSystem.NativeImplementation();
+    pCreditSystem = creditSystemImpl.getExternalCreditSystem();
   }
-
-  CesiumCreditSystemImpl& creditSystemImpl =
-      creditSystem.NativeImplementation();
-  pCreditSystem = creditSystemImpl.getExternalCreditSystem();
 
   return pCreditSystem;
 }


### PR DESCRIPTION
Having the default credit system's graphic raycaster unexpectedly added to the scene at runtime broke our project as we manage raycasters in a specific way. It looks like the default credit system does not display anything and the rest of the native code is fine with the credit system being null, is there a reason to force one to be present?