### PR TITLE
Fix Mesh memory leak when switching between play and edit modes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - Added dependencies on the ShaderGraph and InputSystem packages to resolve material / script compilation errors.
 - Fixed another bug where `CesiumCameraController` tried to access a non-existent input in the legacy input system.
 - Removed an extra "delimiter" added to the end of on-screen credits in some cases.
+- Fixed a memory leak of `Mesh` objects when entering and exiting Play mode in the Unity Editor.
 
 ### v1.0.0 - 2023-04-03
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### ? - ?
 
+##### Breaking Changes :mega:
+
+- `CesiumObjectPool` is no longer accessible from outside the CesiumRuntime assembly.
+
 ##### Additions :tada:
 
 - Added support for primitives with the `TRIANGLE_STRIP` and `TRIANGLE_FAN` topology types.

--- a/Runtime/CesiumObjectPool.cs
+++ b/Runtime/CesiumObjectPool.cs
@@ -1,19 +1,74 @@
-using UnityEngine;
-using UnityEngine.Pool;
+using System;
+using System.Collections.Generic;
 
 namespace CesiumForUnity
 {
-    public static class CesiumObjectPool
+    public class CesiumObjectPool<T> : IDisposable where T : class
     {
-        public static ObjectPool<Mesh> MeshPool => meshPool;
+        private List<T> _pool;
+        private int _maximumSize;
+        private Func<T> _createCallback;
+        private Action<T> _releaseCallback;
+        private Action<T> _destroyCallback;
 
-        private const int capacity = 200;
-        private static ObjectPool<Mesh> meshPool = new ObjectPool<Mesh>(
-                () => new Mesh(),
-                (mesh) => mesh.Clear(),
-                null,
-                (mesh) => GameObject.Destroy(mesh),
-                collectionCheck: false,
-                capacity);
+        public CesiumObjectPool(Func<T> createCallback, Action<T> releaseCallback, Action<T> destroyCalback, int maximumSize = 1000)
+        {
+            this._pool = new List<T>(maximumSize);
+            this._maximumSize = maximumSize;
+            this._createCallback = createCallback;
+            this._releaseCallback = releaseCallback;
+            this._destroyCallback = destroyCalback;
+        }
+
+        public void Dispose()
+        {
+            this.Clear();
+
+            // A null pool indicates released objects should be freed,
+            // rather than added back into the pool.
+            this._pool = null;
+        }
+
+        public int CountInactive => this._pool.Count;
+
+        public void Clear()
+        {
+            if (this._pool == null)
+                return;
+
+            foreach (T o in this._pool)
+            {
+                this._destroyCallback(o);
+            }
+        }
+
+        public T Get()
+        {
+            if (this._pool != null && this._pool.Count > 0)
+            {
+                int pos = this._pool.Count - 1;
+                T result = this._pool[pos];
+                this._pool.RemoveAt(pos);
+                return result;
+            }
+            else
+            {
+                return this._createCallback();
+            }
+        }
+
+        public void Release(T element)
+        {
+            this._releaseCallback(element);
+
+            if (this._pool != null && this._pool.Count < this._maximumSize)
+            {
+                this._pool.Add(element);
+            }
+            else
+            {
+                this._destroyCallback(element);
+            }
+        }
     }
 }

--- a/Runtime/CesiumObjectPool.cs
+++ b/Runtime/CesiumObjectPool.cs
@@ -11,13 +11,13 @@ namespace CesiumForUnity
         private Action<T> _releaseCallback;
         private Action<T> _destroyCallback;
 
-        public CesiumObjectPool(Func<T> createCallback, Action<T> releaseCallback, Action<T> destroyCalback, int maximumSize = 1000)
+        public CesiumObjectPool(Func<T> createCallback, Action<T> releaseCallback, Action<T> destroyCallback, int maximumSize = 1000)
         {
             this._pool = new List<T>(maximumSize);
             this._maximumSize = maximumSize;
             this._createCallback = createCallback;
             this._releaseCallback = releaseCallback;
-            this._destroyCallback = destroyCalback;
+            this._destroyCallback = destroyCallback;
         }
 
         public void Dispose()

