### PR TITLE
Add support for Universal Windows Platform (UWP) / Holo Lens 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
           submodules: recursive
       - name: Install nasm
         uses: ilammy/setup-nasm@v1.4.0
+      - name: Install Visual Studio UWP support
+        run: |
+          choco install -y visualstudio2022-workload-universal
       - name: Install Unity UWP support
         run: |
           start -FilePath "C:\Program Files\Unity Hub\Unity Hub.exe" -ArgumentList "-- --headless install-modules --version 2021.3.13f1 --changeset 9e7d58001ecf --module universal-windows-platform uwp-il2cpp" -Wait

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ilammy/setup-nasm@v1.4.0
       - name: Install Visual Studio UWP support
         run: |
-          choco install -y visualstudio2019-workload-universal --params "--add Microsoft.VisualStudio.ComponentGroup.UWP.VC"
+          choco install -y visualstudio2019-workload-universal --params "--add Microsoft.VisualStudio.ComponentGroup.UWP.VC --add Microsoft.VisualStudio.Component.Windows11SDK.22000"
       - name: Install Unity UWP support
         run: |
           start -FilePath "C:\Program Files\Unity Hub\Unity Hub.exe" -ArgumentList "-- --headless install-modules --version 2021.3.13f1 --changeset 9e7d58001ecf --module universal-windows-platform uwp-il2cpp" -Wait

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ilammy/setup-nasm@v1.4.0
       - name: Install Visual Studio UWP support
         run: |
-          choco install -y visualstudio2022-workload-universal
+          choco install -y visualstudio2019-workload-universal
       - name: Install Unity UWP support
         run: |
           start -FilePath "C:\Program Files\Unity Hub\Unity Hub.exe" -ArgumentList "-- --headless install-modules --version 2021.3.13f1 --changeset 9e7d58001ecf --module universal-windows-platform uwp-il2cpp" -Wait

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ilammy/setup-nasm@v1.4.0
       - name: Install Unity UWP support
         run: |
