### PR TITLE
Add the "AddComponentMenu" attribute to all classes visible to the user

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### ? - ?
 
+##### Additions :tada:
+
+- Cesium components now appear under the "Cesium" category in the Component menu. Previously were under "Scripts > Cesium for Unity"
+
 ##### Fixes :wrench:
 
 - Fixed a bug where `Cesium3DTileset` would not reflect changes made to the properties of its opaque material in the Editor.

--- a/Runtime/Cesium3DTileset.cs
+++ b/Runtime/Cesium3DTileset.cs
@@ -39,6 +39,7 @@ namespace CesiumForUnity
     /// </remarks>
     [ExecuteInEditMode]
     [ReinteropNativeImplementation("CesiumForUnityNative::Cesium3DTilesetImpl", "Cesium3DTilesetImpl.h")]
+    [AddComponentMenu("Cesium/Cesium 3D Tileset")]
     public partial class Cesium3DTileset : MonoBehaviour, IDisposable
     {
         public void Dispose()

--- a/Runtime/CesiumBingMapsRasterOverlay.cs
+++ b/Runtime/CesiumBingMapsRasterOverlay.cs
@@ -27,6 +27,7 @@ namespace CesiumForUnity
     [ReinteropNativeImplementation(
         "CesiumForUnityNative::CesiumBingMapsRasterOverlayImpl",
         "CesiumBingMapsRasterOverlayImpl.h")]
+    [AddComponentMenu("Cesium/Cesium Bing Maps Raster Overlay")]
     public partial class CesiumBingMapsRasterOverlay : CesiumRasterOverlay
     {
         [SerializeField]

--- a/Runtime/CesiumCameraController.cs
+++ b/Runtime/CesiumCameraController.cs
@@ -21,6 +21,7 @@ namespace CesiumForUnity
     [RequireComponent(typeof(CesiumOriginShift))]
     [RequireComponent(typeof(Camera))]
     [DisallowMultipleComponent]
+    [AddComponentMenu("Cesium/Cesium Camera Controller")]
     public class CesiumCameraController : MonoBehaviour
     {
         #region User-editable properties

--- a/Runtime/CesiumCreditSystem.cs
+++ b/Runtime/CesiumCreditSystem.cs
@@ -91,6 +91,7 @@ namespace CesiumForUnity
     /// </summary>
     [ExecuteInEditMode]
     [ReinteropNativeImplementation("CesiumForUnityNative::CesiumCreditSystemImpl", "CesiumCreditSystemImpl.h")]
+    [AddComponentMenu("Cesium/Cesium Credit System")]
     public partial class CesiumCreditSystem : MonoBehaviour
     {
         private List<CesiumCredit> _onScreenCredits;

--- a/Runtime/CesiumCreditSystemUI.cs
+++ b/Runtime/CesiumCreditSystemUI.cs
@@ -21,6 +21,7 @@ namespace CesiumForUnity
     /// </summary>
     [ExecuteInEditMode]
     [RequireComponent(typeof(UIDocument))]
+    [AddComponentMenu("Cesium/Cesium Credit System UI")]
     internal class CesiumCreditSystemUI : MonoBehaviour
     {
         private CesiumCreditSystem _creditSystem;

--- a/Runtime/CesiumDebugColorizeTilesRasterOverlay.cs
+++ b/Runtime/CesiumDebugColorizeTilesRasterOverlay.cs
@@ -9,6 +9,7 @@ namespace CesiumForUnity
     [ReinteropNativeImplementation(
         "CesiumForUnityNative::CesiumDebugColorizeTilesRasterOverlayImpl",
         "CesiumDebugColorizeTilesRasterOverlayImpl.h")]
+    [AddComponentMenu("Cesium/Cesium Debug Colorize Tiles Raster Overlay")]
     public partial class CesiumDebugColorizeTilesRasterOverlay : CesiumRasterOverlay
     {   
         /// <inheritdoc/>

--- a/Runtime/CesiumFlyToController.cs
+++ b/Runtime/CesiumFlyToController.cs
@@ -16,6 +16,7 @@ namespace CesiumForUnity
     /// </remarks>
     [RequireComponent(typeof(CesiumOriginShift))]
     [DisallowMultipleComponent]
+    [AddComponentMenu("Cesium/Cesium Fly To Controller")]
     public class CesiumFlyToController : MonoBehaviour
     {
         [SerializeField]

--- a/Runtime/CesiumGeoreference.cs
+++ b/Runtime/CesiumGeoreference.cs
@@ -60,6 +60,7 @@ namespace CesiumForUnity
     /// </remarks>
     [ExecuteInEditMode]
     [ReinteropNativeImplementation("CesiumForUnityNative::CesiumGeoreferenceImpl", "CesiumGeoreferenceImpl.h")]
+    [AddComponentMenu("Cesium/Cesium Georeference")]
     public partial class CesiumGeoreference : MonoBehaviour
     {
         #region Fields

--- a/Runtime/CesiumGlobeAnchor.cs
+++ b/Runtime/CesiumGlobeAnchor.cs
@@ -42,6 +42,7 @@ namespace CesiumForUnity
     /// </remarks>
     [ExecuteInEditMode]
     [ReinteropNativeImplementation("CesiumForUnityNative::CesiumGlobeAnchorImpl", "CesiumGlobeAnchorImpl.h", staticOnly: true)]
+    [AddComponentMenu("Cesium/Cesium Globe Anchor")]
     public partial class CesiumGlobeAnchor : MonoBehaviour, ICesiumRestartable
     {
         #region Fields

--- a/Runtime/CesiumIonRasterOverlay.cs
+++ b/Runtime/CesiumIonRasterOverlay.cs
@@ -7,6 +7,7 @@ namespace CesiumForUnity
     /// A <see cref="CesiumRasterOverlay"/> that uses an IMAGERY asset from Cesium ion.
     /// </summary>
     [ReinteropNativeImplementation("CesiumForUnityNative::CesiumIonRasterOverlayImpl", "CesiumIonRasterOverlayImpl.h")]
+    [AddComponentMenu("Cesium/Cesium Ion Raster Overlay")]
     public partial class CesiumIonRasterOverlay : CesiumRasterOverlay
     {
         [SerializeField]

--- a/Runtime/CesiumMetadata.cs
+++ b/Runtime/CesiumMetadata.cs
@@ -7,6 +7,7 @@ namespace CesiumForUnity
     /// Provides access to the metadata attached to features in a <see cref="Cesium3DTileset"/>.
     /// </summary>
     [ReinteropNativeImplementation("CesiumForUnityNative::CesiumMetadataImpl", "CesiumMetadataImpl.h")]
+    [AddComponentMenu("Cesium/Cesium Metadata")]
     public partial class CesiumMetadata : MonoBehaviour
     {
         /// <summary>

--- a/Runtime/CesiumOriginShift.cs
+++ b/Runtime/CesiumOriginShift.cs
@@ -25,6 +25,7 @@ namespace CesiumForUnity
     /// </remarks>
     [RequireComponent(typeof(CesiumGlobeAnchor))]
     [DisallowMultipleComponent]
+    [AddComponentMenu("Cesium/Cesium Origin Shift")]
     public class CesiumOriginShift : MonoBehaviour
     {
         void LateUpdate()

--- a/Runtime/CesiumPointCloudRenderer.cs
+++ b/Runtime/CesiumPointCloudRenderer.cs
@@ -17,7 +17,7 @@ namespace CesiumForUnity
     }
 
     [ExecuteInEditMode]
-    [AddComponentMenu("Cesium/Cesium Point Cloud Renderer")]
+    [AddComponentMenu("")]
     internal class CesiumPointCloudRenderer : MonoBehaviour
     {
         private Cesium3DTileset _tileset;

--- a/Runtime/CesiumPointCloudRenderer.cs
+++ b/Runtime/CesiumPointCloudRenderer.cs
@@ -17,6 +17,7 @@ namespace CesiumForUnity
     }
 
     [ExecuteInEditMode]
+    [AddComponentMenu("Cesium/Cesium Point Cloud Renderer")]
     internal class CesiumPointCloudRenderer : MonoBehaviour
     {
         private Cesium3DTileset _tileset;

--- a/Runtime/CesiumSubScene.cs
+++ b/Runtime/CesiumSubScene.cs
@@ -17,6 +17,7 @@ namespace CesiumForUnity
     /// </para>
     /// </remarks>
     [ExecuteInEditMode]
+    [AddComponentMenu("Cesium/Cesium Sub Scene")]
     public class CesiumSubScene : MonoBehaviour
     {
         [SerializeField]

--- a/Runtime/CesiumTileMapServiceRasterOverlay.cs
+++ b/Runtime/CesiumTileMapServiceRasterOverlay.cs
@@ -10,6 +10,7 @@ namespace CesiumForUnity
     [ReinteropNativeImplementation(
         "CesiumForUnityNative::CesiumTileMapServiceRasterOverlayImpl",
         "CesiumTileMapServiceRasterOverlayImpl.h")]
+    [AddComponentMenu("Cesium/Cesium Tile Map Service Raster Overlay")]
     public partial class CesiumTileMapServiceRasterOverlay : CesiumRasterOverlay
     {
         [SerializeField]

--- a/Runtime/CesiumWebMapServiceRasterOverlay.cs
+++ b/Runtime/CesiumWebMapServiceRasterOverlay.cs
@@ -10,6 +10,7 @@ namespace CesiumForUnity
     [ReinteropNativeImplementation(
         "CesiumForUnityNative::CesiumWebMapServiceRasterOverlayImpl",
         "CesiumWebMapServiceRasterOverlayImpl.h")]
+    [AddComponentMenu("Cesium/Cesium Web Map Service Raster Overlay")]
     public partial class CesiumWebMapServiceRasterOverlay : CesiumRasterOverlay
     {
         [SerializeField]


### PR DESCRIPTION
Moves menu location from 'Scripts/Cesium for Unity' to 'Cesium'.

A few other visibility issues were spotted by @j9liu , but the original intent of this request should be satisfied. 

The cesium scripts are a little easier to find from the "Add Component" menus.

Fixes issue #190 