--- a/Runtime/CesiumObjectPool.cs
+++ b/Runtime/CesiumObjectPool.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace CesiumForUnity
 {
-    public class CesiumObjectPool<T> : IDisposable where T : class
+    internal class CesiumObjectPool<T> : IDisposable where T : class
     {
         private List<T> _pool;
         private int _maximumSize;

--- a/Runtime/CesiumObjectPools.cs
+++ b/Runtime/CesiumObjectPools.cs
@@ -6,7 +6,7 @@ using UnityEditor;
 
 namespace CesiumForUnity
 {
-    public class CesiumObjectPools
+    internal class CesiumObjectPools
     {
         public static CesiumObjectPool<Mesh> MeshPool => _meshPool;
 

--- a/Runtime/CesiumObjectPools.cs
+++ b/Runtime/CesiumObjectPools.cs
@@ -1,0 +1,32 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace CesiumForUnity
+{
+    public class CesiumObjectPools
+    {
+        public static CesiumObjectPool<Mesh> MeshPool => _meshPool;
+
+        private static CesiumObjectPool<Mesh> _meshPool;
+
+        public static void Dispose()
+        {
+            _meshPool.Dispose();
+        }
+
+        static CesiumObjectPools()
+        {
+            _meshPool = new CesiumObjectPool<Mesh>(
+                () => new Mesh(),
+                (mesh) => mesh.Clear(),
+                (mesh) => UnityLifetime.Destroy(mesh));
+
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+        }
+
+        private static void OnPlayModeStateChanged(PlayModeStateChange obj)
+        {
+            Dispose();
+        }
+    }
+}

--- a/Runtime/CesiumObjectPools.cs
+++ b/Runtime/CesiumObjectPools.cs
@@ -1,5 +1,8 @@
-using UnityEditor;
 using UnityEngine;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace CesiumForUnity
 {
@@ -21,12 +24,16 @@ namespace CesiumForUnity
                 (mesh) => mesh.Clear(),
                 (mesh) => UnityLifetime.Destroy(mesh));
 
+#if UNITY_EDITOR
             EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+#endif
         }
 
+#if UNITY_EDITOR
         private static void OnPlayModeStateChanged(PlayModeStateChange obj)
         {
             Dispose();
         }
+#endif
     }
 }

--- a/Runtime/CesiumObjectPools.cs.meta
+++ b/Runtime/CesiumObjectPools.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79e50188ee452fb4b97d4fb2a5331e1f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/CesiumRuntime.cs
+++ b/Runtime/CesiumRuntime.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CesiumTests")]

--- a/Runtime/CesiumRuntime.cs.meta
+++ b/Runtime/CesiumRuntime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5279b58daee17ef45b524a3757461078
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -492,7 +492,7 @@ namespace CesiumForUnity
             CesiumPointCloudRenderer renderer = go.AddComponent<CesiumPointCloudRenderer>();
             renderer.tileInfo = info;
 
-            ObjectPool<Mesh> meshPool = CesiumObjectPool.MeshPool;
+            CesiumObjectPool<Mesh> meshPool = CesiumObjectPools.MeshPool;
             Mesh pooledMesh = meshPool.Get();
             meshPool.Release(pooledMesh);
 

--- a/Tests/TestCesiumObjectPool.cs
+++ b/Tests/TestCesiumObjectPool.cs
@@ -1,0 +1,76 @@
+﻿using NUnit.Framework;
+using CesiumForUnity;
+using System.Collections.Generic;
+
+public class TestCesiumObjectPool
+{
+    private class TestObject
+    {
+        public bool isDestroyed = false;
+        public bool isReleased = false;
+    }
+
+    [Test]
+    public void ObjectReleasedIntoPoolCanBeRetrieved()
+    {
+        var pool = new CesiumObjectPool<TestObject>(
+            () => new TestObject(),
+            (to) => to.isReleased = true,
+            (to) => to.isDestroyed = true);
+
+        TestObject obj = pool.Get();
+        pool.Release(obj);
+        TestObject newObj = pool.Get();
+        Assert.AreSame(obj, newObj);
+    }
+
+    [Test]
+    public void IfPoolIsFullObjectIsReleasedAndDestroyed()
+    {
+        int maxSize = 5;
+        var pool = new CesiumObjectPool<TestObject>(
+            () => new TestObject(),
+            (to) => to.isReleased = true,
+            (to) => to.isDestroyed = true,
+            maxSize);
+
+        List<TestObject> gotten = new List<TestObject>();
+        for (int i = 0; i < maxSize; ++i)
+        {
+            gotten.Add(pool.Get());
+        }
+
+        TestObject oneMore = pool.Get();
+
+        foreach (TestObject to in gotten)
+        {
+            pool.Release(to);
+        }
+
+        pool.Release(oneMore);
+
+        Assert.IsTrue(oneMore.isReleased);
+        Assert.IsTrue(oneMore.isDestroyed);
+
+        foreach (TestObject to in gotten)
+        {
+            Assert.IsTrue(to.isReleased);
+            Assert.IsFalse(to.isDestroyed);
+        }
+    }
+
+    [Test]
+    public void AfterPoolIsDisposedReleasedObjectsAreDestroyed()
+    {
+        var pool = new CesiumObjectPool<TestObject>(
+            () => new TestObject(),
+            (to) => to.isReleased = true,
+            (to) => to.isDestroyed = true);
+
+        TestObject to = pool.Get();
+        pool.Dispose();
+        pool.Release(to);
+        Assert.IsTrue(to.isReleased);
+        Assert.IsTrue(to.isDestroyed);
+    }
+}

--- a/Tests/TestCesiumObjectPool.cs.meta
+++ b/Tests/TestCesiumObjectPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f8b414492d3e19041b186aed9f6182ed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -22,7 +22,8 @@
 #include <DotNet/CesiumForUnity/CesiumGeoreference.h>
 #include <DotNet/CesiumForUnity/CesiumGlobeAnchor.h>
 #include <DotNet/CesiumForUnity/CesiumMetadata.h>
-#include <DotNet/CesiumForUnity/CesiumObjectPool.h>
+#include <DotNet/CesiumForUnity/CesiumObjectPool1.h>
+#include <DotNet/CesiumForUnity/CesiumObjectPools.h>
 #include <DotNet/CesiumForUnity/CesiumPointCloudRenderer.h>
 #include <DotNet/System/Array1.h>
 #include <DotNet/System/Collections/Generic/List1.h>
@@ -46,7 +47,6 @@
 #include <DotNet/UnityEngine/MeshTopology.h>
 #include <DotNet/UnityEngine/Object.h>
 #include <DotNet/UnityEngine/Physics.h>
-#include <DotNet/UnityEngine/Pool/ObjectPool1.h>
 #include <DotNet/UnityEngine/Quaternion.h>
 #include <DotNet/UnityEngine/Rendering/IndexFormat.h>
 #include <DotNet/UnityEngine/Rendering/MeshUpdateFlags.h>
@@ -869,7 +869,7 @@ UnityPrepareRendererResources::prepareInLoadThread(
             System::Array1<UnityEngine::Mesh> meshes(meshDataArray.Length());
             for (int32_t i = 0, len = meshes.Length(); i < len; ++i) {
               UnityEngine::Mesh unityMesh =
-                  CesiumForUnity::CesiumObjectPool::MeshPool().Get();
+                  CesiumForUnity::CesiumObjectPools::MeshPool().Get();
               // Don't let Unity unload this mesh during the time in between
               // when we create it and when we attach it to a GameObject.
               if (shouldShowTilesInHierarchy) {
@@ -1366,7 +1366,7 @@ void freePrimitiveGameObject(
   UnityEngine::MeshFilter meshFilter =
       primitiveGameObject.GetComponent<UnityEngine::MeshFilter>();
   if (meshFilter != nullptr) {
-    CesiumForUnity::CesiumObjectPool::MeshPool().Release(
+    CesiumForUnity::CesiumObjectPools::MeshPool().Release(
         meshFilter.sharedMesh());
   }
 
@@ -1384,7 +1384,7 @@ void UnityPrepareRendererResources::free(
     LoadThreadResult* pTyped =
         static_cast<LoadThreadResult*>(pLoadThreadResult);
     for (int32_t i = 0, len = pTyped->meshes.Length(); i < len; ++i) {
-      CesiumForUnity::CesiumObjectPool::MeshPool().Release(pTyped->meshes[i]);
+      CesiumForUnity::CesiumObjectPools::MeshPool().Release(pTyped->meshes[i]);
     }
     delete pTyped;
   }


### PR DESCRIPTION
Fixes #293

There were two problems here:

First, the "get" callback and the "release" callback in the mesh object pool were reversed, meaning that the mesh data was cleared on _get_ rather than on _release_. As a result, meshes with big chunks of data would end up sitting in the Mesh object pool. This was easily fixed by flipping them.

However, even after this change, there was still a small-ish memory leak when switching between Play and Edit modes, caused by the Mesh objects themselves not being destroyed. The static `ObjectPool<Mesh>` - or the objects in it - were seemingly not being destroyed by whatever cleanup logic Unity executes at the end of Play mode.

I initially tried to add some manual cleanup, such as in the `DomainUnload` callback. But this only seemed to be called when entering Play mode, not when exiting it. And destroying Unity object's in this event would be pretty questionable, anyway. So then I tried (and failed) to find a more suitable event. `EditorApplication.playModeStateChanged` seemed promising, but was called too early. The in-use meshes were not yet released back into the pool by the time this event was raised. And Unity's ObjectPool seems to have a pretty obvious bug when calling `Clear` while objects associated with the pool are still in use. End result: broken pool, and we still had a memory leak.

I tried various ways to fix or work around this, but ended up just writing a less broken object pool myself. The pool is still disposed in `EditorApplication.playModeStateChanged`, but in the implementation here, a disposed object pool will simply destroy any objects that are released into it.