### PR TITLE
Added event to notify when new GameObject is created.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Additions :tada:
+
+- Added an event to notify when a new GameObject is created.
+
 ### v1.3.1 - 2023-06-06
 
 ##### Fixes :wrench:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ##### Additions :tada:
 
-- Added an event to notify when a new GameObject is created.
+- Added `OnTileGameObjectCreated` event to `Cesium3DTileset` class, which allows customizing the Tile GameObjects as they are loaded.
 
 ### v1.3.1 - 2023-06-06
 

--- a/Runtime/Cesium3DTileset.cs
+++ b/Runtime/Cesium3DTileset.cs
@@ -70,6 +70,16 @@ namespace CesiumForUnity
             }
         }
 
+        public event Action<GameObject> OnNewGameObjectCreated;
+
+        internal void BroadcastNewGameObjectCreated(GameObject go)
+        {
+            if(OnNewGameObjectCreated != null)
+            {
+                OnNewGameObjectCreated(go);
+            }
+        }
+
         internal static event Action OnSetShowCreditsOnScreen;
 
         [SerializeField]

--- a/Runtime/Cesium3DTileset.cs
+++ b/Runtime/Cesium3DTileset.cs
@@ -69,14 +69,20 @@ namespace CesiumForUnity
                 OnCesium3DTilesetLoadFailure(details);
             }
         }
-
-        public event Action<GameObject> OnNewGameObjectCreated;
+        /// <summary>
+        /// Occurs when a new GameObject is instantiated for a Tile in the tileset.
+        /// </summary>
+        /// <remarks>
+        /// This event can be used to customize the Tile GameObjects as they are loaded,
+        /// such as adding components, changing materials, or applying transformations.
+        /// </remarks>
+        public event Action<GameObject> OnTileGameObjectCreated;
 
         internal void BroadcastNewGameObjectCreated(GameObject go)
         {
-            if(OnNewGameObjectCreated != null)
+            if(OnTileGameObjectCreated != null)
             {
-                OnNewGameObjectCreated(go);
+                OnTileGameObjectCreated(go);
             }
         }
 

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -456,6 +456,8 @@ namespace CesiumForUnity
                                                 "");
             CesiumRasterOverlay.BroadcastCesiumRasterOverlayLoadFailure(overlayDetails);
 
+            tileset.BroadcastNewGameObjectCreated(new GameObject());
+
             double3 cv3 = new double3();
             cv3.x = cv3.y = cv3.z;
             double3 cv4 = new double3(1.0, 2.0, 3.0);

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -1358,6 +1358,8 @@ void* UnityPrepareRendererResources::prepareInMainThread(
         }
       });
 
+  tilesetComponent.BroadcastNewGameObjectCreated(*pModelGameObject);
+
   CesiumGltfGameObject* pCesiumGameObject = new CesiumGltfGameObject{
       std::move(pModelGameObject),
       std::move(pLoadThreadResult->primitiveInfos)};


### PR DESCRIPTION
In trying to integrate TeleportationArea from the XR Interaction Toolkit, the GameObject/colliders need to be registered with the XR Interaction Manager. An easy way to do this is to simply add a TeleportationArea script to the GameObject when its created.

With the new event, it can easily be achieved:
```
cesium3DTileset.OnNewGameObjectCreated += go  => go.AddComponent<TeleportationArea>();
```