### PR TITLE
Added bounds property for tileset

### DIFF
--- a/Runtime/Cesium3DTileset.cs
+++ b/Runtime/Cesium3DTileset.cs
@@ -650,6 +650,17 @@ namespace CesiumForUnity
             }
         }
 
+        /// <summary>
+        /// Gets the axis-aligned bounding box of the root tile of this tileset.
+        /// </summary>
+        public Bounds bounds
+        {
+            get
+            {
+                return getBounds();
+            }
+        }
+
         private partial void SetShowCreditsOnScreen(bool value);
 
         private partial void Start();
@@ -669,5 +680,7 @@ namespace CesiumForUnity
         /// Zoom the Editor camera to this tileset. This method does nothing outside of the Editor.
         /// </summary>
         public partial void FocusTileset();
+
+        private partial Bounds getBounds();
     }
 }

--- a/native~/Runtime/src/Cesium3DTilesetImpl.h
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.h
@@ -5,6 +5,7 @@
 #include <DotNet/CesiumForUnity/CesiumCreditSystem.h>
 #include <DotNet/CesiumForUnity/CesiumGeoreference.h>
 #include <DotNet/System/Action.h>
+#include <DotNet/UnityEngine/Bounds.h>
 
 #include <memory>
 
@@ -39,6 +40,9 @@ public:
 
   void RecreateTileset(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
   void FocusTileset(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
+
+  DotNet::UnityEngine::Bounds getBounds(
+      const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
 
   Cesium3DTilesSelection::Tileset* getTileset();
   const Cesium3DTilesSelection::Tileset* getTileset() const;


### PR DESCRIPTION
I've added a bounds property to Cesium3DTileset. Personally I use this to teleport to tiles added manually by users. 

The bounds calculating code is copied & modified from `Cesium3DTileImpl::getBounds`. The tileset needs some time to load before this property can be used. `_pTileset` needs to be set & `getRootTile()` needs to be available as well. Because of this I now return bounds with all 0's but I don't think this is the most elegant solution. How would you suggest to handle this?