### PR TITLE
Add the ability to scale the CesiumGeoreference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### ? - ?
 
+##### Additions :tada:
+
+- Added a `scale` property to `CesiumGeoreference`, allowing the entire globe to be scaled up or down while preserving precision better than adjusting the scale on the `Transform`.
+
 ##### Fixes :wrench:
 
 - Fixed a bug that caused primitive numbers to be negative in the names of tile game objects when the tile mesh had multiple primitives.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug that caused primitive numbers to be negative in the names of tile game objects when the tile mesh had multiple primitives.
+- Fixed a bug that caused tiles to be displaced when changing the transform of a `CesiumGeoreference` at runtime.
 
 ### v1.1.0 - 2023-05-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ##### Additions :tada:
 
-- Added a `scale` property to `CesiumGeoreference`, allowing the entire globe to be scaled up or down while preserving precision better than adjusting the scale on the `Transform`.
+- Added a `scale` property to `CesiumGeoreference`. This allows the entire globe to be scaled up or down with better precision than the scale property on the georeference's `Transform`.
 
 ##### Fixes :wrench:
 

--- a/Editor/CesiumGeoreferenceEditor.cs
+++ b/Editor/CesiumGeoreferenceEditor.cs
@@ -29,6 +29,8 @@ namespace CesiumForUnity
         private SerializedProperty _ecefY;
         private SerializedProperty _ecefZ;
 
+        private SerializedProperty _scale;
+
         private void OnEnable()
         {
             this._georeference = (CesiumGeoreference)this.target;
@@ -43,6 +45,8 @@ namespace CesiumForUnity
             this._ecefX = this.serializedObject.FindProperty("_ecefX");
             this._ecefY = this.serializedObject.FindProperty("_ecefY");
             this._ecefZ = this.serializedObject.FindProperty("_ecefZ");
+
+            this._scale = this.serializedObject.FindProperty("_scale");
         }
 
         public override void OnInspectorGUI()
@@ -52,6 +56,8 @@ namespace CesiumForUnity
             DrawInspectorButtons();
             EditorGUILayout.Space(5);
 
+            this.DrawScaleProperty();
+            EditorGUILayout.Space(5);
             this.DrawOriginAuthorityProperty();
             EditorGUILayout.Space(5);
             this.DrawLongitudeLatitudeHeightProperties();
@@ -96,6 +102,17 @@ namespace CesiumForUnity
             GUILayout.EndHorizontal();
 
             EditorGUI.EndDisabledGroup();
+        }
+
+        private void DrawScaleProperty()
+        {
+            GUIContent scaleContent = new GUIContent(
+                "Scale",
+                "The scale of the globe in the Unity world. If this value is 0.5, for " +
+                "example, one meter on the globe occupies half a meter in the Unity world. " +
+                "The globe can also be scaled by modifying the georeference's Transform, " +
+                "but setting this property instead will do a better job of preserving precision.");
+            EditorGUILayout.PropertyField(this._scale, scaleContent);
         }
 
         private void DrawOriginAuthorityProperty()

--- a/Runtime/CesiumGeoreference.cs
+++ b/Runtime/CesiumGeoreference.cs
@@ -85,6 +85,9 @@ namespace CesiumForUnity
         [SerializeField]
         private double _ecefZ = 0.0;
 
+        [SerializeField]
+        private double _scale = 1.0;
+
         [NonSerialized]
         private double4x4 _localToEcef = double4x4.identity;
 
@@ -208,6 +211,22 @@ namespace CesiumForUnity
             {
                 this._ecefZ = value;
                 this.originAuthority = CesiumGeoreferenceOriginAuthority.EarthCenteredEarthFixed;
+            }
+        }
+
+        /// <summary>
+        /// The scale of the globe in the Unity world. If this value is 0.5, for example, one
+        /// meter on the globe occupies half a meter in the Unity world. The globe can also
+        /// be scaled by modifying the georeference's Transform, but setting this property instead
+        /// will do a better job of preserving precision.
+        /// </summary>
+        public double scale
+        {
+            get => this._scale;
+            set
+            {
+                this._scale = value;
+                this.MoveOrigin();
             }
         }
 
