### PR TITLE
Georef subscene origin sync

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 
 - Fixed a bug where `Cesium3DTileset` would not reflect changes made to the properties of its opaque material in the Editor.
 - Fixed a bug that could cause missing textures when using two raster overlays with the same projection on a single tileset.
+- Fixed a bug where changing the origin on a `CesiumGeoreference` would not propogate these changes to the active `CesiumSubScene`, if one exists.
 
 ### v1.2.0 - 2023-05-09
 

--- a/Runtime/CesiumSubScene.cs
+++ b/Runtime/CesiumSubScene.cs
@@ -293,12 +293,6 @@ namespace CesiumForUnity
                 if (georeference == null)
                     throw new InvalidOperationException("CesiumSubScene is not nested inside a game object with a CesiumGeoreference.");
 
-                double3 ecefPosition = new double3(
-                    this._ecefX,
-                    this._ecefY,
-                    this._ecefZ
-                );
-
                 if (this.originAuthority == CesiumGeoreferenceOriginAuthority.EarthCenteredEarthFixed)
                     georeference.SetOriginEarthCenteredEarthFixed(
                         this._ecefX,

--- a/Runtime/CesiumSubScene.cs
+++ b/Runtime/CesiumSubScene.cs
@@ -303,25 +303,20 @@ namespace CesiumForUnity
 
             // If not under a georef, nothing to do
             if (this._georeference == null)
+            {
                 throw new InvalidOperationException(
                     "CesiumSubScene should have been nested inside a game object with a CesiumGeoreference.");
-
-            // Update our origin to our parent georef, and maintain our origin authority
-            if (this._originAuthority == CesiumGeoreferenceOriginAuthority.LongitudeLatitudeHeight)
-            {
-                this._longitude = this._georeference.longitude;
-                this._latitude = this._georeference.latitude;
-                this._height = this._georeference.height;
-            }
-            else if (this._originAuthority == CesiumGeoreferenceOriginAuthority.EarthCenteredEarthFixed)
-            {
-                this._ecefX = this._georeference.ecefX;
-                this._ecefY = this._georeference.ecefY;
-                this._ecefZ = this._georeference.ecefZ;
             }
 
-            // Update other values without updating parent
-            this.UpdateOtherCoordinates();
+            // Update our origin to our parent georef, maintain our origin authority,
+            // and copy both sets of reference coordinates. No need to calculate any of this again
+            this._longitude = this._georeference.longitude;
+            this._latitude = this._georeference.latitude;
+            this._height = this._georeference.height;
+
+            this._ecefX = this._georeference.ecefX;
+            this._ecefY = this._georeference.ecefY;
+            this._ecefZ = this._georeference.ecefZ;
         }
 
         private void OnDisable()

--- a/Runtime/CesiumSubScene.cs
+++ b/Runtime/CesiumSubScene.cs
@@ -255,11 +255,7 @@ namespace CesiumForUnity
             this.UpdateOrigin();
         }
 
