### PR TITLE
Some material edits automatically made by Unity.

### DIFF
--- a/Runtime/Resources/CesiumDefaultTilesetMaterial.mat
+++ b/Runtime/Resources/CesiumDefaultTilesetMaterial.mat
@@ -1,5 +1,18 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-5633082443428592771
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 639247ca83abc874e893eb93af2b5e44, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 0
 --- !u!114 &-4552124577082293056
 MonoBehaviour:
   m_ObjectHideFlags: 11
@@ -23,9 +36,9 @@ Material:
   m_Name: CesiumDefaultTilesetMaterial
   m_Shader: {fileID: -6465566751694194690, guid: 407c0cff68611ac46a65eec87a5203f5,
     type: 3}
-  m_ValidKeywords:
-  - _OVERLAYCOUNT_NONE
+  m_ValidKeywords: []
   m_InvalidKeywords:
+  - _OVERLAYCOUNT_NONE
   - _OVERLAY_COUNT_NONE
   - _TESTING_ON
   m_LightmapFlags: 4

--- a/Runtime/Resources/CesiumUnlitTilesetMaterial.mat
+++ b/Runtime/Resources/CesiumUnlitTilesetMaterial.mat
@@ -132,3 +132,16 @@ Material:
     - _overlay1TranslationAndScale: {r: 0, g: 0, b: 1, a: 1}
     - _overlay2TranslationAndScale: {r: 0, g: 0, b: 1, a: 1}
   m_BuildTextureStacks: []
+--- !u!114 &3735925112415471796
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 639247ca83abc874e893eb93af2b5e44, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 0


### PR DESCRIPTION
Ever since #253, every time we open the Samples project, Unity automatically makes some edits to `CesiumDefaultTilesetMaterial.mat` and `CesiumUnlitTilesetMaterial.mat`. In addition to being slightly annoying, this might cause problems in the shipped version of the plugin because plugins installed from the package manager are supposed to be read-only.

So this PR commits Unity's edits, which look to be harmless.