### PR TITLE
Fix CesiumOriginShift test currently breaking builds

### DIFF
--- a/Tests/TestCesiumOriginShift.cs
+++ b/Tests/TestCesiumOriginShift.cs
@@ -164,24 +164,23 @@ public class TestCesiumOriginShift
 
         yield return new WaitForEndOfFrame();
 
-        IEqualityComparer<double> epsilon6 = Comparers.Double(1e-6, 1e-6);
+        IEqualityComparer<double> epsilon6 = Comparers.Double(1e-6, 1e-4);
 
         Assert.That(baseEcef.x, Is.EqualTo(globeAnchor.positionGlobeFixed.x).Using(epsilon6));
 
         // speed per second
         double speed = 1000.0;
         double duration = 10.0;
-        // To make tests more repeatable, we'll run a fixed number of frames, rather than a fixed duration
-        // This means that the rest will have the same result regardless of the frame time
-        int totalNumFrames = (int)(duration / Time.fixedDeltaTime);
+        float startTime = Time.time;
+        Vector3 startPos = globeAnchor.transform.position;
 
-        for(int i = 0; i < totalNumFrames; i += 2)
+        while ((Time.time - startTime) < duration)
         {
             double3 previousPositionEcef = globeAnchor.positionGlobeFixed.x;
 
             yield return new WaitForFixedUpdate();
 
-            double unitsEcef = speed * Time.fixedDeltaTime;
+            double unitsEcef = speed * Time.deltaTime;
             double3 movement = georeference.TransformEarthCenteredEarthFixedDirectionToUnity(new double3(unitsEcef, 0, 0));
             controller.Move((float3)movement);
 

--- a/Tests/TestCesiumOriginShift.cs
+++ b/Tests/TestCesiumOriginShift.cs
@@ -171,10 +171,11 @@ public class TestCesiumOriginShift
         // speed per second
         double speed = 1000.0;
         double duration = 10.0;
-        float startTime = Time.time;
-        Vector3 startPos = globeAnchor.transform.position;
+        // To make tests more repeatable, we'll run a fixed number of frames, rather than a fixed duration
+        // This means that the rest will have the same result regardless of the frame time
+        int totalNumFrames = (int)(duration / Time.fixedDeltaTime);
 
-        while ((Time.time - startTime) < duration)
+        for(int i = 0; i < totalNumFrames; i += 2)
         {
             double3 previousPositionEcef = globeAnchor.positionGlobeFixed.x;
 

--- a/Tests/TestCesiumOriginShift.cs
+++ b/Tests/TestCesiumOriginShift.cs
@@ -168,27 +168,32 @@ public class TestCesiumOriginShift
 
         Assert.That(baseEcef.x, Is.EqualTo(globeAnchor.positionGlobeFixed.x).Using(epsilon6));
 
-        // speed per second
-        double speed = 1000.0;
-        double duration = 10.0;
-        float startTime = Time.time;
-        Vector3 startPos = globeAnchor.transform.position;
+        yield return null;
 
-        while ((Time.time - startTime) < duration)
-        {
-            double3 previousPositionEcef = globeAnchor.positionGlobeFixed.x;
+        // Move, but not far enough to trigger an origin shift
+        double3 previousPositionEcef = globeAnchor.positionGlobeFixed.x;
+        double3 movement = georeference.TransformEarthCenteredEarthFixedDirectionToUnity(new double3(2500.0, 0, 0));
+        controller.Move((float3)movement);
 
-            yield return new WaitForFixedUpdate();
+        // Explicitly sync the globe anchor, so that the origin shift's LateUpdate sees the new position this frame.
+        // Otherwise, it will base the shift on the position in the previous frame because CesiumGlobeAnchor
+        // coroutine that updates from the Transform already ran for this frame before the Move above was called.
+        globeAnchor.Sync();
 
-            double unitsEcef = speed * Time.deltaTime;
-            double3 movement = georeference.TransformEarthCenteredEarthFixedDirectionToUnity(new double3(unitsEcef, 0, 0));
-            controller.Move((float3)movement);
+        yield return null;
 
-            yield return new WaitForEndOfFrame();
+        Assert.That(previousPositionEcef.x + 2500.0, Is.EqualTo(globeAnchor.positionGlobeFixed.x).Using(epsilon6));
+        Assert.Less(georeference.ecefX - globeAnchor.positionGlobeFixed.x, 5000.0);
 
-            globeAnchor.Sync();
-            Assert.That(previousPositionEcef.x + unitsEcef, Is.EqualTo(globeAnchor.positionGlobeFixed.x).Using(epsilon6));
-            Assert.Less(georeference.ecefX - globeAnchor.positionGlobeFixed.x, 5000.0);
-        }
+        // Move again, this time triggering an origin shift
+        previousPositionEcef = globeAnchor.positionGlobeFixed.x;
+        movement = georeference.TransformEarthCenteredEarthFixedDirectionToUnity(new double3(3000.0, 0, 0));
+        controller.Move((float3)movement);
+        globeAnchor.Sync();
+
+        yield return null;
+
+        Assert.That(previousPositionEcef.x + 3000.0, Is.EqualTo(globeAnchor.positionGlobeFixed.x).Using(epsilon6));
+        Assert.Less(System.Math.Abs(georeference.ecefX - globeAnchor.positionGlobeFixed.x), 5000.0);
     }
 }

--- a/Tests/TestCesiumOriginShift.cs
+++ b/Tests/TestCesiumOriginShift.cs
@@ -180,7 +180,7 @@ public class TestCesiumOriginShift
 
             yield return new WaitForFixedUpdate();
 
-            double unitsEcef = speed * Time.deltaTime;
+            double unitsEcef = speed * Time.fixedDeltaTime;
             double3 movement = georeference.TransformEarthCenteredEarthFixedDirectionToUnity(new double3(unitsEcef, 0, 0));
             controller.Move((float3)movement);
 


### PR DESCRIPTION
Currently the `ShiftsOriginWithCharacterController` test for `CesiumOriginShift` is failing, causing builds to fail. Currently, the test's results depend heavily on frame time - it uses `Time.deltaTime` to calculate movement distance, and the rest runs for a specific number of seconds, rather than a specific number of frames. This means that a machine that can render 30 frames per second will get a different test result than a machine that can only render 15. I've changed the test to execute a set number of frames and to use `Time.fixedDeltaTime` for its movement, so the test should produce a same result no matter the frame time.