### PR TITLE
Use AssetDatabase.LoadAssetAtPath instead of Resources.Load in Editor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v1.7.1 - 2023-12-14
+
+##### Fixes :wrench:
+
+- Fixed a bug that prevented the default `CesiumIonServer` asset from remembering its token in a clean project.
+
 ### v1.7.0 - 2023-12-14
 
 ##### Additions :tada:

--- a/Runtime/CesiumIonServer.cs
+++ b/Runtime/CesiumIonServer.cs
@@ -65,7 +65,13 @@ namespace CesiumForUnity
         {
             get
             {
+#if UNITY_EDITOR
+                CesiumIonServer result = AssetDatabase.LoadAssetAtPath(
+                    "Assets/CesiumSettings/Resources/CesiumIonServers/ion.cesium.com.asset",
+                    typeof(CesiumIonServer)) as CesiumIonServer;
+#else
                 CesiumIonServer result = Resources.Load<CesiumIonServer>("CesiumIonServers/ion.cesium.com");
+#endif
 
 #if UNITY_EDITOR
                 if (result == null)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.cesium.unity",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "displayName": "Cesium for Unity",
   "description": "Cesium for Unity brings the 3D geospatial ecosystem to Unity. By combining a high-accuracy full-scale WGS84 globe, open APIs and open standards for spatial indexing such as 3D Tiles, and cloud-based real-world content from [Cesium ion](https://cesium.com/cesium-ion) with Unity, this plugin enables 3D geospatial workflows and applications in Unity.",
   "license": "Apache-2.0",


### PR DESCRIPTION
After releasing Cesium for Unity v1.7.0, I did a final test with a clean Cesium for Unity Samples project, and found no Cesium ion assets could load because the project default token was blank. And in fact, Unity had modified the `ion.cesium.com.asset` file to _remove_ the token. If I set the token again, it would be remembered. But this seemed to happen via modification to non-committed files in the Library directory, so I couldn't make the Samples project work out of the box. 🤕

Though I can't completely explain it, the problem appeared to be that `Resources.Load<CesiumIonServer>("CesiumIonServers/ion.cesium.com")` was returning null the first time, even though the asset file existed on disk. `CesiumRuntimeSettings` uses an alternate method to load an asset in the Editor (`AssetDatabase.LoadAssetAtPath`), and I guess I just learned why. After making `CesiumIonServer` do the same, the problem goes away. So that's what this PR does, and here comes v1.7.1.
