### PR TITLE
Support custom input actions on `CesiumCameraController`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 - Added a `distance` property to `CesiumOriginShift`, which specifies the maximum allowed distance from the current origin before it is shifted.
 - Added support for the `KHR_texture_transform` glTF extension - including rotation - in `baseColorTexture`, `metallicRoughnessTexture`, `emissiveTexture`, `normalTexture`, and `occlusionTexture`. The transformation is now applied on the GPU via nodes in the Material, rather than on the CPU by directly modifying texture coordinates.
 - Added `materialKey` to `CesiumRasterOverlay`, which matches the overlay to its corresponding parameters in the tileset's material. This allows for explicit ordering of raster overlays and overlay-specific effects. 
+- `CesiumCameraController` can now accept custom input actions that override the default inputs.
 
 ##### Fixes :wrench:
 

--- a/Editor/CesiumCameraControllerEditor.cs
+++ b/Editor/CesiumCameraControllerEditor.cs
@@ -119,7 +119,7 @@ namespace CesiumForUnity
             GUILayout.EndHorizontal();
 
             EditorGUI.EndDisabledGroup();
-            
+
             EditorGUILayout.Space(5);
 
             GUILayout.BeginHorizontal();
@@ -141,7 +141,7 @@ namespace CesiumForUnity
             GUILayout.BeginHorizontal();
             GUIContent dynamicClippingPlanesMinHeightContent = new GUIContent(
                 "Dynamic Clipping Planes Min Height",
-                "The height to start dynamically adjust the camera's clipping " + 
+                "The height to start dynamically adjust the camera's clipping " +
                 "planes. Below this height, the clipping planes will be set to their " +
                 "initial values.");
             GUILayout.Label(dynamicClippingPlanesMinHeightContent, GUILayout.Width(labelWidth));
@@ -153,7 +153,7 @@ namespace CesiumForUnity
             EditorGUILayout.Space(5);
 
             this._lookAction.isExpanded = EditorGUILayout.BeginFoldoutHeaderGroup(this._lookAction.isExpanded, new GUIContent("Input Actions"));
-            if(this._lookAction.isExpanded)
+            if (this._lookAction.isExpanded)
             {
                 EditorGUILayout.PropertyField(this._lookAction);
                 EditorGUILayout.PropertyField(this._moveAction);

--- a/Editor/CesiumCameraControllerEditor.cs
+++ b/Editor/CesiumCameraControllerEditor.cs
@@ -17,12 +17,14 @@ namespace CesiumForUnity
         private SerializedProperty _enableDynamicClippingPlanes;
         private SerializedProperty _dynamicClippingPlanesMinHeight;
 
+#if ENABLE_INPUT_SYSTEM
         private SerializedProperty _lookAction;
         private SerializedProperty _moveAction;
         private SerializedProperty _moveUpAction;
         private SerializedProperty _speedChangeAction;
         private SerializedProperty _speedResetAction;
         private SerializedProperty _toggleDynamicSpeedAction;
+#endif
 
         private void OnEnable()
         {
@@ -44,12 +46,14 @@ namespace CesiumForUnity
             this._dynamicClippingPlanesMinHeight =
                 this.serializedObject.FindProperty("_dynamicClippingPlanesMinHeight");
 
+#if ENABLE_INPUT_SYSTEM
             this._lookAction = this.serializedObject.FindProperty("_lookAction");
             this._moveAction = this.serializedObject.FindProperty("_moveAction");
             this._moveUpAction = this.serializedObject.FindProperty("_moveUpAction");
             this._speedChangeAction = this.serializedObject.FindProperty("_speedChangeAction");
             this._speedResetAction = this.serializedObject.FindProperty("_speedResetAction");
             this._toggleDynamicSpeedAction = this.serializedObject.FindProperty("_toggleDynamicSpeedAction");
+#endif
         }
 
         public override void OnInspectorGUI()
@@ -150,6 +154,7 @@ namespace CesiumForUnity
 
             EditorGUI.EndDisabledGroup();
 
+#if ENABLE_INPUT_SYSTEM
             EditorGUILayout.Space(5);
 
             this._lookAction.isExpanded = EditorGUILayout.BeginFoldoutHeaderGroup(this._lookAction.isExpanded, new GUIContent("Input Actions"));
@@ -163,6 +168,7 @@ namespace CesiumForUnity
                 EditorGUILayout.PropertyField(this._toggleDynamicSpeedAction);
             }
             EditorGUILayout.EndFoldoutHeaderGroup();
