### PR TITLE
Fix UnityPrepareRendererResources trying to destroy texture assets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Removed the "Universal Additional Camera Data" script from DynamicCamera, as it shows up as a missing script in other render pipelines.
 - Fixed a bug where adding a `CesiumSubScene` as the child of an existing `CesiumGeoreference` in editor would cause the parent `CesiumGeoreference` to have its coordinates reset to the default.
 - Fixed the "DynamicCamera is not nested inside a game object with a CesiumGeoreference" warning when adding a new DynamicCamera in the editor.
+- Fixed "Destroying assets is not permitted to avoid data loss" error when using a custom opaque material with texture assets on a `Cesium3DTileset`.
 
 ### v1.7.1 - 2023-12-14
 

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -1191,7 +1191,8 @@ void* UnityPrepareRendererResources::prepareInMainThread(
               if (texCoordIndexIt != primitiveInfo.uvIndexMap.end()) {
                 UnityEngine::Texture texture =
                     TextureLoader::loadTexture(gltf, baseColorTexture->index);
-                texture.hideFlags(DotNet::UnityEngine::HideFlags::DontSave);
+                texture.hideFlags(
+                    DotNet::UnityEngine::HideFlags::HideAndDontSave);
                 if (texture != nullptr) {
                   material.SetTexture(
                       shaderProperty.getBaseColorTextureID(),
@@ -1211,7 +1212,8 @@ void* UnityPrepareRendererResources::prepareInMainThread(
               if (texCoordIndexIt != primitiveInfo.uvIndexMap.end()) {
                 UnityEngine::Texture texture =
                     TextureLoader::loadTexture(gltf, metallicRoughness->index);
-                texture.hideFlags(DotNet::UnityEngine::HideFlags::DontSave);
+                texture.hideFlags(
+                    DotNet::UnityEngine::HideFlags::HideAndDontSave);
                 if (texture != nullptr) {
                   material.SetTexture(
                       shaderProperty.getMetallicRoughnessTextureID(),
@@ -1232,7 +1234,8 @@ void* UnityPrepareRendererResources::prepareInMainThread(
               UnityEngine::Texture texture = TextureLoader::loadTexture(
                   gltf,
                   pMaterial->normalTexture->index);
-              texture.hideFlags(DotNet::UnityEngine::HideFlags::DontSave);
+              texture.hideFlags(
+                  DotNet::UnityEngine::HideFlags::HideAndDontSave);
               if (texture != nullptr) {
                 material.SetTexture(
                     shaderProperty.getNormalMapTextureID(),
@@ -1254,7 +1257,8 @@ void* UnityPrepareRendererResources::prepareInMainThread(
               UnityEngine::Texture texture = TextureLoader::loadTexture(
                   gltf,
                   pMaterial->occlusionTexture->index);
-              texture.hideFlags(DotNet::UnityEngine::HideFlags::DontSave);
+              texture.hideFlags(
+                  DotNet::UnityEngine::HideFlags::HideAndDontSave);
               if (texture != nullptr) {
                 material.SetTexture(
                     shaderProperty.getOcclusionTextureID(),
@@ -1291,7 +1295,8 @@ void* UnityPrepareRendererResources::prepareInMainThread(
               UnityEngine::Texture texture = TextureLoader::loadTexture(
                   gltf,
                   pMaterial->emissiveTexture->index);
-              texture.hideFlags(DotNet::UnityEngine::HideFlags::DontSave);
+              texture.hideFlags(
+                  DotNet::UnityEngine::HideFlags::HideAndDontSave);
               if (texture != nullptr) {
                 material.SetTexture(
                     shaderProperty.getEmissiveTextureID(),
@@ -1393,7 +1398,8 @@ void freePrimitiveGameObject(
       int32_t textureID = textureIDs[i];
       UnityEngine::Texture texture = material.GetTexture(textureID);
       std::string name = texture == nullptr ? "" : texture.name().ToStlString();
-      if (texture != nullptr && (texture.hideFlags() & UnityEngine::HideFlags::DontSave)) {
+      if (texture != nullptr &&
+          (texture.hideFlags() & UnityEngine::HideFlags::HideAndDontSave)) {
         UnityLifetime::Destroy(texture);
       }
     }

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -1191,6 +1191,7 @@ void* UnityPrepareRendererResources::prepareInMainThread(
               if (texCoordIndexIt != primitiveInfo.uvIndexMap.end()) {
                 UnityEngine::Texture texture =
                     TextureLoader::loadTexture(gltf, baseColorTexture->index);
+                texture.hideFlags(DotNet::UnityEngine::HideFlags::DontSave);
                 if (texture != nullptr) {
                   material.SetTexture(
                       shaderProperty.getBaseColorTextureID(),
@@ -1210,6 +1211,7 @@ void* UnityPrepareRendererResources::prepareInMainThread(
               if (texCoordIndexIt != primitiveInfo.uvIndexMap.end()) {
                 UnityEngine::Texture texture =
                     TextureLoader::loadTexture(gltf, metallicRoughness->index);
+                texture.hideFlags(DotNet::UnityEngine::HideFlags::DontSave);
                 if (texture != nullptr) {
                   material.SetTexture(
                       shaderProperty.getMetallicRoughnessTextureID(),
@@ -1230,6 +1232,7 @@ void* UnityPrepareRendererResources::prepareInMainThread(
               UnityEngine::Texture texture = TextureLoader::loadTexture(
                   gltf,
                   pMaterial->normalTexture->index);
+              texture.hideFlags(DotNet::UnityEngine::HideFlags::DontSave);
               if (texture != nullptr) {
                 material.SetTexture(
                     shaderProperty.getNormalMapTextureID(),
@@ -1251,6 +1254,7 @@ void* UnityPrepareRendererResources::prepareInMainThread(
               UnityEngine::Texture texture = TextureLoader::loadTexture(
                   gltf,
                   pMaterial->occlusionTexture->index);
+              texture.hideFlags(DotNet::UnityEngine::HideFlags::DontSave);
               if (texture != nullptr) {
                 material.SetTexture(
                     shaderProperty.getOcclusionTextureID(),
@@ -1287,6 +1291,7 @@ void* UnityPrepareRendererResources::prepareInMainThread(
               UnityEngine::Texture texture = TextureLoader::loadTexture(
                   gltf,
                   pMaterial->emissiveTexture->index);
+              texture.hideFlags(DotNet::UnityEngine::HideFlags::DontSave);
               if (texture != nullptr) {
                 material.SetTexture(
                     shaderProperty.getEmissiveTextureID(),
@@ -1387,10 +1392,14 @@ void freePrimitiveGameObject(
     for (int32_t i = 0, len = textureIDs.Count(); i < len; ++i) {
       int32_t textureID = textureIDs[i];
       UnityEngine::Texture texture = material.GetTexture(textureID);
-      if (texture != nullptr)
+      std::string name = texture == nullptr ? "" : texture.name().ToStlString();
+      if (texture != nullptr && (texture.hideFlags() & UnityEngine::HideFlags::DontSave)) {
         UnityLifetime::Destroy(texture);
+      }
     }
 
+    std::string materialName =
+        material == nullptr ? "" : material.name().ToStlString();
     UnityLifetime::Destroy(material);
   }
 

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -1399,7 +1399,8 @@ void freePrimitiveGameObject(
       UnityEngine::Texture texture = material.GetTexture(textureID);
       std::string name = texture == nullptr ? "" : texture.name().ToStlString();
       if (texture != nullptr &&
-          (texture.hideFlags() & UnityEngine::HideFlags::HideAndDontSave)) {
+          (texture.hideFlags() & UnityEngine::HideFlags::HideAndDontSave) ==
+              UnityEngine::HideFlags::HideAndDontSave) {
         UnityLifetime::Destroy(texture);
       }
     }

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -1191,9 +1191,9 @@ void* UnityPrepareRendererResources::prepareInMainThread(
               if (texCoordIndexIt != primitiveInfo.uvIndexMap.end()) {
                 UnityEngine::Texture texture =
                     TextureLoader::loadTexture(gltf, baseColorTexture->index);
-                texture.hideFlags(
-                    DotNet::UnityEngine::HideFlags::HideAndDontSave);
                 if (texture != nullptr) {
+                  texture.hideFlags(
+                      DotNet::UnityEngine::HideFlags::HideAndDontSave);
                   material.SetTexture(
                       shaderProperty.getBaseColorTextureID(),
                       texture);
@@ -1212,9 +1212,9 @@ void* UnityPrepareRendererResources::prepareInMainThread(
               if (texCoordIndexIt != primitiveInfo.uvIndexMap.end()) {
                 UnityEngine::Texture texture =
                     TextureLoader::loadTexture(gltf, metallicRoughness->index);
-                texture.hideFlags(
-                    DotNet::UnityEngine::HideFlags::HideAndDontSave);
                 if (texture != nullptr) {
+                  texture.hideFlags(
+                      DotNet::UnityEngine::HideFlags::HideAndDontSave);
                   material.SetTexture(
                       shaderProperty.getMetallicRoughnessTextureID(),
                       texture);
@@ -1234,9 +1234,9 @@ void* UnityPrepareRendererResources::prepareInMainThread(
               UnityEngine::Texture texture = TextureLoader::loadTexture(
                   gltf,
                   pMaterial->normalTexture->index);
-              texture.hideFlags(
-                  DotNet::UnityEngine::HideFlags::HideAndDontSave);
               if (texture != nullptr) {
+                texture.hideFlags(
+                    DotNet::UnityEngine::HideFlags::HideAndDontSave);
                 material.SetTexture(
                     shaderProperty.getNormalMapTextureID(),
                     texture);
@@ -1257,9 +1257,9 @@ void* UnityPrepareRendererResources::prepareInMainThread(
               UnityEngine::Texture texture = TextureLoader::loadTexture(
                   gltf,
                   pMaterial->occlusionTexture->index);
-              texture.hideFlags(
-                  DotNet::UnityEngine::HideFlags::HideAndDontSave);
               if (texture != nullptr) {
+                texture.hideFlags(
+                    DotNet::UnityEngine::HideFlags::HideAndDontSave);
                 material.SetTexture(
                     shaderProperty.getOcclusionTextureID(),
                     texture);
@@ -1295,9 +1295,9 @@ void* UnityPrepareRendererResources::prepareInMainThread(
               UnityEngine::Texture texture = TextureLoader::loadTexture(
                   gltf,
                   pMaterial->emissiveTexture->index);
-              texture.hideFlags(
-                  DotNet::UnityEngine::HideFlags::HideAndDontSave);
               if (texture != nullptr) {
+                texture.hideFlags(
+                    DotNet::UnityEngine::HideFlags::HideAndDontSave);
                 material.SetTexture(
                     shaderProperty.getEmissiveTextureID(),
                     texture);

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -1397,7 +1397,6 @@ void freePrimitiveGameObject(
     for (int32_t i = 0, len = textureIDs.Count(); i < len; ++i) {
       int32_t textureID = textureIDs[i];
       UnityEngine::Texture texture = material.GetTexture(textureID);
-      std::string name = texture == nullptr ? "" : texture.name().ToStlString();
       if (texture != nullptr &&
           (texture.hideFlags() & UnityEngine::HideFlags::HideAndDontSave) ==
               UnityEngine::HideFlags::HideAndDontSave) {
@@ -1405,8 +1404,6 @@ void freePrimitiveGameObject(
       }
     }
 
-    std::string materialName =
-        material == nullptr ? "" : material.name().ToStlString();
     UnityLifetime::Destroy(material);
   }
 


### PR DESCRIPTION
Fixes #344.

Currently, when UnityPrepareRendererResources frees a tile, it calls `DestroyImmediate` on the material and all of its textures. This is fine and in fact desired behavior for the materials and textures Cesium creates at runtime - we need to make sure these texture resources get cleaned up so we don't leak memory. This is also fine for user-provided materials, as we create a new instance of the material - as long as the material doesn't have any texture assets set for its texture properties. Textures aren't copied when you copy a material, so when `freePrimitiveGameObject` goes through all of the material's texture properties and calls `Destroy` on everything it finds, it ends up attempting to destroy the assets the end user specified on the material. This produces a "Destroying assets is not permitted to avoid data loss" error.

There are two ways we can solve this. The first way would be to make a new instance of all the textures the same way we make a new instance of the materials. However, it would be simpler to just keep track of all the textures we're creating at runtime, and just not try to destroy textures we didn't create. There's a few ways to do this, but I went with the simplest - setting the `UnityEngine::HideFlags::HideAndDontSave` hideFlag on each texture created, and checking it before destroying. This prevents assets from being destroyed.

One caveat is that if the user sets a texture *they* created on the material that also has `UnityEngine::HideFlags::HideAndDontSave` set, our code will attempt to destroy it too. This won't result in errors, just undesirable behavior. However, I think this possibility is pretty slim, and in the case where it's an issue we can suggest that they simply use `UnityEngine::HideFlags::DontSave` instead. 