### PR TITLE
set tileset's children's layers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Added `CesiumPointCloudShading`, which allows point cloud tilesets to be rendered with attenuation based on geometric error. Attenuation is currently only supported in URP.
 - Added support for Unity's built-in render pipeline.
+- `GameObject` instances created for the tiles in a `Cesium3DTileset` now inherit the `layer` of the parent tileset.
 
 ##### Fixes :wrench:
 

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -77,6 +77,8 @@ namespace CesiumForUnity
             go.name = go.name;
             go = new GameObject("name");
             go.SetActive(go.activeSelf);
+            int layer = go.layer;
+            go.layer = layer;
             Transform transform = go.transform;
             transform.parent = transform.parent;
             transform.SetParent(transform.parent, false);

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -731,6 +731,7 @@ void* UnityPrepareRendererResources::prepareInMainThread(
   }
 
   pModelGameObject->transform().SetParent(this->_tileset.transform(), false);
+  pModelGameObject->layer(this->_tileset.layer());
   pModelGameObject->SetActive(false);
 
   glm::dmat4 tileTransform = tile.getTransform();
@@ -777,7 +778,8 @@ void* UnityPrepareRendererResources::prepareInMainThread(
        showTilesInHierarchy,
        currentOverlayCount,
        &pMetadataComponent,
-       &shaderProperty = _shaderProperty](
+       &shaderProperty = _shaderProperty,
+       tilesetLayer = this->tileset.layer()](
           const Model& gltf,
           const Node& node,
           const Mesh& mesh,
@@ -818,7 +820,7 @@ void* UnityPrepareRendererResources::prepareInMainThread(
         }
 
         primitiveGameObject.transform().parent(pModelGameObject->transform());
-
+        primitiveGameObject.layer(tilesetLayer);
         glm::dmat4 modelToEcef = tileTransform * transform;
 
         CesiumForUnity::CesiumGlobeAnchor anchor =


### PR DESCRIPTION
This is a small change that will set the model's gameobject as well as the primitive's gameobject layers to match the tileset layer. 
Right now runtime generated gameobjects have the default layer with no great way to change it.

Setting the layer of the mesh primitives allows us to take advantage of camera's [cullingmask ](https://docs.unity3d.com/ScriptReference/Camera-cullingMask.html) as well as physics [layermask](https://docs.unity3d.com/ScriptReference/LayerMask.html).