+#endif
         }
     }
 }

--- a/Editor/CesiumCameraControllerEditor.cs
+++ b/Editor/CesiumCameraControllerEditor.cs
@@ -17,6 +17,13 @@ namespace CesiumForUnity
         private SerializedProperty _enableDynamicClippingPlanes;
         private SerializedProperty _dynamicClippingPlanesMinHeight;
 
+        private SerializedProperty _lookAction;
+        private SerializedProperty _moveAction;
+        private SerializedProperty _moveUpAction;
+        private SerializedProperty _speedChangeAction;
+        private SerializedProperty _speedResetAction;
+        private SerializedProperty _toggleDynamicSpeedAction;
+
         private void OnEnable()
         {
             this._enableMovement =
@@ -36,6 +43,13 @@ namespace CesiumForUnity
                 this.serializedObject.FindProperty("_enableDynamicClippingPlanes");
             this._dynamicClippingPlanesMinHeight =
                 this.serializedObject.FindProperty("_dynamicClippingPlanesMinHeight");
+
+            this._lookAction = this.serializedObject.FindProperty("_lookAction");
+            this._moveAction = this.serializedObject.FindProperty("_moveAction");
+            this._moveUpAction = this.serializedObject.FindProperty("_moveUpAction");
+            this._speedChangeAction = this.serializedObject.FindProperty("_speedChangeAction");
+            this._speedResetAction = this.serializedObject.FindProperty("_speedResetAction");
+            this._toggleDynamicSpeedAction = this.serializedObject.FindProperty("_toggleDynamicSpeedAction");
         }
 
         public override void OnInspectorGUI()
@@ -135,6 +149,20 @@ namespace CesiumForUnity
             GUILayout.EndHorizontal();
 
             EditorGUI.EndDisabledGroup();
+
+            EditorGUILayout.Space(5);
+
+            this._lookAction.isExpanded = EditorGUILayout.BeginFoldoutHeaderGroup(this._lookAction.isExpanded, new GUIContent("Input Actions"));
+            if(this._lookAction.isExpanded)
+            {
+                EditorGUILayout.PropertyField(this._lookAction);
+                EditorGUILayout.PropertyField(this._moveAction);
+                EditorGUILayout.PropertyField(this._moveUpAction);
+                EditorGUILayout.PropertyField(this._speedChangeAction);
+                EditorGUILayout.PropertyField(this._speedResetAction);
+                EditorGUILayout.PropertyField(this._toggleDynamicSpeedAction);
+            }
+            EditorGUILayout.EndFoldoutHeaderGroup();
         }
     }
 }

--- a/Runtime/CesiumCameraController.cs
+++ b/Runtime/CesiumCameraController.cs
@@ -1,5 +1,7 @@
 using UnityEngine;
 using Unity.Mathematics;
+using System.Linq;
+
 
 #if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
@@ -127,6 +129,24 @@ namespace CesiumForUnity
             set => this._dynamicClippingPlanesMinHeight = Mathf.Max(value, 0.0f);
         }
 
+        [SerializeField]
+        private InputActionProperty _lookAction;
+
+        [SerializeField]
+        private InputActionProperty _moveAction;
+
+        [SerializeField]
+        private InputActionProperty _moveUpAction;
+
+        [SerializeField]
+        private InputActionProperty _speedChangeAction;
+
+        [SerializeField]
+        private InputActionProperty _speedResetAction;
+
+        [SerializeField]
+        private InputActionProperty _toggleDynamicSpeedAction;
+
         #endregion
 
         #region Private variables
