### PR TITLE
Fix Mac Standalone

### DIFF
--- a/Editor/CompileCesiumForUnityNative.cs
+++ b/Editor/CompileCesiumForUnityNative.cs
@@ -154,7 +154,8 @@ namespace CesiumForUnity
             if (library.Platform == BuildTarget.Android ||
                 library.Platform == BuildTarget.StandaloneOSX)
             {
-                importer.SetPlatformData(library.Platform, "CPU", library.Cpu == LibraryCpuArchitecture.ARM64 ? "ARM64" : null);
+                if(library.Cpu != null)
+                    importer.SetPlatformData(library.Platform, "CPU", library.Cpu.ToString());
             }
             else if (library.Platform == BuildTarget.WSAPlayer)
             {


### PR DESCRIPTION
This code fixes the issue here https://community.cesium.com/t/missing-dlls-in-osx-standalone-il2cpp-builds/26714.