-          start -FilePath "C:\Program Files\Unity Hub\Unity Hub.exe" -ArgumentList "-- --headless install-modules --version 2021.3.13f1 --changeset 9e7d58001ecf --module universal-windows-platform"
+          start -FilePath "C:\Program Files\Unity Hub\Unity Hub.exe" -ArgumentList "-- --headless install-modules --version 2021.3.13f1 --changeset 9e7d58001ecf --module universal-windows-platform uwp-il2cpp" -Wait
       - name: Create SSH tunnel to Unity License Server
         env:
           UNITY_LICENSE_SERVER_SSH_KEY: ${{ secrets.UNITY_LICENSE_SERVER_SSH_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
           submodules: recursive
       - name: Install nasm
         uses: ilammy/setup-nasm@v1.4.0
+      - name: Install Unity UWP support
+        run: |
+          start -FilePath "C:\Program Files\Unity Hub\Unity Hub.exe" -ArgumentList "-- --headless install-modules --version 2021.3.13f1 --changeset 9e7d58001ecf --module universal-windows-platform"
       - name: Create SSH tunnel to Unity License Server
         env:
           UNITY_LICENSE_SERVER_SSH_KEY: ${{ secrets.UNITY_LICENSE_SERVER_SSH_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ilammy/setup-nasm@v1.4.0
       - name: Install Visual Studio UWP support
         run: |
-          choco install -y visualstudio2019-workload-universal
+          choco install -y visualstudio2019-workload-universal --params "--add Microsoft.VisualStudio.ComponentGroup.UWP.VC"
       - name: Install Unity UWP support
         run: |
           start -FilePath "C:\Program Files\Unity Hub\Unity Hub.exe" -ArgumentList "-- --headless install-modules --version 2021.3.13f1 --changeset 9e7d58001ecf --module universal-windows-platform uwp-il2cpp" -Wait

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,12 +24,6 @@ jobs:
           submodules: recursive
       - name: Install nasm
         uses: ilammy/setup-nasm@v1.4.0
-      - name: Install Visual Studio UWP support
-        run: |
-          choco install -y visualstudio2019-workload-universal --params "--add Microsoft.VisualStudio.ComponentGroup.UWP.VC --add Microsoft.VisualStudio.Component.Windows11SDK.22000"
-      - name: Install Unity UWP support
-        run: |
-          start -FilePath "C:\Program Files\Unity Hub\Unity Hub.exe" -ArgumentList "-- --headless install-modules --version 2021.3.13f1 --changeset 9e7d58001ecf --module universal-windows-platform uwp-il2cpp" -Wait
       - name: Create SSH tunnel to Unity License Server
         env:
           UNITY_LICENSE_SERVER_SSH_KEY: ${{ secrets.UNITY_LICENSE_SERVER_SSH_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
           # Store temp files on the D drive, which is much faster than the EBS-backed C drive.
           $ENV:TEMP="d:\cesium\temp"
           dotnet run --project Build~
+          cat D:\cesium\CesiumForUnityBuildProject\Packages\com.cesium.unity\native~\build-WSA-x86_64\build.log
           dir d:\cesium\CesiumForUnityBuildProject
       - name: Publish package artifact
         if: ${{ success() }}

--- a/Build~/Package.cs
+++ b/Build~/Package.cs
@@ -144,6 +144,23 @@ namespace Build
 
                 if (OperatingSystem.IsWindows())
                 {
+                    // TODO: we're currently only building for UWP on Windows. This should be an option, or a separate build command.
+                    Console.WriteLine("**** Compiling for Universal Windows Platform Player");
+                    unity.Run(new[]
+                    {
+                        "-batchmode",
+                        "-nographics",
+                        "-projectPath",
+                        Utility.ProjectRoot,
+                        "-buildTarget",
+                        "WindowsStoreApps",
+                        "-executeMethod",
+                        "CesiumForUnity.BuildCesiumForUnity.CompileForUWPAndExit"
+                    });
+
+                    Console.WriteLine("**** Adding generated files (for the UWP Player) to the package");
+                    AddGeneratedFiles("!UNITY_EDITOR && UNITY_WSA", generatedRuntimePath, Path.Combine(outputPackagePath, "Runtime", "generated"));
+
                     Console.WriteLine("**** Compiling for Windows Player");
                     unity.Run(new[]
                     {

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Additions :tada:
+
+- Added support for Universal Windows Platform (UWP), which is required to build applications for the Holo Lens 2.
+
 ### v1.5.0 - 2023-08-01
 
 ##### Fixes :wrench:

--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -6,7 +6,7 @@ This is a summary of the setup and workflows for developers who want to modify t
 
 ### Prerequisites
 
-* CMake v3.15 or later (the latest version is recommended)
+* CMake v3.18 or later (the latest version is recommended)
 * [.NET SDK v6.0 or later](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
 * If you're using Visual Studio, you need Visual Studio 2022.
 * Unity 2021.3+ (the latest version of the Unity 2021.3 LTS release is recommended)

--- a/Editor/BuildCesiumForUnity.cs
+++ b/Editor/BuildCesiumForUnity.cs
@@ -44,6 +44,22 @@ namespace CesiumForUnity
             EditorApplication.Exit(0);
         }
 
+        public static void CompileForUWPAndExit()
+        {
+            string buildPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(buildPath);
+            try
+            {
+                PlayerSettings.SetScriptingBackend(BuildTargetGroup.WSA, ScriptingImplementation.IL2CPP);
+                BuildPlayer(BuildTargetGroup.WSA, BuildTarget.WSAPlayer, Path.Combine(buildPath, "UWP"));
+            }
+            finally
+            {
+                Directory.Delete(buildPath, true);
+            }
+            EditorApplication.Exit(0);
+        }
+
         public static void CompileForIOSAndExit()
         {
             string buildPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());

--- a/Editor/ConfigureReinterop.cs
+++ b/Editor/ConfigureReinterop.cs
@@ -22,6 +22,8 @@ namespace CesiumForUnity
         public const string CppOutputPath = "../native~/Editor/generated-Android";
 #elif UNITY_IOS
         public const string CppOutputPath = "../native~/Editor/generated-iOS";
+#elif UNITY_WSA
+        public const string CppOutputPath = "../native~/Runtime/generated-WSA";
 #elif UNITY_64
         public const string CppOutputPath = "../native~/Editor/generated-Standalone";
 #else

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -30,6 +30,8 @@ namespace CesiumForUnity
         public const string CppOutputPath = "../native~/Runtime/generated-Android";
 #elif UNITY_IOS
         public const string CppOutputPath = "../native~/Runtime/generated-iOS";
+#elif UNITY_WSA
+        public const string CppOutputPath = "../native~/Runtime/generated-WSA";
 #elif UNITY_64
         public const string CppOutputPath = "../native~/Runtime/generated-Standalone";
 #else

--- a/native~/CMakeLists.txt
+++ b/native~/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.18)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 project(CesiumForUnityNative
@@ -28,6 +28,19 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(BUILD_SHARED_LIB OFF)
 set( SUPPORT_CONSOLE_APP OFF)
 add_subdirectory(extern/tidy-html5 EXCLUDE_FROM_ALL)
+
+# Patch tidy-html5's sprtf.c to work on UWP. UWP doesn't have lstrlen, but
+# it's totally unnecessary because simply passing -1 as the length will do the same thing.
+# So just swap in the -1.
+if (${CMAKE_SYSTEM_NAME} MATCHES "WindowsStore")
+  get_target_property(tidySources tidy-static "SOURCES")
+  list(REMOVE_ITEM tidySources "src/sprtf.c")
+  file(READ "extern/tidy-html5/src/sprtf.c" sprtSource)
+  string(REPLACE "int len = (int)lstrlen(ps);" "int len = -1;" sprtSource "${sprtSource}")
+  file(CONFIGURE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/extern/tidy-html5/sprtf.c" CONTENT "${sprtSource}")
+  list(APPEND tidySources "${CMAKE_CURRENT_BINARY_DIR}/extern/tidy-html5/sprtf.c")
+  set_target_properties(tidy-static PROPERTIES "SOURCES" "${tidySources}")
+endif()
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Android")
   set(HTTPLIB_USE_OPENSSL_IF_AVAILABLE OFF)


### PR DESCRIPTION
It supports both ARM64 and x64 processors. UWP apps can be run on normal Windows and distributed on the Windows Store, as well.

Some notes / setup instructions:

1. Add "Universal Windows Platform Build Support" to your Unity version via the Unity Hub.
2. Add the "Universal Windows Platform Development" workload to Visual Studio using its installer.
3. Add the "C++ (v143) Universal Windows Platform tools" optional component. (if you're using VS2019 it will be v142 instead of v143)
4. The "Architecture" dropdown in the Universal Windows Platform Build Settings doesn't seem to actually matter. The native code is build for both x64 and ARM64. 32-bit platforms aren't supported. The Visual Studio solution generated by Unity can be used to build for either platform, regardless of what was selected here.
5. Be sure that the `InternetClient` Capability is enabled under Project Settings -> Player -> Universal Windows Platform tab -> Capabilities. Otherwise, we won't be able to load tilesets from the internet.
