### PR TITLE
Remove references to non-existent input axes (part 2)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed another bug where `CesiumCameraController` tried to access a non-existent input in the legacy input system.
+
 ### v1.0.0 - 2023-04-03
 
 ##### Additions :tada:

--- a/Runtime/CesiumCameraController.cs
+++ b/Runtime/CesiumCameraController.cs
@@ -420,7 +420,17 @@ namespace CesiumForUnity
 
             float inputForward = Input.GetAxis("Vertical");
             float inputRight = Input.GetAxis("Horizontal");
-            float inputUp = Input.GetAxis("YAxis");
+            float inputUp = 0.0f;
+
+            if (Input.GetKeyDown("q"))
+            {
+                inputUp -= 1.0f;
+            }
+
+            if (Input.GetKeyDown("e"))
+            {
+                inputUp += 1.0f;
+            }
 
             float inputSpeedChange = Input.GetAxis("Mouse ScrollWheel");
             bool inputSpeedReset =


### PR DESCRIPTION
It came up [on the forum](https://community.cesium.com/t/argumentexception-input-axis-yaxis-is-not-setup/23207) that _another_ axis that I thought existed didn't actually exist, even after #252 . This removes that final invalid axis, and I actually tested it this time to confirm there were no more runtime errors. 😅 