### PR TITLE
Check triangle mesh before attempting to bake it for physics

### DIFF
--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -131,6 +131,7 @@ namespace CesiumForUnity
             mesh.SetUVs(0, new NativeArray<Vector2>());
             mesh.SetIndices(new NativeArray<int>(), MeshTopology.Triangles, 0, true, 0);
             mesh.RecalculateBounds();
+            int vertexCount = mesh.vertexCount;
             int instanceID = mesh.GetInstanceID();
 
             Bounds bounds = new Bounds(new Vector3(0, 0, 0), new Vector3(1, 2, 1));

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -1064,7 +1064,7 @@ void* UnityPrepareRendererResources::prepareInMainThread(
         }
 
         if (createPhysicsMeshes) {
-          if (!primitiveInfo.containsPoints && unityMesh.vertexCount() > 3) {
+          if (!primitiveInfo.containsPoints && unityMesh.vertexCount() >= 3) {
             // This should not trigger mesh baking for physics, because the
             // meshes were already baked in the worker thread.
             UnityEngine::MeshCollider meshCollider =

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -659,8 +659,10 @@ UnityPrepareRendererResources::prepareInLoadThread(
               const std::int32_t len = meshes.Length();
               std::vector<std::int32_t> instanceIDs;
               for (int32_t i = 0; i < len; ++i) {
-                // Don't attempt to bake a physics mesh from a point cloud.
-                if (primitiveInfos[i].containsPoints) {
+                // Don't attempt to bake a physics mesh from a point cloud or
+                // from an invalid triangle mesh.
+                if (primitiveInfos[i].containsPoints ||
+                    meshes[i].vertexCount() < 3) {
                   continue;
                 }
                 instanceIDs.push_back(meshes[i].GetInstanceID());
@@ -1061,12 +1063,14 @@ void* UnityPrepareRendererResources::prepareInMainThread(
           pointCloudRenderer.tileInfo(tileInfo);
         }
 
-        if (createPhysicsMeshes && !primitiveInfo.containsPoints) {
-          // This should not trigger mesh baking for physics, because the
-          // meshes were already baked in the worker thread.
-          UnityEngine::MeshCollider meshCollider =
-              primitiveGameObject.AddComponent<UnityEngine::MeshCollider>();
-          meshCollider.sharedMesh(unityMesh);
+        if (createPhysicsMeshes) {
+          if (!primitiveInfo.containsPoints && unityMesh.vertexCount() > 3) {
+            // This should not trigger mesh baking for physics, because the
+            // meshes were already baked in the worker thread.
+            UnityEngine::MeshCollider meshCollider =
+                primitiveGameObject.AddComponent<UnityEngine::MeshCollider>();
+            meshCollider.sharedMesh(unityMesh);
+          }
         }
 
         const ExtensionMeshPrimitiveExtFeatureMetadata* pMetadata =


### PR DESCRIPTION
This PR checks if a triangle mesh contains at least three vertices before trying to bake it into a physics mesh. This catches an error that can come from loading data with degenerate triangles: 

![image](https://user-images.githubusercontent.com/32226860/233734334-0cafffd7-a1c4-419a-9296-0891ec33e9fc.png)

It's not a perfect solution, but at least it will prevent the app from crashing in play mode. Maybe we should `Debug.LogWarning` something about it?