### PR TITLE
Add ComputeLoadProgress to C# Cesium3DTileset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Additions :tada:
+
+- Added `ComputeLoadProgress` function to estimate the percentage of the 3D tileset that has been loaded for the current view.
+
 ### v1.5.0 - 2023-08-01
 
 ##### Fixes :wrench:

--- a/Runtime/Cesium3DTileset.cs
+++ b/Runtime/Cesium3DTileset.cs
@@ -650,6 +650,14 @@ namespace CesiumForUnity
             }
         }
 
+        /// <summary>
+        /// Estimate the percentage of the tiles for the current view that have been loaded. 
+        /// </summary>
+        /// <returns>
+        /// A float value between 0 and 100 representing the load progress.
+        /// </returns>
+        public partial float ComputeLoadProgress();
+
         private partial void SetShowCreditsOnScreen(bool value);
 
         private partial void Start();

--- a/native~/Runtime/src/Cesium3DTilesetImpl.cpp
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.cpp
@@ -328,10 +328,10 @@ void Cesium3DTilesetImpl::FocusTileset(
 
 float Cesium3DTilesetImpl::ComputeLoadProgress(
     const DotNet::CesiumForUnity::Cesium3DTileset& tileset) {
-      if(getTileset() == nullptr){
-        return 0;
-      }
-      return getTileset()->computeLoadProgress();
+  if (getTileset() == nullptr) {
+    return 0;
+  }
+  return getTileset()->computeLoadProgress();
 }
 
 Tileset* Cesium3DTilesetImpl::getTileset() { return this->_pTileset.get(); }

--- a/native~/Runtime/src/Cesium3DTilesetImpl.cpp
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.cpp
@@ -326,6 +326,14 @@ void Cesium3DTilesetImpl::FocusTileset(
 #endif
 }
 
+float Cesium3DTilesetImpl::ComputeLoadProgress(
+    const DotNet::CesiumForUnity::Cesium3DTileset& tileset) {
+      if(getTileset() == nullptr){
+        return 0;
+      }
+      return getTileset()->computeLoadProgress();
+}
+
 Tileset* Cesium3DTilesetImpl::getTileset() { return this->_pTileset.get(); }
 
 const Tileset* Cesium3DTilesetImpl::getTileset() const {

--- a/native~/Runtime/src/Cesium3DTilesetImpl.h
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.h
@@ -40,7 +40,8 @@ public:
   void RecreateTileset(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
   void FocusTileset(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
 
-  float ComputeLoadProgress(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
+  float
+  ComputeLoadProgress(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
 
   Cesium3DTilesSelection::Tileset* getTileset();
   const Cesium3DTilesSelection::Tileset* getTileset() const;

--- a/native~/Runtime/src/Cesium3DTilesetImpl.h
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.h
@@ -40,6 +40,8 @@ public:
   void RecreateTileset(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
   void FocusTileset(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
 
+  float ComputeLoadProgress(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
+
   Cesium3DTilesSelection::Tileset* getTileset();
   const Cesium3DTilesSelection::Tileset* getTileset() const;
 


### PR DESCRIPTION
Added ComputeLoadProgress function to estimate the percentage of the 3D tileset that has been loaded for the current view.

Example code on how to compute the time it takes for a tileset to load:

```using UnityEngine;
using CesiumForUnity;
using System.Diagnostics;

public class PerformanceTesting : MonoBehaviour
{
    Cesium3DTileset _tileset;
    public UnityEngine.UI.Text text;
    Stopwatch stopwatch = Stopwatch.StartNew();
    long elapsedTimeInMilliseconds = 0;
    bool finished = false;

    private void Start()
    {
        _tileset = this.GetComponent<Cesium3DTileset>();
    }
    void Update()
    {
        float loadProgress = _tileset.ComputeLoadProgress();
        if(loadProgress != 100.0f)
        {
            finished = false;
        }
        else if(!finished && loadProgress == 100.0f)
        {
            finished = true;
            elapsedTimeInMilliseconds = stopwatch.ElapsedMilliseconds;
        }
        text.text = "Time taken to load: " + elapsedTimeInMilliseconds + "\n";
    }
}
```