@@ -345,6 +364,10 @@ namespace CesiumForUnity
         {
             if (!this._isInitialized)
                 throw new InvalidOperationException("The origin of a CesiumGeoreference must not be set before its Initialize method is called, either explicitly or via OnEnable.");
+
+            // Scale must be greater than 0
+            if (this._scale < 1e-8)
+                this._scale = 1e-8;
 
             this.UpdateOtherCoordinates();
 

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -347,6 +347,7 @@ namespace CesiumForUnity
             georeference.ecefY = georeference.ecefY;
             georeference.ecefZ = georeference.ecefZ;
             georeference.originAuthority = georeference.originAuthority;
+            georeference.scale = georeference.scale;
             double4x4 ecefToLocal = georeference.ecefToLocalMatrix;
 
             CesiumGeoreference inParent = go.GetComponentInParent<CesiumGeoreference>();

--- a/Tests/TestCesiumGeoreference.cs
+++ b/Tests/TestCesiumGeoreference.cs
@@ -106,11 +106,11 @@ public class TestCesiumGeoreference
         Assert.That(goAnchored.transform.localScale.z, Is.EqualTo(6.0f));
 
         // The globe anchor's scale initially matches the local scale.
-        Assert.That(anchor.scaleEastUpNorth.x, Is.EqualTo(4.0));
-        Assert.That(anchor.scaleEastUpNorth.y, Is.EqualTo(5.0));
-        Assert.That(anchor.scaleEastUpNorth.z, Is.EqualTo(6.0));
-
         IEqualityComparer<double> epsilon8 = Comparers.Double(1e-8);
+        Assert.That(anchor.scaleEastUpNorth.x, Is.EqualTo(4.0).Using(epsilon8));
+        Assert.That(anchor.scaleEastUpNorth.y, Is.EqualTo(5.0).Using(epsilon8));
+        Assert.That(anchor.scaleEastUpNorth.z, Is.EqualTo(6.0).Using(epsilon8));
+
         Assert.That(anchor.longitudeLatitudeHeight.x, Is.Not.EqualTo(-55.0).Using(epsilon8));
         Assert.That(anchor.longitudeLatitudeHeight.y, Is.Not.EqualTo(55.0).Using(epsilon8));
         Assert.That(anchor.longitudeLatitudeHeight.z, Is.Not.EqualTo(1000.0).Using(epsilon8));
@@ -130,9 +130,9 @@ public class TestCesiumGeoreference
         Assert.That(goAnchored.transform.localScale.z, Is.EqualTo(3.0f).Using(epsilon4));
 
         // ...while the globe-relative properties stay the same.
-        Assert.That(anchor.scaleEastUpNorth.x, Is.EqualTo(4.0));
-        Assert.That(anchor.scaleEastUpNorth.y, Is.EqualTo(5.0));
-        Assert.That(anchor.scaleEastUpNorth.z, Is.EqualTo(6.0));
+        Assert.That(anchor.scaleEastUpNorth.x, Is.EqualTo(4.0).Using(epsilon8));
+        Assert.That(anchor.scaleEastUpNorth.y, Is.EqualTo(5.0).Using(epsilon8));
+        Assert.That(anchor.scaleEastUpNorth.z, Is.EqualTo(6.0).Using(epsilon8));
 
         Assert.That(anchor.longitudeLatitudeHeight.x, Is.EqualTo(longitudeLatitudeHeight.x).Using(epsilon8));
         Assert.That(anchor.longitudeLatitudeHeight.y, Is.EqualTo(longitudeLatitudeHeight.y).Using(epsilon8));

--- a/Tests/TestCesiumGeoreference.cs
+++ b/Tests/TestCesiumGeoreference.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using System.Collections;
 using System.Collections.Generic;
+using Unity.Mathematics;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.TestTools.Utils;
@@ -77,5 +78,64 @@ public class TestCesiumGeoreference
         Assert.That(goAnchored.transform.localPosition.x, Is.EqualTo(0.0f).Using(epsilon4));
         Assert.That(goAnchored.transform.localPosition.y, Is.EqualTo(-1000.0f).Using(epsilon4));
         Assert.That(goAnchored.transform.localPosition.z, Is.EqualTo(0.0f).Using(epsilon4));
+    }
+
+    [UnityTest]
+    public IEnumerator GeoreferenceScaleAffectsGlobeAnchors()
+    {
+        GameObject goGeoreference = new GameObject("Georeference");
+        CesiumGeoreference georeference = goGeoreference.AddComponent<CesiumGeoreference>();
+        georeference.SetOriginLongitudeLatitudeHeight(-55.0, 55.0, 1000.0);
+
+        GameObject goAnchored = new GameObject("Anchored");
+        goAnchored.transform.parent = goGeoreference.transform;
+        goAnchored.transform.localPosition = new Vector3(1.0f, 2.0f, 3.0f);
+        goAnchored.transform.localScale = new Vector3(4.0f, 5.0f, 6.0f);
+
+        CesiumGlobeAnchor anchor = goAnchored.AddComponent<CesiumGlobeAnchor>();
+        double3 longitudeLatitudeHeight = anchor.longitudeLatitudeHeight;
+
+        yield return null;
+
+        Assert.That(goAnchored.transform.localPosition.x, Is.EqualTo(1.0f));
+        Assert.That(goAnchored.transform.localPosition.y, Is.EqualTo(2.0f));
+        Assert.That(goAnchored.transform.localPosition.z, Is.EqualTo(3.0f));
+
+        Assert.That(goAnchored.transform.localScale.x, Is.EqualTo(4.0f));
+        Assert.That(goAnchored.transform.localScale.y, Is.EqualTo(5.0f));
+        Assert.That(goAnchored.transform.localScale.z, Is.EqualTo(6.0f));
+
+        // The globe anchor's scale initially matches the local scale.
+        Assert.That(anchor.scaleEastUpNorth.x, Is.EqualTo(4.0));
+        Assert.That(anchor.scaleEastUpNorth.y, Is.EqualTo(5.0));
+        Assert.That(anchor.scaleEastUpNorth.z, Is.EqualTo(6.0));
+
+        IEqualityComparer<double> epsilon8 = Comparers.Double(1e-8);
+        Assert.That(anchor.longitudeLatitudeHeight.x, Is.Not.EqualTo(-55.0).Using(epsilon8));
+        Assert.That(anchor.longitudeLatitudeHeight.y, Is.Not.EqualTo(55.0).Using(epsilon8));
+        Assert.That(anchor.longitudeLatitudeHeight.z, Is.Not.EqualTo(1000.0).Using(epsilon8));
+
+        georeference.scale = 0.5;
+
+        yield return null;
+
+        // The local transforms are affected by the georeference's scale...
+        IEqualityComparer<float> epsilon4 = new FloatEqualityComparer(1e-3f);
+        Assert.That(goAnchored.transform.localPosition.x, Is.EqualTo(0.5f).Using(epsilon4));
+        Assert.That(goAnchored.transform.localPosition.y, Is.EqualTo(1.0f).Using(epsilon4));
+        Assert.That(goAnchored.transform.localPosition.z, Is.EqualTo(1.5f).Using(epsilon4));
+
+        Assert.That(goAnchored.transform.localScale.x, Is.EqualTo(2.0f).Using(epsilon4));
+        Assert.That(goAnchored.transform.localScale.y, Is.EqualTo(2.5f).Using(epsilon4));
+        Assert.That(goAnchored.transform.localScale.z, Is.EqualTo(3.0f).Using(epsilon4));
+
+        // ...while the globe-relative properties stay the same.
+        Assert.That(anchor.scaleEastUpNorth.x, Is.EqualTo(4.0));
+        Assert.That(anchor.scaleEastUpNorth.y, Is.EqualTo(5.0));
+        Assert.That(anchor.scaleEastUpNorth.z, Is.EqualTo(6.0));
+
+        Assert.That(anchor.longitudeLatitudeHeight.x, Is.EqualTo(longitudeLatitudeHeight.x).Using(epsilon8));
+        Assert.That(anchor.longitudeLatitudeHeight.y, Is.EqualTo(longitudeLatitudeHeight.y).Using(epsilon8));
+        Assert.That(anchor.longitudeLatitudeHeight.z, Is.EqualTo(longitudeLatitudeHeight.z).Using(epsilon8));
     }
 }