@@ -169,12 +189,10 @@ namespace CesiumForUnity
         #region Input configuration
 
 #if ENABLE_INPUT_SYSTEM
-        InputAction lookAction;
-        InputAction moveAction;
-        InputAction moveUpAction;
-        InputAction speedChangeAction;
-        InputAction speedResetAction;
-        InputAction toggleDynamicSpeedAction;
+        private bool HasInputAction(InputActionProperty property)
+        {
+            return (property.action != null && property.action.bindings.Any()) || (property.reference != null);
+        }
 
         void ConfigureInputs()
         {
@@ -183,47 +201,71 @@ namespace CesiumForUnity
 #endif
             InputActionMap map = new InputActionMap("Cesium Camera Controller");
 
-            lookAction = map.AddAction("look", binding: "<Mouse>/delta");
-            lookAction.AddBinding("<Gamepad>/rightStick").WithProcessor("scaleVector2(x=15, y=15)");
+            if(!HasInputAction(_lookAction))
+            {
+                InputAction newLookAction = map.AddAction("look", binding: "<Mouse>/delta");
+                newLookAction.AddBinding("<Gamepad>/rightStick").WithProcessor("scaleVector2(x=15, y=15)");
+                _lookAction = new InputActionProperty(newLookAction);
+            }
 
-            moveAction = map.AddAction("move", binding: "<Gamepad>/leftStick");
-            moveAction.AddCompositeBinding("Dpad")
-                .With("Up", "<Keyboard>/w")
-                .With("Down", "<Keyboard>/s")
-                .With("Left", "<Keyboard>/a")
-                .With("Right", "<Keyboard>/d")
-                .With("Up", "<Keyboard>/upArrow")
-                .With("Down", "<Keyboard>/downArrow")
-                .With("Left", "<Keyboard>/leftArrow")
-                .With("Right", "<Keyboard>/rightArrow");
+            if(!HasInputAction(_moveAction))
+            {
+                InputAction newMoveAction = map.AddAction("move", binding: "<Gamepad>/leftStick");
+                newMoveAction.AddCompositeBinding("Dpad")
+                    .With("Up", "<Keyboard>/w")
+                    .With("Down", "<Keyboard>/s")
+                    .With("Left", "<Keyboard>/a")
+                    .With("Right", "<Keyboard>/d")
+                    .With("Up", "<Keyboard>/upArrow")
+                    .With("Down", "<Keyboard>/downArrow")
+                    .With("Left", "<Keyboard>/leftArrow")
+                    .With("Right", "<Keyboard>/rightArrow");
+                _moveAction = new InputActionProperty(newMoveAction);
+            }
 
-            moveUpAction = map.AddAction("moveUp");
-            moveUpAction.AddCompositeBinding("Dpad")
-                .With("Up", "<Keyboard>/space")
-                .With("Down", "<Keyboard>/c")
-                .With("Up", "<Keyboard>/e")
-                .With("Down", "<Keyboard>/q")
-                .With("Up", "<Gamepad>/rightTrigger")
-                .With("Down", "<Gamepad>/leftTrigger");
+            if(!HasInputAction(_moveUpAction))
+            {
+                InputAction newMoveUpAction = map.AddAction("moveUp");
+                newMoveUpAction.AddCompositeBinding("Dpad")
+                    .With("Up", "<Keyboard>/space")
+                    .With("Down", "<Keyboard>/c")
+                    .With("Up", "<Keyboard>/e")
+                    .With("Down", "<Keyboard>/q")
+                    .With("Up", "<Gamepad>/rightTrigger")
+                    .With("Down", "<Gamepad>/leftTrigger");
+                _moveUpAction = new InputActionProperty(newMoveUpAction);
+            }
 
-            speedChangeAction = map.AddAction("speedChange", binding: "<Mouse>/scroll");
-            speedChangeAction.AddCompositeBinding("Dpad")
-                .With("Up", "<Gamepad>/rightShoulder")
-                .With("Down", "<Gamepad>/leftShoulder");
+            if(!HasInputAction(_speedChangeAction))
+            {
+                InputAction newSpeedChangeAction = map.AddAction("speedChange", binding: "<Mouse>/scroll");
+                newSpeedChangeAction.AddCompositeBinding("Dpad")
+                    .With("Up", "<Gamepad>/rightShoulder")
+                    .With("Down", "<Gamepad>/leftShoulder");
+                _speedChangeAction = new InputActionProperty(newSpeedChangeAction);
+            }
 
-            speedResetAction = map.AddAction("speedReset", binding: "<Mouse>/middleButton");
-            speedResetAction.AddBinding("<Gamepad>/buttonNorth");
+            if(!HasInputAction(_speedResetAction))
+            {
+                InputAction newSpeedResetAction = map.AddAction("speedReset", binding: "<Mouse>/middleButton");
+                newSpeedResetAction.AddBinding("<Gamepad>/buttonNorth");
+                _speedResetAction = new InputActionProperty(newSpeedResetAction);
+            }
 
-            toggleDynamicSpeedAction =
-                map.AddAction("toggleDynamicSpeed", binding: "<Keyboard>/g");
-            toggleDynamicSpeedAction.AddBinding("<Gamepad>/buttonEast");
+            if(!HasInputAction(_toggleDynamicSpeedAction))
+            {
+                InputAction newToggleDynamicSpeedAction =
+                    map.AddAction("toggleDynamicSpeed", binding: "<Keyboard>/g");
+                newToggleDynamicSpeedAction.AddBinding("<Gamepad>/buttonEast");
+                _toggleDynamicSpeedAction = new InputActionProperty(newToggleDynamicSpeedAction);
+            }
 
-            moveAction.Enable();
-            lookAction.Enable();
-            moveUpAction.Enable();
-            speedChangeAction.Enable();
-            speedResetAction.Enable();
-            toggleDynamicSpeedAction.Enable();
+            _moveAction.action.Enable();
+            _lookAction.action.Enable();
+            _moveUpAction.action.Enable();
+            _speedChangeAction.action.Enable();
+            _speedResetAction.action.Enable();
+            _toggleDynamicSpeedAction.action.Enable();
         }
 #endif
 
