### PR TITLE
Fix console errors when entering play mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 
 - Fixed how the occlusion strength is used in the default tileset shader which was causing shadows to be too dark.
 - Fixed a bug that caused a prefab with a `CesiumGlobeAnchor` to lose its position after save/reload.
+- Fixed a `MissingReferenceException` when entering Play mode with "Domain Reload" disabled. This would also prevent tilesets with raster overlays from appearing at all in Play mode.
 
 In addition to the above, this release updates [cesium-native](https://github.com/CesiumGS/cesium-native) from v0.25.0 to v0.25.1. See the [changelog](https://github.com/CesiumGS/cesium-native/blob/main/CHANGES.md) for a complete list of changes in cesium-native.
 

--- a/Runtime/CesiumCreditSystem.cs
+++ b/Runtime/CesiumCreditSystem.cs
@@ -329,7 +329,8 @@ namespace CesiumForUnity
         private void OnSceneUnloaded(Scene scene)
         {
             SceneManager.sceneUnloaded -= this.OnSceneUnloaded;
-            UnityLifetime.Destroy(this.gameObject);
+            //if (this != null && this.gameObject != null)
+                UnityLifetime.Destroy(this.gameObject);
         }
 
 #if UNITY_EDITOR

--- a/Runtime/CesiumCreditSystem.cs
+++ b/Runtime/CesiumCreditSystem.cs
@@ -329,7 +329,7 @@ namespace CesiumForUnity
         private void OnSceneUnloaded(Scene scene)
         {
             SceneManager.sceneUnloaded -= this.OnSceneUnloaded;
-            //if (this != null && this.gameObject != null)
+            if (this != null && this.gameObject != null)
                 UnityLifetime.Destroy(this.gameObject);
         }
 

--- a/Runtime/CesiumCreditSystemUI.cs
+++ b/Runtime/CesiumCreditSystemUI.cs
@@ -48,8 +48,12 @@ namespace CesiumForUnity
             this._creditSystem.OnCreditsUpdate += this.SetCredits;
 
             this._uiDocument = this.GetComponent<UIDocument>();
-            this._onScreenCredits = this._uiDocument.rootVisualElement.Q("OnScreenCredits");
-            this._popupCredits = this._uiDocument.rootVisualElement.Q("PopupCredits");
+
+            //if (this._uiDocument.rootVisualElement != null)
+            {
+                this._onScreenCredits = this._uiDocument.rootVisualElement.Q("OnScreenCredits");
+                this._popupCredits = this._uiDocument.rootVisualElement.Q("PopupCredits");
+            }
 
 #if UNITY_EDITOR
             if (!EditorApplication.isPlaying)
@@ -65,7 +69,7 @@ namespace CesiumForUnity
                 eventSystemGameObject.AddComponent<EventSystem>();
 
 #if ENABLE_INPUT_SYSTEM
-                 eventSystemGameObject.AddComponent<InputSystemUIInputModule>();
+                eventSystemGameObject.AddComponent<InputSystemUIInputModule>();
 #elif ENABLE_LEGACY_INPUT_MANAGER
                  eventSystemGameObject.AddComponent<StandaloneInputModule>();
 #endif
@@ -159,7 +163,7 @@ namespace CesiumForUnity
             for (int i = 0; i < sceneViews.Count; i++)
             {
                 this.AddCreditsToSceneView((SceneView)sceneViews[i]);
-            }          
+            }
 #endif
         }
 
@@ -387,7 +391,7 @@ namespace CesiumForUnity
         {
 #if UNITY_EDITOR
             ArrayList sceneViews = SceneView.sceneViews;
-            for(int i = 0; i < sceneViews.Count; i++)
+            for (int i = 0; i < sceneViews.Count; i++)
             {
                 this.RemoveCreditsFromSceneView((SceneView)sceneViews[i]);
             }

--- a/Runtime/CesiumCreditSystemUI.cs
+++ b/Runtime/CesiumCreditSystemUI.cs
@@ -49,7 +49,7 @@ namespace CesiumForUnity
 
             this._uiDocument = this.GetComponent<UIDocument>();
 
-            //if (this._uiDocument.rootVisualElement != null)
+            if (this._uiDocument.rootVisualElement != null)
             {
                 this._onScreenCredits = this._uiDocument.rootVisualElement.Q("OnScreenCredits");
                 this._popupCredits = this._uiDocument.rootVisualElement.Q("PopupCredits");


### PR DESCRIPTION
Fixes #339 

This fixes a couple of errors that are logged to the console when entering Play mode. Specifically this one:

```
ArgumentNullException: Value cannot be null.
Parameter name: e
UnityEngine.UIElements.UQueryExtensions.Q (UnityEngine.UIElements.VisualElement e, System.String name, System.String className) (at <7f21349c9161407ba80a85ddaed7fabb>:0)
CesiumForUnity.CesiumCreditSystemUI.OnEnable () (at Packages/com.cesium.unity/Runtime/CesiumCreditSystemUI.cs:54)
```

And this one:

```
MissingReferenceException: The object of type 'CesiumCreditSystem' has been destroyed but you are still trying to access it.
Your script should either check if it is null or you should not destroy the object.
CesiumForUnity.CesiumCreditSystem.OnSceneUnloaded (UnityEngine.SceneManagement.Scene scene) (at Packages/com.cesium.unity/Runtime/CesiumCreditSystem.cs:333)
UnityEngine.SceneManagement.SceneManager.Internal_SceneUnloaded (UnityEngine.SceneManagement.Scene scene) (at <7b2a272e51214e2f91bbc4fb4f28eff8>:0)
```

Also fixes a more serious problem (#339) that occurs when Project Settings -> Editor -> Enter Play Mode Settings -> Reload Domain is disabled and prevents tilesets with raster overlays from working at all.

All of these problems are caused by Unity destroying some game objects while we hold references to them, and Cesium for Unity not checking to see if they're still valid before using them.