### PR TITLE
Convert to generic Resources.Load calls for Texture2D

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that prevented editor windows from functioning when `com.unity.vectorgraphics` package was installed.
+
 ### v1.6.0
 
 ##### Additions :tada:

--- a/Editor/CesiumEditorStyle.cs
+++ b/Editor/CesiumEditorStyle.cs
@@ -45,7 +45,7 @@ namespace CesiumForUnity
 
         private static Texture2D LoadImage(string resourcePath)
         {
-            Texture2D icon = (Texture2D)Resources.Load(resourcePath);
+            Texture2D icon = Resources.Load<Texture2D>(resourcePath);
             icon.wrapMode = TextureWrapMode.Clamp;
 
             return icon;

--- a/Editor/CesiumEditorWindow.cs
+++ b/Editor/CesiumEditorWindow.cs
@@ -29,7 +29,7 @@ namespace CesiumForUnity
         void OnEnable()
         {
             // Load the icon separately from the other resources.
-            Texture2D icon = (Texture2D)Resources.Load("Cesium-64x64");
+            Texture2D icon = Resources.Load<Texture2D>("Cesium-64x64");
             icon.wrapMode = TextureWrapMode.Clamp;
             this.titleContent = new GUIContent("Cesium", icon);
 

--- a/Editor/CesiumIonAssetsWindow.cs
+++ b/Editor/CesiumIonAssetsWindow.cs
@@ -35,7 +35,7 @@ namespace CesiumForUnity
         private void OnEnable()
         { 
             // Load the icon separately from the other resources.
-            Texture2D icon = (Texture2D)Resources.Load("Cesium-64x64");
+            Texture2D icon = Resources.Load<Texture2D>("Cesium-64x64");
             icon.wrapMode = TextureWrapMode.Clamp;
             this.titleContent = new GUIContent("Cesium ion Assets", icon);
 


### PR DESCRIPTION
Swapped out the manual casts in the `Resources.Load` calls for their generic equivalent so that Unity won't try to pick an invalid `Texture2D` with the same name.

This case arose when using the [com.unity.vectorgraphics](https://docs.unity3d.com/Packages/com.unity.vectorgraphics@2.0/manual/index.html) package. As I understand it, the Vector Graphics package overwrites the import type of `.svg` files and they are no longer able to be cast to `Texture2D`. This was causing a few of the Cesium editors to throw exceptions and not render anything to the inspector. By using the generic version of `Resources.Load` Unity will pick valid `Texture2D` (in this case, the `.png` files rather than the `.svg`).