@@ -374,8 +416,8 @@ namespace CesiumForUnity
 #if ENABLE_INPUT_SYSTEM
             Vector2 lookDelta;
             Vector2 moveDelta;
-            lookDelta = lookAction.ReadValue<Vector2>();
-            moveDelta = moveAction.ReadValue<Vector2>();
+            lookDelta = _lookAction.action.ReadValue<Vector2>();
+            moveDelta = _moveAction.action.ReadValue<Vector2>();
 
 #if UNITY_IOS || UNITY_ANDROID
             bool handledMove = false;
@@ -408,12 +450,12 @@ namespace CesiumForUnity
             float inputForward = moveDelta.y;
             float inputRight = moveDelta.x;
 
-            float inputUp = moveUpAction.ReadValue<Vector2>().y;
+            float inputUp = _moveUpAction.action.ReadValue<Vector2>().y;
 
-            float inputSpeedChange = speedChangeAction.ReadValue<Vector2>().y;
-            bool inputSpeedReset = speedResetAction.ReadValue<float>() > 0.5f;
+            float inputSpeedChange = _speedChangeAction.action.ReadValue<Vector2>().y;
+            bool inputSpeedReset = _speedResetAction.action.ReadValue<float>() > 0.5f;
 
-            bool toggleDynamicSpeed = toggleDynamicSpeedAction.ReadValue<float>() > 0.5f;
+            bool toggleDynamicSpeed = _toggleDynamicSpeedAction.action.ReadValue<float>() > 0.5f;
 #else
             float inputRotateHorizontal = Input.GetAxis("Mouse X");
             float inputRotateVertical = Input.GetAxis("Mouse Y");

