### PR TITLE
Fix cracks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - Fixed a bug that could cause missing textures when using two raster overlays with the same projection on a single tileset.
 - Fixed a bug where changing the origin on a `CesiumGeoreference` would not propogate these changes to the active `CesiumSubScene`, if one exists.
 - Lessen the amount of extreme camera rotation in the CesiumCameraController after a frame hitch by using Time.smoothDeltaTime.
+- Resolved a tile rendering issue, which caused cracks to appear between tiles, caused by improper use of mipmaps.
 
 ### v1.2.0 - 2023-05-09
 

--- a/native~/Runtime/src/TextureLoader.cpp
+++ b/native~/Runtime/src/TextureLoader.cpp
@@ -22,11 +22,12 @@ namespace CesiumForUnityNative {
 UnityEngine::Texture
 TextureLoader::loadTexture(const CesiumGltf::ImageCesium& image) {
   CESIUM_TRACE("TextureLoader::loadTexture");
+  bool useMipMaps = !image.mipPositions.empty();
   UnityEngine::Texture2D result(
       image.width,
       image.height,
       UnityEngine::TextureFormat::RGBA32,
-      true,
+      useMipMaps,
       false);
   result.hideFlags(UnityEngine::HideFlags::HideAndDontSave);
 
@@ -39,7 +40,7 @@ TextureLoader::loadTexture(const CesiumGltf::ImageCesium& image) {
   size_t textureLength = textureData.Length();
   assert(textureLength >= image.pixelData.size());
 
-  if (image.mipPositions.empty()) {
+  if (!useMipMaps) {
     // No mipmaps, copy the whole thing and then let Unity generate mipmaps on a
     // worker thread.
     std::memcpy(pixels, image.pixelData.data(), image.pixelData.size());

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -250,8 +250,17 @@ void generateMipMaps(
     Texture* pTexture = Model::getSafe(&pModel->textures, textureInfo->index);
     if (pTexture) {
       Image* pImage = Model::getSafe(&pModel->images, pTexture->source);
-      if (pImage) {
-        CesiumGltfReader::GltfReader::generateMipMaps(pImage->cesium);
+      const Sampler* pSampler =
+          Model::getSafe(&pModel->samplers, pTexture->sampler);
+      if (pImage && pSampler) {
+        switch (pSampler->minFilter.value_or(
+            CesiumGltf::Sampler::MinFilter::LINEAR_MIPMAP_LINEAR)) {
+        case CesiumGltf::Sampler::MinFilter::LINEAR_MIPMAP_LINEAR:
+        case CesiumGltf::Sampler::MinFilter::LINEAR_MIPMAP_NEAREST:
+        case CesiumGltf::Sampler::MinFilter::NEAREST_MIPMAP_LINEAR:
+        case CesiumGltf::Sampler::MinFilter::NEAREST_MIPMAP_NEAREST:
+          CesiumGltfReader::GltfReader::generateMipMaps(pImage->cesium);
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #325

This problem was fixed by copying logic from Cesium for Unreal. (https://github.com/CesiumGS/cesium-unreal/blob/ue5-main/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp). If I change the code to always generate mipmaps, the cracks also appear in Unreal.