### PR TITLE
Fix test failure by yielding null instead of WaitForEndOfFrame.

### DIFF
--- a/Tests/TestCesiumOriginShift.cs
+++ b/Tests/TestCesiumOriginShift.cs
@@ -162,7 +162,7 @@ public class TestCesiumOriginShift
         controller.center = Vector3.zero;
         controller.enableOverlapRecovery = false;
 
-        yield return new WaitForEndOfFrame();
+        yield return null;
 
         IEqualityComparer<double> epsilon6 = Comparers.Double(1e-6, 1e-4);
 
@@ -189,6 +189,7 @@ public class TestCesiumOriginShift
         previousPositionEcef = globeAnchor.positionGlobeFixed.x;
         movement = georeference.TransformEarthCenteredEarthFixedDirectionToUnity(new double3(3000.0, 0, 0));
         controller.Move((float3)movement);
+
         globeAnchor.Sync();
 
         yield return null;


### PR DESCRIPTION
This fixes the test failure on CI and on my own machine when running the tests from the command-line the way that CI does. I can't entirely explain why `WaitForEndOfFrame` causes problems, though. 