--- a/Runtime/CesiumCameraController.cs
+++ b/Runtime/CesiumCameraController.cs
@@ -201,14 +201,14 @@ namespace CesiumForUnity
 #endif
             InputActionMap map = new InputActionMap("Cesium Camera Controller");
 
-            if(!HasInputAction(_lookAction))
+            if (!HasInputAction(_lookAction))
             {
                 InputAction newLookAction = map.AddAction("look", binding: "<Mouse>/delta");
                 newLookAction.AddBinding("<Gamepad>/rightStick").WithProcessor("scaleVector2(x=15, y=15)");
                 _lookAction = new InputActionProperty(newLookAction);
             }
 
-            if(!HasInputAction(_moveAction))
+            if (!HasInputAction(_moveAction))
             {
                 InputAction newMoveAction = map.AddAction("move", binding: "<Gamepad>/leftStick");
                 newMoveAction.AddCompositeBinding("Dpad")
@@ -223,7 +223,7 @@ namespace CesiumForUnity
                 _moveAction = new InputActionProperty(newMoveAction);
             }
 
-            if(!HasInputAction(_moveUpAction))
+            if (!HasInputAction(_moveUpAction))
             {
                 InputAction newMoveUpAction = map.AddAction("moveUp");
                 newMoveUpAction.AddCompositeBinding("Dpad")
@@ -236,7 +236,7 @@ namespace CesiumForUnity
                 _moveUpAction = new InputActionProperty(newMoveUpAction);
             }
 
-            if(!HasInputAction(_speedChangeAction))
+            if (!HasInputAction(_speedChangeAction))
             {
                 InputAction newSpeedChangeAction = map.AddAction("speedChange", binding: "<Mouse>/scroll");
                 newSpeedChangeAction.AddCompositeBinding("Dpad")
@@ -245,14 +245,14 @@ namespace CesiumForUnity
                 _speedChangeAction = new InputActionProperty(newSpeedChangeAction);
             }
 
-            if(!HasInputAction(_speedResetAction))
+            if (!HasInputAction(_speedResetAction))
             {
                 InputAction newSpeedResetAction = map.AddAction("speedReset", binding: "<Mouse>/middleButton");
                 newSpeedResetAction.AddBinding("<Gamepad>/buttonNorth");
                 _speedResetAction = new InputActionProperty(newSpeedResetAction);
             }
 
-            if(!HasInputAction(_toggleDynamicSpeedAction))
+            if (!HasInputAction(_toggleDynamicSpeedAction))
             {
                 InputAction newToggleDynamicSpeedAction =
                     map.AddAction("toggleDynamicSpeed", binding: "<Keyboard>/g");

--- a/Runtime/CesiumCameraController.cs
+++ b/Runtime/CesiumCameraController.cs
@@ -129,6 +129,7 @@ namespace CesiumForUnity
             set => this._dynamicClippingPlanesMinHeight = Mathf.Max(value, 0.0f);
         }
 
+#if ENABLE_INPUT_SYSTEM
         [SerializeField]
         private InputActionProperty _lookAction;
 
@@ -146,6 +147,7 @@ namespace CesiumForUnity
 
         [SerializeField]
         private InputActionProperty _toggleDynamicSpeedAction;
+#endif
 
         #endregion
 


### PR DESCRIPTION
Fixes #414.

This change adds a set of properties to `CesiumCameraController` that allows specifying an input action to bind to each action in the camera controller (such as look, move, speed change, etc). This property can specifying a binding for that action, or reference an existing action to use for the input. If no action is specified, `CesiumCameraController` will create default bindings for that action as it did before this change.