### PR TITLE
Better activation radius gizmo for CesiumSubScene

### DIFF
--- a/Runtime/CesiumSubScene.cs
+++ b/Runtime/CesiumSubScene.cs
@@ -21,6 +21,11 @@ namespace CesiumForUnity
     [IconAttribute("Packages/com.cesium.unity/Editor/Resources/Cesium-24x24.png")]
     public class CesiumSubScene : MonoBehaviour
     {
+#if UNITY_EDITOR
+        // Caches the built-in sphere mesh across all CesiumSubScenes for use in OnDrawGizmos
+        private static Mesh _previewSphereMesh;
+#endif
+
         [SerializeField]
         private double _activationRadius = 1000;
 
@@ -442,9 +447,15 @@ namespace CesiumForUnity
         {
             if (this._showActivationRadius)
             {
-                // TODO: would be nice to draw a better wireframe sphere.
+                // Gizmos.DrawWireSphere only draws three wire circles representing the sphere's radii
+                // To do better, we need to fetch the built-in sphere mesh and use that
+                if (_previewSphereMesh == null)
+                {
+                    _previewSphereMesh = Resources.GetBuiltinResource<Mesh>("Sphere.fbx");
+                }
+
                 Gizmos.color = Color.blue;
-                Gizmos.DrawWireSphere(this.transform.position, (float)this._activationRadius);
+                Gizmos.DrawWireMesh(_previewSphereMesh, this.transform.position, Quaternion.identity, (float3)new double3(this._activationRadius, this._activationRadius, this._activationRadius));
             }
         }
 #endif


### PR DESCRIPTION
Closes #83.

`CesiumSubScene` currently uses `Gizmos.DrawWireSphere` to visualize the activation radius of the subscene. This doesn't help very much, since `Gizmos.DrawWireSphere` really only draws three wire circles representing the sphere's radii, and that's it. The simplest way to do better is to grab the built-in sphere mesh (the one that gets used when you create a sphere using `GameObject > 3D Object > Sphere`) and draw that in wireframe.