### PR TITLE
Handle incomplete mip chains correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that could lead to incorrect textures when a KTX2 image did not include a complete mip chain.
+
 ### v1.4.0 - 2023-07-03
 
 ##### Additions :tada:

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -104,6 +104,7 @@ namespace CesiumForUnity
             go.hideFlags = HideFlags.DontSave;
 
             Texture2D texture2D = new Texture2D(256, 256, TextureFormat.RGBA32, false, false);
+            texture2D = new Texture2D(256, 256, TextureFormat.RGBA32, 1, false);
             texture2D.LoadRawTextureData(IntPtr.Zero, 0);
             NativeArray<byte> textureBytes = texture2D.GetRawTextureData<byte>();
 

--- a/native~/Runtime/src/TextureLoader.cpp
+++ b/native~/Runtime/src/TextureLoader.cpp
@@ -22,7 +22,8 @@ namespace CesiumForUnityNative {
 UnityEngine::Texture
 TextureLoader::loadTexture(const CesiumGltf::ImageCesium& image) {
   CESIUM_TRACE("TextureLoader::loadTexture");
-  bool useMipMaps = !image.mipPositions.empty();
+  std::int32_t mipCount =
+      image.mipPositions.empty() ? 1 : std::int32_t(image.mipPositions.size());
 
   UnityEngine::TextureFormat textureFormat;
 
@@ -71,7 +72,7 @@ TextureLoader::loadTexture(const CesiumGltf::ImageCesium& image) {
   }
 
   UnityEngine::Texture2D
-      result(image.width, image.height, textureFormat, useMipMaps, false);
+      result(image.width, image.height, textureFormat, mipCount, false);
   result.hideFlags(UnityEngine::HideFlags::HideAndDontSave);
 
   Unity::Collections::NativeArray1<std::uint8_t> textureData =
@@ -83,7 +84,7 @@ TextureLoader::loadTexture(const CesiumGltf::ImageCesium& image) {
   size_t textureLength = textureData.Length();
   assert(textureLength >= image.pixelData.size());
 
-  if (!useMipMaps) {
+  if (image.mipPositions.empty()) {
     // No mipmaps, copy the whole thing and then let Unity generate mipmaps on a
     // worker thread.
     std::memcpy(pixels, image.pixelData.data(), image.pixelData.size());


### PR DESCRIPTION
Depends on CesiumGS/cesium-native#682 so merge that first
Fixes #346 

When cesium-native provided a `mipPositions` array with fewer than the total number of mip levels that could be present, the remaining ones were left uninitialized. With this PR, whatever mip levels are provided are used.
