### PR TITLE
Fix generated code problems with nullable primitive return values

### DIFF
--- a/Reinterop~/CppType.cs
+++ b/Reinterop~/CppType.cs
@@ -51,7 +51,7 @@ namespace Reinterop
             if (named != null && named.Name == "Nullable" && named.TypeArguments.Length == 1)
             {
                 CppType nullabledType = CppType.FromCSharp(context, named.TypeArguments[0]);
-                if (nullabledType.Kind == InteropTypeKind.BlittableStruct)
+                if (nullabledType.Kind == InteropTypeKind.BlittableStruct || nullabledType.Kind == InteropTypeKind.Primitive)
                     return new CppType(InteropTypeKind.Nullable, new[] {"std"}, "optional", new[] { nullabledType }, 0, "<optional>");
             }
 
@@ -463,6 +463,7 @@ namespace Reinterop
                     return $"::std::uint32_t({variableName})";
                 case InteropTypeKind.EnumFlags:
                     return $"{variableName}.underlying_value()";
+                case InteropTypeKind.Primitive:
                 case InteropTypeKind.BlittableStruct:
                     if (this.Flags.HasFlag(CppTypeFlags.Reference))
                         return $"&{variableName}";
@@ -473,7 +474,6 @@ namespace Reinterop
                         return $"{variableName}.has_value() ? &{variableName}.value() : nullptr";
                     else
                         return variableName;
-                case InteropTypeKind.Primitive:
                 case InteropTypeKind.Unknown:
                 default:
                     return variableName;

--- a/Reinterop~/Interop.cs
+++ b/Reinterop~/Interop.cs
@@ -81,7 +81,7 @@ namespace Reinterop
             CSharpType csReturnType = CSharpType.FromSymbol(context, returnType);
             CSharpType csInteropReturnType = csReturnType.AsInteropTypeReturn();
 
-            // Rewrite methods that return a blittable struct to instead taking a pointer to one.
+            // Rewrite methods that return a blittable struct to instead take a pointer to one.
             // See Interop.RewriteStructReturn in this file for the C++ side of this and more
             // explanation of why it's needed.
             bool hasStructRewrite = false;
@@ -600,7 +600,9 @@ namespace Reinterop
 
                 return true;
             }
-            else if (returnType.Kind == InteropTypeKind.Nullable && interopReturnType.Kind == InteropTypeKind.BlittableStruct)
+            else if (returnType.Kind == InteropTypeKind.Nullable &&
+                     (interopReturnType.Kind == InteropTypeKind.BlittableStruct ||
+                      interopReturnType.Kind == InteropTypeKind.Primitive))
             {
                 CppType originalInteropReturnType = interopReturnType;
                 interopReturnType = CppType.UInt8;


### PR DESCRIPTION
As a test, I added the following to `Runtime/Helpers.cs`:

```csharp
public static bool? TestThing()
{
    return null;
}
```

And the following to `Runtime/ConfigureReinterop.cs`:

```csharp
Helpers.TestThing();
```

Reinterop generated invalid code for this. After this PR, the code is generated correctly. We previously handled nullable blittable structs, but not nullable primitives.