### PR TITLE
Change occlusion value of '0' to mean full occlusion.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed how the occlusion strength is used in the default tileset shader which was causing shadows to be too dark.
+
 ### v1.3.1 - 2023-06-06
 
 ##### Fixes :wrench:

--- a/Runtime/Resources/CesiumDefaultTilesetShader.shadergraph
+++ b/Runtime/Resources/CesiumDefaultTilesetShader.shadergraph
@@ -287,6 +287,12 @@
         },
         {
             "m_Id": "747c0b2acec54979b802706fd6e3e982"
+        },
+        {
+            "m_Id": "10b0fc88ba6544f981f45ee779691a10"
+        },
+        {
+            "m_Id": "e0166dc05bdc4b5ca51b8912b619f89c"
         }
     ],
     "m_GroupDatas": [
@@ -368,6 +374,20 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "2d5f51898df645b5bcdaec990a5d23ad"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "10b0fc88ba6544f981f45ee779691a10"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "d12188a9cb824131bf5ec7a1ca5a2ee6"
                 },
                 "m_SlotId": 0
             }
@@ -871,7 +891,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "d12188a9cb824131bf5ec7a1ca5a2ee6"
+                    "m_Id": "10b0fc88ba6544f981f45ee779691a10"
                 },
                 "m_SlotId": 0
             }
@@ -1033,6 +1053,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "e0166dc05bdc4b5ca51b8912b619f89c"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "10b0fc88ba6544f981f45ee779691a10"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "e49b955ca53840fe99b5b34852e2103a"
                 },
                 "m_SlotId": 1
@@ -1056,6 +1090,20 @@
                     "m_Id": "b2c123c0474c47978bb44f2f78bd2770"
                 },
                 "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "e5d96ffeefa643799b27d1ff9853f0ea"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "e0166dc05bdc4b5ca51b8912b619f89c"
+                },
+                "m_SlotId": 0
             }
         },
         {
@@ -1606,6 +1654,48 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.AddNode",
+    "m_ObjectId": "10b0fc88ba6544f981f45ee779691a10",
+    "m_Group": {
+        "m_Id": "da5f26e4dc7649dbae635a3bcb0ac50b"
+    },
+    "m_Name": "Add",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 164.99998474121095,
+            "y": 2190.000244140625,
+            "width": 126.00001525878906,
+            "height": 118.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "a439f939a7ae4186b8b4ac35c652a6d3"
+        },
+        {
+            "m_Id": "86912dc00b5e40eba2489e18f4aec6b5"
+        },
+        {
+            "m_Id": "476d5f3583674430bd18383a3e40a7cd"
+        }
+    ],
+    "synonyms": [
+        "addition",
+        "sum",
+        "plus"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.StickyNoteData",
     "m_ObjectId": "10fd73791b27497f8371dab1015c22b7",
     "m_Title": "glTF Base Color",
@@ -1678,6 +1768,30 @@
     "m_TextureType": 0,
     "m_NormalMapSpace": 0,
     "m_EnableGlobalMipBias": true
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "127ea937d901462f95c80eecadefa2ae",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 1.0,
+        "y": 1.0,
+        "z": 1.0,
+        "w": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
 }
 
 {
@@ -3284,6 +3398,30 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "476d5f3583674430bd18383a3e40a7cd",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
 }
 
 {
@@ -4948,6 +5086,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "86912dc00b5e40eba2489e18f4aec6b5",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "87d27d9ec71948039f957c782a4f67bc",
     "m_Group": {
@@ -5893,6 +6055,30 @@
         "m_SerializableColors": []
     },
     "m_SerializedDescriptor": "SurfaceDescription.Metallic"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "a439f939a7ae4186b8b4ac35c652a6d3",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
 }
 
 {
@@ -7058,6 +7244,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "cf44c707c04d4e96a496c5105867fa86",
+    "m_Id": 1,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BlockNode",
     "m_ObjectId": "d12188a9cb824131bf5ec7a1ca5a2ee6",
     "m_Group": {
@@ -7337,7 +7547,7 @@
     "m_ObjectId": "da5f26e4dc7649dbae635a3bcb0ac50b",
     "m_Title": "glTF Ambient Occlusion",
     "m_Position": {
-        "x": -1222.0001220703125,
+        "x": -1222.0,
         "y": 2105.0
     }
 }
@@ -7630,6 +7840,45 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.OneMinusNode",
+    "m_ObjectId": "e0166dc05bdc4b5ca51b8912b619f89c",
+    "m_Group": {
+        "m_Id": "da5f26e4dc7649dbae635a3bcb0ac50b"
+    },
+    "m_Name": "One Minus",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -28.000030517578126,
+            "y": 2321.0,
+            "width": 128.00001525878907,
+            "height": 94.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "127ea937d901462f95c80eecadefa2ae"
+        },
+        {
+            "m_Id": "cf44c707c04d4e96a496c5105867fa86"
+        }
+    ],
+    "synonyms": [
+        "complement",
+        "invert",
+        "opposite"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.UVMaterialSlot",
     "m_ObjectId": "e1833c0c242244858357695ab7a2c9ee",
     "m_Id": 2,
@@ -7819,10 +8068,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -246.0000762939453,
-            "y": 2357.0,
-            "width": 170.0001983642578,
-            "height": 34.0
+            "x": -245.00003051757813,
+            "y": 2304.0,
+            "width": 170.0,
+            "height": 34.000244140625
         }
     },
     "m_Slots": [

--- a/Runtime/Resources/CesiumDefaultTilesetShader.shadergraph
+++ b/Runtime/Resources/CesiumDefaultTilesetShader.shadergraph
@@ -287,6 +287,9 @@
         },
         {
             "m_Id": "747c0b2acec54979b802706fd6e3e982"
+        },
+        {
+            "m_Id": "dcf7466438e84ba5b015be66c3064baa"
         }
     ],
     "m_GroupDatas": [
@@ -1033,6 +1036,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "dcf7466438e84ba5b015be66c3064baa"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "b2c123c0474c47978bb44f2f78bd2770"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "e49b955ca53840fe99b5b34852e2103a"
                 },
                 "m_SlotId": 1