-        /// <summary>
-        /// Recomputes the coordinate system based on an updated origin. It is usually not
-        /// necessary to call this directly as it is called automatically when needed.
-        /// </summary>
-        public void UpdateOrigin()
+        private void UpdateOtherCoordinates()
         {
             if (this._originAuthority == CesiumGeoreferenceOriginAuthority.LongitudeLatitudeHeight)
             {
@@ -286,6 +282,15 @@ namespace CesiumForUnity
                 this._latitude = llh.y;
                 this._height = llh.z;
             }
+        }
+
+        /// <summary>
+        /// Recomputes the coordinate system based on an updated origin. It is usually not
+        /// necessary to call this directly as it is called automatically when needed.
+        /// </summary>
+        public void UpdateOrigin()
+        {
+            UpdateOtherCoordinates();
 
             if (this.isActiveAndEnabled)
             {

--- a/Runtime/CesiumSubScene.cs
+++ b/Runtime/CesiumSubScene.cs
@@ -296,6 +296,32 @@ namespace CesiumForUnity
 
         private void OnParentGeorefChanged()
         {
+            if (!this.isActiveAndEnabled)
+                return;
+
+            this.UpdateGeoreference();
+
+            // If not under a georef, nothing to do
+            if (this._georeference == null)
+                throw new InvalidOperationException(
+                    "CesiumSubScene should have been nested inside a game object with a CesiumGeoreference.");
+
+            // Update our origin to our parent georef, and maintain our origin authority
+            if (this._originAuthority == CesiumGeoreferenceOriginAuthority.LongitudeLatitudeHeight)
+            {
+                this._longitude = this._georeference.longitude;
+                this._latitude = this._georeference.latitude;
+                this._height = this._georeference.height;
+            }
+            else if (this._originAuthority == CesiumGeoreferenceOriginAuthority.EarthCenteredEarthFixed)
+            {
+                this._ecefX = this._georeference.ecefX;
+                this._ecefY = this._georeference.ecefY;
+                this._ecefZ = this._georeference.ecefZ;
+            }
+
+            // Update other values without updating parent
+            this.UpdateOtherCoordinates();
         }
 
         private void OnDisable()

--- a/Tests/TestCesiumGeoreference.cs
+++ b/Tests/TestCesiumGeoreference.cs
@@ -138,4 +138,99 @@ public class TestCesiumGeoreference
         Assert.That(anchor.longitudeLatitudeHeight.y, Is.EqualTo(longitudeLatitudeHeight.y).Using(epsilon8));
         Assert.That(anchor.longitudeLatitudeHeight.z, Is.EqualTo(longitudeLatitudeHeight.z).Using(epsilon8));
     }
+
+    [UnityTest]
+    public IEnumerator ChangingOriginAtRuntimeUpdatesSubScene()
+    {
+        GameObject goGeoreference = new GameObject("Georeference");
+        CesiumGeoreference georeference = goGeoreference.AddComponent<CesiumGeoreference>();
+        georeference.SetOriginLongitudeLatitudeHeight(-55.0, 55.0, 1000.0);
+
+        GameObject goSubscene = new GameObject("SubScene");
+        goSubscene.transform.parent = goGeoreference.transform;
+        georeference.SetOriginLongitudeLatitudeHeight(-55.0, 55.0, 1000.0);
+
+        CesiumSubScene subscene = goSubscene.AddComponent<CesiumSubScene>();
+
+        IEqualityComparer<double> epsilon8 = Comparers.Double(1e-8);
+
+        yield return null;
+
+        // Change the origin with 3 components
+        {
+            georeference.SetOriginLongitudeLatitudeHeight(-10.0, 10.0, 100.0);
+            yield return null;
+
+            // The subscene should sync up
+            Assert.That(subscene.longitude, Is.EqualTo(-10.0).Using(epsilon8));
+            Assert.That(subscene.latitude, Is.EqualTo(10.0).Using(epsilon8));
+            Assert.That(subscene.height, Is.EqualTo(100.0).Using(epsilon8));
+            yield return null;
+        }
+
+        // Change with just longitude
+        {
+            georeference.longitude = 40.0;
+            yield return null;
+
+            Assert.That(subscene.longitude, Is.EqualTo(40.0).Using(epsilon8));
+            yield return null;
+        }
+
+        // Change with just latitude
+        {
+            georeference.latitude = 50.0;
+            yield return null;
+
+            Assert.That(subscene.latitude, Is.EqualTo(50.0).Using(epsilon8));
+            yield return null;
+        }
+
+        // Change with just height
+        {
+            georeference.height = 60.0;
+            yield return null;
+
+            Assert.That(subscene.height, Is.EqualTo(60.0).Using(epsilon8));
+            yield return null;
+        }
+
+        // Now a 3 component change, but ECEF
+        {
+            georeference.SetOriginEarthCenteredEarthFixed(-3000.0, 4000.0, 5000.0);
+            yield return null;
+
+            Assert.That(subscene.ecefX, Is.EqualTo(-3000.0).Using(epsilon8));
+            Assert.That(subscene.ecefY, Is.EqualTo(4000.0).Using(epsilon8));
+            Assert.That(subscene.ecefZ, Is.EqualTo(5000.0).Using(epsilon8));
+            yield return null;
+        }
+
+        // Change with just X
+        {
+            georeference.ecefX = -3050.0;
+            yield return null;
+
+            Assert.That(subscene.ecefX, Is.EqualTo(-3050.0).Using(epsilon8));
+            yield return null;
+        }
+
+        // Change with just Y
+        {
+            georeference.ecefX = 4050.0;
+            yield return null;
+
+            Assert.That(subscene.ecefX, Is.EqualTo(4050.0).Using(epsilon8));
+            yield return null;
+        }
+
+        // Change with just Z
+        {
+            georeference.ecefZ = 5050.0;
+            yield return null;
+
+            Assert.That(subscene.ecefZ, Is.EqualTo(5050.0).Using(epsilon8));
+            yield return null;
+        }
+    }
 }


### PR DESCRIPTION
Let any changes to `CesiumGeoreference` origin propagate to the active subscene, if exists.
Refactored `CesiumSubScene` to register itself as a listener to any parent `CesiumGeoreference` changes (`changed ` delegate). Similar to the pattern that `CesiumGlobeAnchor` uses.
A special `OnParentGeorefChanged` function ensures that parent changes don't propagate even more parent changes.
Added 2 new unit tests.



Resolves Issue #175 