### PR TITLE
Add missing package dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Added dependencies on the ShaderGraph and InputSystem packages to resolve material / script compilation errors.
+
 ### v1.0.0 - 2023-04-03
 
 ##### Additions :tada:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "licensesUrl": "https://github.com/CesiumGS/cesium-unity/blob/main/LICENSE",
   "dependencies": {
     "com.unity.mathematics": "1.2.0",
-    "com.unity.test-framework": "1.1.31"
+    "com.unity.test-framework": "1.1.31",
+    "com.unity.shadergraph": "12.1.8",
+    "com.unity.inputsystem": "1.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "com.unity.mathematics": "1.2.0",
     "com.unity.test-framework": "1.1.31",
-    "com.unity.shadergraph": "12.1.8",
-    "com.unity.inputsystem": "1.4.4"
+    "com.unity.shadergraph": "12.1.6",
+    "com.unity.inputsystem": "1.4.2"
   }
 }


### PR DESCRIPTION
This PR fixes #276 and adds missing package dependencies to the `package.json` file.

- The Shader Graph package is required because our materials are defined as shader graphs, and the package isn't installed by default for built-in projects.
- The Input System Package shouldn't be required for our plugin, but it seems like the `#define` to catch whether it's installed doesn't prevent the compiler from attempting to compile it (therefore running into errors?). Users can choose to use the legacy input system in the project settings, so I'm more inclined to install the package and avoid the compilation errors, and just let them opt out if needed.