### PR TITLE
Detect material property changes in Editor mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### ? - ?
 
-### Fixes :wrench:
+##### Fixes :wrench:
 
 - Fixed a bug where `Cesium3DTileset` would not reflect changes made to the properties of its opaque material in the Editor.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+### Fixes :wrench:
+
+- Fixed a bug where `Cesium3DTileset` would not reflect changes made to the properties of its opaque material in the Editor.
+
 ### v1.2.0 - 2023-05-09
 
 ##### Additions :tada:

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -147,7 +147,9 @@ namespace CesiumForUnity
             MeshRenderer meshRenderer = new MeshRenderer();
             GameObject meshGameObject = meshRenderer.gameObject;
             meshRenderer.material = UnityEngine.Object.Instantiate(meshRenderer.material);
+
             int id = Shader.PropertyToID("name");
+            int crc = meshRenderer.material.ComputeCRC();
             meshRenderer.material.SetTexture(id, texture2D);
             meshRenderer.material.SetFloat(id, 1.0f);
             meshRenderer.material.SetVector(id, new Vector4());

--- a/native~/Runtime/src/Cesium3DTilesetImpl.cpp
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.cpp
@@ -470,6 +470,13 @@ void Cesium3DTilesetImpl::LoadTileset(
 
     excluder.AddToTileset(tileset);
   }
+
+  // If the tileset has an opaque material, set its hash here to avoid
+  // destroying it on the first tick after creation.
+  if (tileset.opaqueMaterial() != nullptr) {
+    int32_t opaqueMaterialHash = tileset.opaqueMaterial().ComputeCRC();
+    _lastOpaqueMaterialHash = opaqueMaterialHash;
+  }
 }
 
 } // namespace CesiumForUnityNative

--- a/native~/Runtime/src/Cesium3DTilesetImpl.cpp
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.cpp
@@ -25,6 +25,7 @@
 #include <DotNet/UnityEngine/Camera.h>
 #include <DotNet/UnityEngine/Debug.h>
 #include <DotNet/UnityEngine/GameObject.h>
+#include <DotNet/UnityEngine/Material.h>
 #include <DotNet/UnityEngine/Quaternion.h>
 #include <DotNet/UnityEngine/Time.h>
 #include <DotNet/UnityEngine/Transform.h>
@@ -51,7 +52,8 @@ Cesium3DTilesetImpl::Cesium3DTilesetImpl(
       _updateInEditorCallback(nullptr),
 #endif
       _creditSystem(nullptr),
-      _destroyTilesetOnNextUpdate(false) {
+      _destroyTilesetOnNextUpdate(false),
+      _lastOpaqueMaterialHash(0) {
 }
 
 Cesium3DTilesetImpl::~Cesium3DTilesetImpl() {}
@@ -82,12 +84,24 @@ void Cesium3DTilesetImpl::Update(
   }
 
 #if UNITY_EDITOR
-  // If "Update In Editor" is false, return early.
   if (UnityEngine::Application::isEditor() &&
-      !UnityEditor::EditorApplication::isPlaying() &&
-      !tileset.updateInEditor()) {
-    return;
+      !UnityEditor::EditorApplication::isPlaying()) {
+    // If "Update In Editor" is false, return early.
+    if (!tileset.updateInEditor()) {
+      return;
+    }
+
+    // If the opaque material or any of its properties have changed, recreate
+    // the tileset to reflect those changes.
+    if (tileset.opaqueMaterial() != nullptr) {
+      int32_t opaqueMaterialHash = tileset.opaqueMaterial().ComputeCRC();
+      if (_lastOpaqueMaterialHash != opaqueMaterialHash) {
+        this->DestroyTileset(tileset);
+        _lastOpaqueMaterialHash = opaqueMaterialHash;
+      }
+    }
   }
+
 #endif
 
   if (!this->_pTileset) {

--- a/native~/Runtime/src/Cesium3DTilesetImpl.h
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.h
@@ -61,6 +61,7 @@ private:
 #endif
   DotNet::CesiumForUnity::CesiumCreditSystem _creditSystem;
   bool _destroyTilesetOnNextUpdate;
+  int32_t _lastOpaqueMaterialHash;
 };
 
 } // namespace CesiumForUnityNative


### PR DESCRIPTION
Fixes #180. This replaces the `Instantiate(material)` call with `MaterialPropertyBlock` instead, allowing for changes to the opaque material to be propagated to already-loaded tiles.

I did some initial profiling of the difference between `Material` and `MaterialPropertyBlock`. This is on the first sample scene, with just Cesium World Terrain and OSM Buildings. It's true that using the property block disables SRP batching, and it does have a noticeable performance difference: 

| `Material` | `MaterialPropertyBlock` |
| ---------- | --------------------------- |
| ![RegularMaterial](https://github.com/CesiumGS/cesium-unity/assets/32226860/f9da17f8-719c-4909-a4a6-2566f2009089) | ![MaterialPropertyBlock](https://github.com/CesiumGS/cesium-unity/assets/32226860/036a5e75-fc91-40f4-a8a4-33d539cea242) |

In this scene, SRP batching allows us to stay just under 7ms per frame drawing. Without SRP batching, the drawing time fluctuates constantly between 9-12ms per frame.

Here's the performance on the second sample scene, with CWT and Melbourne Photogrammetry.

| `Material` | `MaterialPropertyBlock` |
| ---------- | --------------------------- |
| ![RegularMaterial2](https://github.com/CesiumGS/cesium-unity/assets/32226860/474b955e-b072-4493-9f6b-c4827db3ee52) | ![MaterialPropertyBlock2](https://github.com/CesiumGS/cesium-unity/assets/32226860/4dc02953-b5a6-4969-9235-af92d55de40c) |

For this scene, the `MaterialPropertyBlock` does increase the GPU time per frame, but not as drastically. And I'm not sure what makes Melbourne Photogrammetry more stable than other datasets?

Finally, I made a third sample scene with a view of San Francisco Photogrammetry and CWT.

| `Material` | `MaterialPropertyBlock` |
| ---------- | -------------------------- |
| ![RegularMaterial3](https://github.com/CesiumGS/cesium-unity/assets/32226860/3fa380fd-e2fe-4361-899c-2cc341e9001d) | ![MaterialPropertyBlock3](https://github.com/CesiumGS/cesium-unity/assets/32226860/18d92634-ee01-4385-89c3-504ba7a900c6) |

This looks more similar to the first sample scene's performance, though the difference is not as bad. There's fluctuation between 9-12ms per frame. San Francisco is probably not as "batchable" as Cesium OSM Buildings because it has more differences between tile material properties. Hence why the performance of OSM buildings is so much better with batching, but is relatively the same with the `MaterialPropertyBlock` approach.

Also, it seems like something is consistently generating 368B of GC every frame, but I can't imagine what. It doesn't seem to be related to this PR.
