### PR TITLE
Improve scene view camera location when focusing on tileset

### DIFF
--- a/native~/Runtime/src/Cesium3DTilesetImpl.cpp
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.cpp
@@ -235,7 +235,7 @@ struct CalculateECEFCameraPosition {
             ellipsoid));
     const glm::dmat3& halfAxes = orientedBoundingBox.getHalfAxes();
     glm::dvec3 offset =
-        glm::length(halfAxes[0] + halfAxes[1] + halfAxes[2]) *
+        glm::length(halfAxes[2]) *
         glm::normalize(
             glm::dvec3(enuToEcef[0]) + glm::dvec3(enuToEcef[1]) +
             glm::dvec3(enuToEcef[2]));


### PR DESCRIPTION
If the root bounding box has a large width and length, the offset to be gigantic and the tileset won't load. Instead, just factoring in the height of the box will put the scene view camera just above the tileset.

Example tileset from this forum post: https://community.cesium.com/t/cesium-for-unity-textured-buildings-question/23563