### PR TITLE
Use Delayed input fields for `CesiumGeoreference` editor

### DIFF
--- a/Editor/CesiumGeoreferenceEditor.cs
+++ b/Editor/CesiumGeoreferenceEditor.cs
@@ -140,7 +140,8 @@ namespace CesiumForUnity
                 this._latitude,
                 -90.0,
                 90.0,
-                latitudeContent);
+                latitudeContent,
+                delayed: true);
 
             GUIContent longitudeContent = new GUIContent(
                 "Longitude",
@@ -149,7 +150,8 @@ namespace CesiumForUnity
                  this._longitude,
                  -180.0,
                  180.0,
-                 longitudeContent);
+                 longitudeContent,
+                 delayed: true);
 
             GUIContent heightContent = new GUIContent(
                 "Height",

--- a/Editor/CesiumInspectorGUI.cs
+++ b/Editor/CesiumInspectorGUI.cs
@@ -1,6 +1,5 @@
 ﻿
 using System;
-using System.Text.RegularExpressions;
 using Unity.Mathematics;
 using UnityEditor;
 using UnityEngine;
@@ -139,13 +138,21 @@ namespace CesiumForUnity
         }
 
         public static void ClampedDoubleField(
-            SerializedProperty property, double min, double max, GUIContent label)
+            SerializedProperty property, double min, double max, GUIContent label, bool delayed = false)
         {
             // SerializedPropertyType.Float is used for both float and double;
             // SerializedPropertyType.Double does not exist.
             if (property.propertyType == SerializedPropertyType.Float)
             {
-                double value = EditorGUILayout.DoubleField(label, property.doubleValue);
+                double value;
+                if (delayed)
+                {
+                    value = EditorGUILayout.DelayedDoubleField(label, property.doubleValue);
+                }
+                else
+                {
+                    value = EditorGUILayout.DoubleField(label, property.doubleValue);
+                }
                 property.doubleValue = Math.Clamp(value, min, max);
             }
             else

--- a/Runtime/CesiumGeoreference.cs
+++ b/Runtime/CesiumGeoreference.cs
@@ -1,6 +1,6 @@
+using Reinterop;
 using System;
 using System.Collections.Generic;
-using Reinterop;
 using Unity.Mathematics;
 using UnityEngine;
 
@@ -76,15 +76,19 @@ namespace CesiumForUnity
         private double _longitude = -105.25737;
 
         [SerializeField]
+        [Delayed]
         private double _height = 2250.0;
 
         [SerializeField]
+        [Delayed]
         private double _ecefX = 6378137.0;
 
         [SerializeField]
+        [Delayed]
         private double _ecefY = 0.0;
 
         [SerializeField]
+        [Delayed]
         private double _ecefZ = 0.0;
 
         [SerializeField]


### PR DESCRIPTION
Fixes #324.

This change uses `EditorGUI.DelayedDoubleField` and the `Delayed` attribute to reduce the number of updates when editing the properties of a `CesiumGeoreference` in the inspector.