@@ -1053,9 +1070,9 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "b2c123c0474c47978bb44f2f78bd2770"
+                    "m_Id": "dcf7466438e84ba5b015be66c3064baa"
                 },
-                "m_SlotId": 1
+                "m_SlotId": 0
             }
         },
         {
@@ -5502,6 +5519,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "9529743426be4bb18f285a99d3fccff2",
+    "m_Id": 1,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
     "m_ObjectId": "965bf93aed2947908ec82cf30287ea9d",
     "m_Guid": {
@@ -6407,9 +6448,9 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -27.9998779296875,
+            "x": 56.00002670288086,
             "y": 2190.0,
-            "width": 125.9998550415039,
+            "width": 125.99996948242188,
             "height": 118.0
         }
     },
@@ -6577,6 +6618,30 @@
         "w": 0.0
     },
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "b9a8497acbee4dd78c78d17c85a2a38d",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 1.0,
+        "y": 1.0,
+        "z": 1.0,
+        "w": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
 }
 
 {
@@ -7485,6 +7550,45 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.OneMinusNode",
+    "m_ObjectId": "dcf7466438e84ba5b015be66c3064baa",
+    "m_Group": {
+        "m_Id": "da5f26e4dc7649dbae635a3bcb0ac50b"
+    },
+    "m_Name": "One Minus",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -101.0,
+            "y": 2297.0,
+            "width": 128.0,
+            "height": 94.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "b9a8497acbee4dd78c78d17c85a2a38d"
+        },
+        {
+            "m_Id": "9529743426be4bb18f285a99d3fccff2"
+        }
+    ],
+    "synonyms": [
+        "complement",
+        "invert",
+        "opposite"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
     "m_ObjectId": "dd409ebdea56415fbdb18037c813476b",
     "m_Id": -590019148,
@@ -7819,9 +7923,9 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -246.0000762939453,
-            "y": 2357.0,
-            "width": 170.0001983642578,
+            "x": -271.0,
+            "y": 2338.0,
+            "width": 170.0,
             "height": 34.0
         }
     },

