### PR TITLE
Add additional physics check for single degenerate triangle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - Added dependencies on the ShaderGraph and InputSystem packages to resolve material / script compilation errors.
 - Fixed another bug where `CesiumCameraController` tried to access a non-existent input in the legacy input system.
 - Removed an extra "delimiter" added to the end of on-screen credits in some cases.
+- Fixed a crash that happened when attempting to create physics meshes for degenerate triangle meshes.
 
 ### v1.0.0 - 2023-04-03
 

--- a/Runtime/Cesium3DTile.cs
+++ b/Runtime/Cesium3DTile.cs
@@ -17,8 +17,7 @@ namespace CesiumForUnity
         internal IntPtr _pTile;
 
         internal Cesium3DTile()
-        {
-        }
+        {}
 
         /// <summary>
         /// Gets the axis-aligned bounding box of this tile. If this tile came from a <see cref="CesiumTileExcluder"/>,

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -134,6 +134,9 @@ namespace CesiumForUnity
             int vertexCount = mesh.vertexCount;
             int instanceID = mesh.GetInstanceID();
 
+            Vector3[] vertices = mesh.vertices;
+            Vector3 vertex = vertices[0];
+
             Bounds bounds = new Bounds(new Vector3(0, 0, 0), new Vector3(1, 2, 1));
 
             MeshCollider meshCollider = go.AddComponent<MeshCollider>();


### PR DESCRIPTION
This is a followup PR to #289. I was still seeing the error around some parts of a dataset, around tiles with a single but degenerate triangle. The error isn't raised anymore after this fix.