### PR TITLE
Make the project compatible with OSX 10.13

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Made the project compatible with OSX 10.13 and greater by setting the `CMAKE_OSX_DEPLOYMENT_TARGET` variable to `10.13`.
+
 ### v1.6.2 - 2023-09-20
 
 ##### Fixes :wrench:

--- a/Editor/CompileCesiumForUnityNative.cs
+++ b/Editor/CompileCesiumForUnityNative.cs
@@ -344,6 +344,8 @@ namespace CesiumForUnity
             {
                 if (cpu != null)
                     library.ExtraConfigureArgs.Add("-DCMAKE_OSX_ARCHITECTURES=" + cpu.ToString().ToLowerInvariant());
+
+                library.ExtraConfigureArgs.Add("-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13");
             }
 
             if (platform.platform == BuildTarget.WSAPlayer)


### PR DESCRIPTION
Fixes #367 

Sets the `CMAKE_OSX_DEPLOYMENT_TARGET` variable to `10.13`, which is similar to how Unreal does it:

```
cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15
```

The build command now looks like:

```
cmake -B /Users/josephkaile/dev-base/cesium-unity-samples/Packages/com.cesium.unity/native~/build-Standalone-x86_64 -S /Users/josephkaile/dev-base/cesium-unity-samples/Packages/com.cesium.unity/native~ -DEDITOR=false -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="/Users/josephkaile/dev-base/cesium-unity-samples/Packages/com.cesium.unity/Plugins/Standalone/x86_64" -DREINTEROP_GENERATED_DIRECTORY=generated-Standalone -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13

cmake -B /Users/josephkaile/dev-base/cesium-unity-samples/Packages/com.cesium.unity/native~/build-Standalone-arm64 -S /Users/josephkaile/dev-base/cesium-unity-samples/Packages/com.cesium.unity/native~ -DEDITOR=false -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="/Users/josephkaile/dev-base/cesium-unity-samples/Packages/com.cesium.unity/Plugins/Standalone/arm64" -DREINTEROP_GENERATED_DIRECTORY=generated-Standalone -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
```
