### PR TITLE
Modify CesiumSubScene to use parent CesiumGeoreference's coordinates when added in-editor.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug that prevented the default `CesiumIonServer` asset from remembering its token in a clean project.
+- Fixed a bug where adding a `CesiumSubScene` as the child of an existing `CesiumGeoreference` in editor would cause the parent `CesiumGeoreference` to have its coordinates reset to the default.
 
 ### v1.7.0 - 2023-12-14
 

--- a/EditorTests.meta
+++ b/EditorTests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ee37edb25779c4544b705b2954c45f15
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EditorTests/CesiumEditorTests.asmdef
+++ b/EditorTests/CesiumEditorTests.asmdef
@@ -1,0 +1,25 @@
+{
+    "name": "CesiumEditorTests",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "CesiumRuntime",
+        "Unity.Mathematics"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/EditorTests/CesiumEditorTests.asmdef.meta
+++ b/EditorTests/CesiumEditorTests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8065b9c90ecacd44ca0906e38b93ca37
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EditorTests/TestCesiumSubScene.cs
+++ b/EditorTests/TestCesiumSubScene.cs
@@ -1,0 +1,55 @@
+using CesiumForUnity;
+using NUnit.Framework;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class TestCesiumSubScene
+{
+    [UnityTest]
+    public IEnumerator AddingSubSceneCopiesGeoreferenceCoordinates()
+    {
+        GameObject goGeoreference = new GameObject("Georeference");
+        CesiumGeoreference georeference = goGeoreference.AddComponent<CesiumGeoreference>();
+        georeference.SetOriginLongitudeLatitudeHeight(-55.0, 55.0, 1000.0);
+
+        GameObject goSubScene = new GameObject("SubScene");
+        goSubScene.transform.parent = goGeoreference.transform;
+        CesiumSubScene subScene = goSubScene.AddComponent<CesiumSubScene>();
+
+        yield return null;
+
+        Assert.AreEqual(-55.0, georeference.longitude);
+        Assert.AreEqual(55.0, georeference.latitude);
+        Assert.AreEqual(1000.0, georeference.height);
+        Assert.AreEqual(georeference.longitude, subScene.longitude);
+        Assert.AreEqual(georeference.latitude, subScene.latitude);
+        Assert.AreEqual(georeference.height, subScene.height);
+    }
+
+    [UnityTest]
+    public IEnumerator ModifyingSubsceneModifiesParentGeoreference()
+    {
+        GameObject goGeoreference = new GameObject("Georeference");
+        CesiumGeoreference georeference = goGeoreference.AddComponent<CesiumGeoreference>();
+        georeference.SetOriginLongitudeLatitudeHeight(-55.0, 55.0, 1000.0);
+
+        GameObject goSubScene = new GameObject("SubScene");
+        goSubScene.transform.parent = goGeoreference.transform;
+        CesiumSubScene subScene = goSubScene.AddComponent<CesiumSubScene>();
+
+        yield return null;
+
+        subScene.SetOriginLongitudeLatitudeHeight(-10.0, 10.0, 100.0);
+
+        yield return null;
+
+        Assert.AreEqual(subScene.longitude, -10.0);
+        Assert.AreEqual(subScene.latitude, 10.0);
+        Assert.AreEqual(subScene.height, 100.0);
+
+        Assert.AreEqual(georeference.longitude, -10.0);
+        Assert.AreEqual(georeference.latitude, 10.0);
+        Assert.AreEqual(georeference.height, 100.0);
+    }
+}

--- a/EditorTests/TestCesiumSubScene.cs.meta
+++ b/EditorTests/TestCesiumSubScene.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b77912debd15cc948b79e3db7086440a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/CesiumSubScene.cs
+++ b/Runtime/CesiumSubScene.cs
@@ -367,7 +367,7 @@ namespace CesiumForUnity
 
             // Update our origin to our parent georef, maintain our origin authority,
             // and copy both sets of reference coordinates. No need to calculate any of this again
-            CopyParentCoordinates();
+            this.CopyParentCoordinates();
         }
 
         private void OnDisable()


### PR DESCRIPTION
Fixes #343.

When `CesiumSubScene::OnEnable` is called, it sets the coordinates of the parent `CesiumGeoreference` to the coordinates it has set. This means when adding a new `CesiumSubScene` component as a child of an existing `CesiumGeoreference`, it would reset the coordinates of the parent to the default coordinates. This change uses the `Reset` event to restore the georeference's original coordinates without changing the behavior outside of the editor.