### PR TITLE
Fix warning when adding new DynamicCamera in the editor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug that prevented the default `CesiumIonServer` asset from remembering its token in a clean project.
+- Fixed "DynamicCamera is not nested inside a game object with a CesiumGeoreference" warning when adding a new DynamicCamera in the editor.
 
 ### v1.7.0 - 2023-12-14
 

--- a/Editor/CesiumEditorUtility.cs
+++ b/Editor/CesiumEditorUtility.cs
@@ -329,9 +329,8 @@ namespace CesiumForUnity
 
             GameObject dynamicCameraPrefab = Resources.Load<GameObject>("DynamicCamera");
             GameObject dynamicCameraObject =
-                UnityEngine.Object.Instantiate(dynamicCameraPrefab);
+                UnityEngine.Object.Instantiate(dynamicCameraPrefab, georeference.gameObject.transform);
             dynamicCameraObject.name = "DynamicCamera";
-            dynamicCameraObject.transform.parent = georeference.gameObject.transform;
 
             Undo.RegisterCreatedObjectUndo(dynamicCameraObject, "Create DynamicCamera");
 


### PR DESCRIPTION
Fixes #321.

When adding a new DynamicCamera from the Cesium editor utility, it would pop up a warning that the camera wasn't parented to a `CesiumGeoreference` despite this being the case. By using the overload of `Object.Instantiate` that supports specifying the new object's parent transform, the DynamicCamera's parent will be set by the time it initializes, avoiding this warning.