### PR TITLE
Add missing check for ETC1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug that prevented building on iOS.
+- Fixed a bug where KTX tilesets did not display properly on iOS devices due to a missing check for ETC1 texture format.
 
 ### v1.5.0 - 2023-08-01
 

--- a/native~/Runtime/src/Cesium3DTilesetImpl.cpp
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.cpp
@@ -434,6 +434,10 @@ void Cesium3DTilesetImpl::LoadTileset(
       DotNet::UnityEngine::Experimental::Rendering::GraphicsFormat::
           RGBA_ETC2_SRGB,
       DotNet::UnityEngine::Experimental::Rendering::FormatUsage::Sample);
+  supportedFormats.ETC1_RGB = UnityEngine::SystemInfo::IsFormatSupported(
+      DotNet::UnityEngine::Experimental::Rendering::GraphicsFormat::
+          RGB_ETC_UNorm,
+      DotNet::UnityEngine::Experimental::Rendering::FormatUsage::Sample);
   supportedFormats.BC1_RGB = DotNet::UnityEngine::SystemInfo::IsFormatSupported(
       DotNet::UnityEngine::Experimental::Rendering::GraphicsFormat::
           RGBA_DXT1_SRGB,


### PR DESCRIPTION
Fixed a bug where KTX tilesets did not display properly on iOS devices due to a missing check for ETC1 texture format.