--- a/native~/Runtime/src/CameraManager.cpp
+++ b/native~/Runtime/src/CameraManager.cpp
@@ -73,8 +73,8 @@ ViewState unityCameraToViewState(
 
   return ViewState::create(
       cameraPosition,
-      cameraDirection,
-      cameraUp,
+      glm::normalize(cameraDirection),
+      glm::normalize(cameraUp),
       glm::dvec2(camera.pixelWidth(), camera.pixelHeight()),
       horizontalFOV,
       verticalFOV);

--- a/native~/Runtime/src/CesiumGeoreferenceImpl.cpp
+++ b/native~/Runtime/src/CesiumGeoreferenceImpl.cpp
@@ -33,7 +33,8 @@ LocalHorizontalCoordinateSystem createCoordinateSystem(
             georeference.height()),
         LocalDirection::East,
         LocalDirection::Up,
-        LocalDirection::North);
+        LocalDirection::North,
+        1.0 / georeference.scale());
   } else {
     return LocalHorizontalCoordinateSystem(
         glm::dvec3(
@@ -42,7 +43,8 @@ LocalHorizontalCoordinateSystem createCoordinateSystem(
             georeference.ecefZ()),
         LocalDirection::East,
         LocalDirection::Up,
-        LocalDirection::North);
+        LocalDirection::North,
+        1.0 / georeference.scale());
   }
 }
 


### PR DESCRIPTION
This a PR into #302 so merge that first.

Adds a `scale` property to `CesiumGeoreference` that can be used to precisely scale the entire globe. By doing the scaling computations in double precision, this offers more precision than adjusting the scale property on the Transform. I was able to scale the globe down to 1e-8 without any obvious vertex precision problems (though Unity's near and far plane limits become a bit of an issue at that scale).

Objects with a CesiumGlobeAnchor scale with the globe (as expected, hopefully).

Fixes #291

Unfortunately this does not fix #280. The built-in render pipeline still goes black suddenly when the scale is smaller than about 7e-05.