### PR TITLE
Fix incorrectly-added delimiter

### DIFF
--- a/Runtime/CesiumCreditSystemUI.cs
+++ b/Runtime/CesiumCreditSystemUI.cs
@@ -342,12 +342,16 @@ namespace CesiumForUnity
             {
                 CesiumCredit credit = onScreenCredits[i];
                 List<VisualElement> visualElements = this.ConvertCreditToVisualElements(credit, removeExtraSpace);
+
+                if (i > 0)
+                {
+                    onScreenElement.Add(this.CreateLabelFromText(this._delimiter, false));
+                }
+
                 for (int j = 0, elementCount = visualElements.Count; j < elementCount; j++)
                 {
                     onScreenElement.Add(visualElements[j]);
                 }
-
-                onScreenElement.Add(this.CreateLabelFromText(this._delimiter, false));
             }
 
             for (int i = 0, creditCount = popupCredits.Count; i < creditCount; i++)
@@ -368,6 +372,7 @@ namespace CesiumForUnity
 
             if (popupCredits.Count > 0)
             {
+                onScreenElement.Add(this.CreateLabelFromText(this._delimiter, false)); 
                 onScreenElement.Add(this.CreateDataAttributionElement(popupElement));
             }
         }

--- a/Runtime/CesiumCreditSystemUI.cs
+++ b/Runtime/CesiumCreditSystemUI.cs
@@ -372,7 +372,11 @@ namespace CesiumForUnity
 
             if (popupCredits.Count > 0)
             {
-                onScreenElement.Add(this.CreateLabelFromText(this._delimiter, false)); 
+                if (onScreenCredits.Count > 0)
+                {
+                    onScreenElement.Add(this.CreateLabelFromText(this._delimiter, false));
+                }
+
                 onScreenElement.Add(this.CreateDataAttributionElement(popupElement));
             }
         }


### PR DESCRIPTION
This PR is a nitpick fix. The credits UI would always add a bullet-point delimiter after an entry in the on-screen credits text. This is fine if the "Data Attribution" text is present. But if there's only a tileset with on-screen credits, the "Data Attribution" text doesn't show, so the delimiter will have nothing behind it.

This PR makes it so that any on-screen credits after the first one will prepend the delimiter. Additionally, the "Data Attribution" label is responsible for prepending its own delimiter.