### PR TITLE
Build XCode project as part of the build process

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Build the XCode project and verify it for errors during the iOS building proces. This ensures the iOS plugin from CI has all the required libraries.
+
 ### v1.6.1 - 2023-09-03
 
 ##### Fixes :wrench:

--- a/Editor/BuildCesiumForUnity.cs
+++ b/Editor/BuildCesiumForUnity.cs
@@ -67,7 +67,7 @@ namespace CesiumForUnity
             try
             {
                 BuildPlayer(BuildTargetGroup.iOS, BuildTarget.iOS, Path.Combine(buildPath, "iOS"), false);
-                // Check that XCode project is able to build
+                // Check that the XCode project is able to build
                 System.Diagnostics.Process p = System.Diagnostics.Process.Start("xcodebuild",
                   $"-project {Path.Combine(buildPath, "iOS/game/Unity-iPhone.xcodeproj")} CODE_SIGNING_ALLOWED=NO");
                 p.WaitForExit();

--- a/Editor/BuildCesiumForUnity.cs
+++ b/Editor/BuildCesiumForUnity.cs
@@ -66,10 +66,18 @@ namespace CesiumForUnity
             Directory.CreateDirectory(buildPath);
             try
             {
-                BuildPlayer(BuildTargetGroup.iOS, BuildTarget.iOS, Path.Combine(buildPath, "iOS"));
+                BuildPlayer(BuildTargetGroup.iOS, BuildTarget.iOS, Path.Combine(buildPath, "iOS"), false);
+                // Check that XCode project is able to build
+                System.Diagnostics.Process p = System.Diagnostics.Process.Start("xcodebuild",
+                  $"-project {Path.Combine(buildPath, "iOS/game/Unity-iPhone.xcodeproj")} CODE_SIGNING_ALLOWED=NO");
+                p.WaitForExit();
+                if (p.ExitCode != 0)
+                    throw new Exception("xcodebuild failed");
             }
             finally
             {
+                if (Directory.Exists(Path.Combine(buildPath, "iOS")))
+                    Directory.Delete(Path.Combine(buildPath, "iOS"), true);
                 Directory.Delete(buildPath, true);
             }
             EditorApplication.Exit(0);
@@ -130,7 +138,7 @@ namespace CesiumForUnity
             };
         }
 
-        private static void BuildPlayer(BuildTargetGroup targetGroup, BuildTarget target, string outputPath)
+        private static void BuildPlayer(BuildTargetGroup targetGroup, BuildTarget target, string outputPath, bool deleteProject = true)
         {
             BuildReport report = BuildPipeline.BuildPlayer(new BuildPlayerOptions()
             {
@@ -161,7 +169,7 @@ namespace CesiumForUnity
             }
 
             // We don't actually need the built project; delete it.
-            if (Directory.Exists(outputPath))
+            if (deleteProject && Directory.Exists(outputPath))
                 Directory.Delete(outputPath, true);
         }
     }

--- a/native~/CMakeLists.txt
+++ b/native~/CMakeLists.txt
@@ -65,6 +65,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "iOS")
     set (ALL_TARGETS
         CesiumForUnityNative-Runtime
         Async++
+        Cesium3DTilesReader
         Cesium3DTilesSelection
         CesiumAsync
         CesiumGeospatial


### PR DESCRIPTION
Fixes #362 and #357

As part of the iOS building process, build the XCode project and ensure no errors. This ensures the iOS plugin from CI is not missing any libraries.