--- a/Runtime/Resources/CesiumDefaultTilesetShader.shadergraph
+++ b/Runtime/Resources/CesiumDefaultTilesetShader.shadergraph
@@ -287,9 +287,6 @@
         },
         {
             "m_Id": "747c0b2acec54979b802706fd6e3e982"
-        },
-        {
-            "m_Id": "dcf7466438e84ba5b015be66c3064baa"
         }
     ],
     "m_GroupDatas": [
@@ -1036,20 +1033,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "dcf7466438e84ba5b015be66c3064baa"
-                },
-                "m_SlotId": 1
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "b2c123c0474c47978bb44f2f78bd2770"
-                },
-                "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "e49b955ca53840fe99b5b34852e2103a"
                 },
                 "m_SlotId": 1
@@ -1070,9 +1053,9 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "dcf7466438e84ba5b015be66c3064baa"
+                    "m_Id": "b2c123c0474c47978bb44f2f78bd2770"
                 },
-                "m_SlotId": 0
+                "m_SlotId": 1
             }
         },
         {
@@ -5519,30 +5502,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "9529743426be4bb18f285a99d3fccff2",
-    "m_Id": 1,
-    "m_DisplayName": "Out",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
     "m_ObjectId": "965bf93aed2947908ec82cf30287ea9d",
     "m_Guid": {
@@ -6448,9 +6407,9 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 56.00002670288086,
+            "x": -27.9998779296875,
             "y": 2190.0,
-            "width": 125.99996948242188,
+            "width": 125.9998550415039,
             "height": 118.0
         }
     },
@@ -6618,30 +6577,6 @@
         "w": 0.0
     },
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "b9a8497acbee4dd78c78d17c85a2a38d",
-    "m_Id": 0,
-    "m_DisplayName": "In",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "In",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 1.0,
-        "y": 1.0,
-        "z": 1.0,
-        "w": 1.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    }
 }
 
 {
@@ -7550,45 +7485,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.OneMinusNode",
-    "m_ObjectId": "dcf7466438e84ba5b015be66c3064baa",
-    "m_Group": {
-        "m_Id": "da5f26e4dc7649dbae635a3bcb0ac50b"
-    },
-    "m_Name": "One Minus",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -101.0,
-            "y": 2297.0,
-            "width": 128.0,
-            "height": 94.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "b9a8497acbee4dd78c78d17c85a2a38d"
-        },
-        {
-            "m_Id": "9529743426be4bb18f285a99d3fccff2"
-        }
-    ],
-    "synonyms": [
-        "complement",
-        "invert",
-        "opposite"
-    ],
-    "m_Precision": 0,
-    "m_PreviewExpanded": false,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
     "m_ObjectId": "dd409ebdea56415fbdb18037c813476b",
     "m_Id": -590019148,
@@ -7923,9 +7819,9 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -271.0,
-            "y": 2338.0,
-            "width": 170.0,
+            "x": -246.0000762939453,
+            "y": 2357.0,
+            "width": 170.0001983642578,
             "height": 34.0
         }
     },


### PR DESCRIPTION
This was causing shadows to be extremely dark. 
Before and after:
![before](https://github.com/CesiumGS/cesium-unity/assets/97980867/1fbf383d-e634-4aff-a475-360678123b2e)
![after](https://github.com/CesiumGS/cesium-unity/assets/97980867/03a1a044-a209-4611-a031-a01bf084af3f)

In both Unity and glTF,  Occlusion of 0.0 means full occlusion, 1.0 means fully lit:

glTF:
occlusion : The occlusion texture; it indicates areas that receive less indirect lighting from ambient sources. Direct lighting is not affected. The red channel of the texture encodes the occlusion value, where 0.0 means fully-occluded area (no indirect lighting) and 1.0 means not occluded area (full indirect lighting). Other texture channels (if present) do not affect occlusion.
The texture binding for occlusion maps MAY optionally contain a scalar strength value that is used to reduce the occlusion effect. When present, it affects the occlusion value as **1.0 + strength * (occlusionTexture - 1.0).**

[Unity ](https://docs.unity3d.com/Packages/com.unity.render-pipelines.high-definition@10.10/manual/Ambient-Occlusion.html):
When authoring ambient occlusion Textures, be aware that a value of 0 specifies an area that is fully occluded and a value of 1 specifies an area that is fully visible.

Also, Shadergraph and Surface Shaders have a default occlusion value 1.0 which means no ambient occlusion.

So, by using the equation above:

![new-ambient-occlusion](https://github.com/CesiumGS/cesium-unity/assets/97980867/d4803578-c620-492d-a4de-65d1978c14b2)
