### PR TITLE
Update feature ID texture for `KHR_texture_transform` (plus bugfix!)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Change Log
 
+### ? - ?
+
+##### Additions :tada:
+
+- Added support for the `KHR_texture_transform` glTF extension - including rotation - for picking with `CesiumFeatureIdTexture`.
+
+##### Fixes :wrench:
+
+- Fixed a bug where UVs were not properly interpolated in `CesiumFeatureIdTexture.GetFeatureIdFromHit`, resulting in incorrect values.
+
 ### v1.8.0 - 2023-03-01
 
 ##### Breaking Changes :mega:

--- a/Reinterop~/Methods.cs
+++ b/Reinterop~/Methods.cs
@@ -114,7 +114,7 @@ namespace Reinterop
             // If this is an instance method, pass the current object as the first parameter.
             if (!method.IsStatic)
             {
-                interopParameters = new[] { (ParameterName: "thiz", CallSiteName: "(*this)", Type: result.CppDefinition.Type.AsParameterType(), InteropType: result.CppDefinition.Type.AsInteropType()) }.Concat(interopParameters);
+                interopParameters = new[] { (ParameterName: "thiz", CallSiteName: "(*this)", Type: result.CppDefinition.Type.AsParameterType(), InteropType: result.CppDefinition.Type.AsParameterType().AsInteropType()) }.Concat(interopParameters);
             }
 
             bool hasStructRewrite = Interop.RewriteStructReturn(ref interopParameters, ref returnType, ref interopReturnType);

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -776,10 +776,13 @@ namespace CesiumForUnity
             property.valueType = property.valueType;
 
             RaycastHit hitInfo = new RaycastHit();
+            primitiveFeatures = hitInfo.transform.GetComponent<CesiumPrimitiveFeatures>();
             int triangleIndex = hitInfo.triangleIndex;
-            Vector3 coordinate = hitInfo.barycentricCoordinate;
+            Vector3 hitPoint = hitInfo.point;
+            
             Vector2 textureCoordinate = new Vector2();
             textureCoordinate.x = textureCoordinate.y;
+            hitPoint = m2.MultiplyPoint3x4(hitPoint);
 
             CesiumIonServer server = CesiumIonServer.defaultServer;
             server.serverUrl = "";

--- a/native~/Runtime/src/CesiumFeatureIdTextureImpl.cpp
+++ b/native~/Runtime/src/CesiumFeatureIdTextureImpl.cpp
@@ -1,10 +1,14 @@
 #include "CesiumFeatureIdTextureImpl.h"
 
+#include <CesiumGeometry/IntersectionTests.h>
 #include <CesiumGltf/AccessorUtility.h>
 
 #include <DotNet/CesiumForUnity/CesiumFeatureIdTexture.h>
 #include <DotNet/CesiumForUnity/CesiumFeatureIdTextureStatus.h>
+#include <DotNet/CesiumForUnity/CesiumPrimitiveFeatures.h>
+#include <DotNet/UnityEngine/Matrix4x4.h>
 #include <DotNet/UnityEngine/RaycastHit.h>
+#include <DotNet/UnityEngine/Transform.h>
 #include <DotNet/UnityEngine/Vector2.h>
 #include <DotNet/UnityEngine/Vector3.h>
 
@@ -17,17 +21,13 @@ CesiumFeatureIdTextureImpl::CreateTexture(
     const CesiumGltf::MeshPrimitive& primitive,
     const int64_t featureCount,
     const CesiumGltf::FeatureIdTexture& featureIdTexture) {
+  CesiumGltf::TextureViewOptions options;
+  options.applyKhrTextureTransformExtension = true;
+
   CesiumFeatureIdTexture texture;
   CesiumFeatureIdTextureImpl& textureImpl = texture.NativeImplementation();
   textureImpl._featureIdTextureView =
-      CesiumGltf::FeatureIdTextureView(model, featureIdTexture);
-  textureImpl._texCoordAccessor = CesiumGltf::getTexCoordAccessorView(
-      model,
-      primitive,
-      featureIdTexture.texCoord);
-  textureImpl._indexAccessor =
-      CesiumGltf::getIndexAccessorView(model, primitive);
-  textureImpl._primitiveMode = primitive.mode;
+      CesiumGltf::FeatureIdTextureView(model, featureIdTexture, options);
 
   switch (textureImpl._featureIdTextureView.status()) {
   case CesiumGltf::FeatureIdTextureViewStatus::Valid:
@@ -37,13 +37,23 @@ CesiumFeatureIdTextureImpl::CreateTexture(
   case CesiumGltf::FeatureIdTextureViewStatus::ErrorInvalidChannels:
     texture.status(CesiumFeatureIdTextureStatus::ErrorInvalidTextureAccess);
     texture.featureCount(0);
-    break;
+    return texture;
   default:
     // Error with the texture or image. The status is already set by the C#
     // constructor.
     texture.featureCount(0);
-    break;
+    return texture;
   }
+
+  textureImpl._texCoordAccessor = CesiumGltf::getTexCoordAccessorView(
+      model,
+      primitive,
+      textureImpl._featureIdTextureView.getTexCoordSetIndex());
+  textureImpl._indexAccessor =
+      CesiumGltf::getIndexAccessorView(model, primitive);
+  textureImpl._positionAccessor =
+      CesiumGltf::getPositionAccessorView(model, primitive);
+  textureImpl._primitiveMode = primitive.mode;
 
   return texture;
 }
@@ -71,6 +81,15 @@ std::int64_t CesiumFeatureIdTextureImpl::GetFeatureIdForVertex(
 std::int64_t CesiumFeatureIdTextureImpl::GetFeatureIdFromRaycastHit(
     const CesiumFeatureIdTexture& featureIdTexture,
     const DotNet::UnityEngine::RaycastHit& hitInfo) {
+  if (hitInfo.transform().GetComponent<CesiumPrimitiveFeatures>() == nullptr) {
+    return -1;
+  }
+
+  if (this->_positionAccessor.status() !=
+      CesiumGltf::AccessorViewStatus::Valid) {
+    return -1;
+  }
+
   int64_t vertexCount =
       std::visit(CesiumGltf::CountFromAccessor{}, this->_texCoordAccessor);
 
@@ -81,25 +100,51 @@ std::int64_t CesiumFeatureIdTextureImpl::GetFeatureIdFromRaycastHit(
           this->_primitiveMode},
       this->_indexAccessor);
 
-  std::array<glm::dvec2, 3> UVs;
-  for (size_t i = 0; i < UVs.size(); i++) {
+  std::array<glm::dvec2, 3> uvs;
+  std::array<glm::vec3, 3> positions;
+
+  for (size_t i = 0; i < positions.size(); i++) {
+    int64_t index = vertexIndices[i];
+    if (index < 0 || index >= vertexCount) {
+      return -1;
+    }
+
     auto maybeTexCoord = std::visit(
-        CesiumGltf::TexCoordFromAccessor{vertexIndices[i]},
+        CesiumGltf::TexCoordFromAccessor{index},
         this->_texCoordAccessor);
     if (!maybeTexCoord) {
       return -1;
     }
+    uvs[i] = *maybeTexCoord;
 
-    const glm::dvec2& texCoord = *maybeTexCoord;
-    UVs[i] = glm::dvec2(texCoord[0], texCoord[1]);
+    CesiumGltf::AccessorTypes::VEC3<float> position =
+        this->_positionAccessor[index];
+    positions[i] =
+        glm::vec3(position.value[0], position.value[1], position.value[2]);
   }
 
-  DotNet::UnityEngine::Vector3 barycentricCoords =
-      hitInfo.barycentricCoordinate();
+  // The barycentric coordinates in RaycastHit don't align with the positions
+  // in the glTF accessor, so we manually compute barycentric coordinates here.
+  DotNet::UnityEngine::Vector3 worldPosition = hitInfo.point();
+  DotNet::UnityEngine::Matrix4x4 worldToLocal =
+      hitInfo.transform().worldToLocalMatrix();
+  DotNet::UnityEngine::Vector3 localPosition =
+      worldToLocal.MultiplyPoint3x4(worldPosition);
 
-  glm::dvec2 UV = (static_cast<double>(barycentricCoords.x) * UVs[0]) +
-                  (static_cast<double>(barycentricCoords.y) * UVs[1]) +
-                  (static_cast<double>(barycentricCoords.z) * UVs[2]);
+  glm::dvec3 barycentricCoordinates;
+  bool foundIntersection = CesiumGeometry::IntersectionTests::pointInTriangle(
+      glm::dvec3(localPosition.x, localPosition.y, localPosition.z),
+      glm::dvec3(positions[0]),
+      glm::dvec3(positions[1]),
+      glm::dvec3(positions[2]),
+      barycentricCoordinates);
+  if (!foundIntersection) {
+    return -1;
+  }
+
+  glm::dvec2 UV = (barycentricCoordinates[0] * uvs[0]) +
+                  (barycentricCoordinates[1] * uvs[1]) +
+                  (barycentricCoordinates[2] * uvs[2]);
 
   return this->_featureIdTextureView.getFeatureID(UV.x, UV.y);
 }

--- a/native~/Runtime/src/CesiumFeatureIdTextureImpl.h
+++ b/native~/Runtime/src/CesiumFeatureIdTextureImpl.h
@@ -49,6 +49,7 @@ private:
   CesiumGltf::FeatureIdTextureView _featureIdTextureView;
   CesiumGltf::TexCoordAccessorType _texCoordAccessor;
   CesiumGltf::IndexAccessorType _indexAccessor;
+  CesiumGltf::PositionAccessorType _positionAccessor;
   int32_t _primitiveMode;
 };
 } // namespace CesiumForUnityNative

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -344,12 +344,14 @@ void loadPrimitive(
       Unity::Collections::LowLevel::Unsafe::NativeArrayUnsafeUtility::
           GetUnsafeBufferPointerWithoutChecks(dest));
 
-  if (primitive.mode == MeshPrimitive::Mode::TRIANGLES ||
-      primitive.mode == MeshPrimitive::Mode::POINTS) {
+  switch (primitive.mode) {
+  case MeshPrimitive::Mode::TRIANGLES:
+  case MeshPrimitive::Mode::POINTS:
     for (int64_t i = 0; i < indicesView.size(); ++i) {
       indices[i] = indicesView[i];
     }
-  } else if (primitive.mode == MeshPrimitive::Mode::TRIANGLE_STRIP) {
+    break;
+  case MeshPrimitive::Mode::TRIANGLE_STRIP:
     for (int64_t i = 0; i < indicesView.size() - 2; ++i) {
       if (i % 2) {
         indices[3 * i] = indicesView[i];
@@ -361,13 +363,15 @@ void loadPrimitive(
         indices[3 * i + 2] = indicesView[i + 2];
       }
     }
-  } else { // MeshPrimitive::Mode::TRIANGLE_FAN
-    TIndex i0 = indicesView[0];
+    break;
+  case MeshPrimitive::Mode::TRIANGLE_FAN:
+  default:
     for (int64_t i = 2; i < indicesView.size(); ++i) {
-      indices[3 * i] = i0;
+      indices[3 * i] = indicesView[0];
       indices[3 * i + 1] = indicesView[i - 1];
       indices[3 * i + 2] = indicesView[i];
     }
+    break;
   }
 
   // Max attribute count supported by Unity, see VertexAttribute.


### PR DESCRIPTION
Depends on https://github.com/CesiumGS/cesium-native/pull/827.

Unity counterpart of https://github.com/CesiumGS/cesium-unreal/pull/1360. This incorporates the previous cesium-native changes so that `KHR_texture_transform` can be used while picking feature ID textures. 

### Test Picking

1. Create a dummy tileset containing the feature ID texture transform model [here](https://github.com/CesiumGS/cesium/tree/main/Specs/Data/Models/glTF-2.0/FeatureIdTextureWithTextureTransform/glTF).
2. In the `05_CesiumMetadata` sample level, add a new blank tileset. Add the aforementioned tileset via URL.
3. Set the ECEF coordinates of the `CesiumGeoreference` to (0, 0, 0). You should be able to double-click the tileset to zoom to it, but if that doesn't work properly, enable **Show Tiles In Hierarchy** and double-click the child game object that contains the mesh.
4. Reset the DynamicCamera transform. So position should be (0, 0, 0). Rotation should also be (0, 0, 0). (I've noticed the Unity editor complains about NaNs here, maybe I should write an issue about that...)
5. Offset the DynamicCamera from (0, 0, 0), along the Z axis. You want to position it so it can turn and view the feature ID texture at runtime.
6. Modify **CesiumSamplesMetadataPicking.cs** to `Debug.Log` the feature ID resulting from `GetFeatureIdFromHit`. Also, be sure that you remove the check for `modelMetadata != null` b/c this tileset doesn't use metadata.
7. Press Play. If all works out, you'll be able to move the camera (with some effort) to click on the feature ID texture. The darkest square returns a value of 54, and the brightest square corresponds to 135.

When a value is repeatedly logged, Unity will consolidate the notifications to a single entry in the console. So sometimes you won't see a feature ID at the bottom of the console if you re-pick it, because it's being counted under an earlier entry. Just clear the console so you can see it pop up again.

### Bonus Bugfix

While implementing this, I discovered a bug with feature ID picking that resulted from an inconsistency between Unity and the glTF model. In particular, the `RaycastHit.barycentricCoordinate` returned by Unity were completely different (in magnitude) from the barycentric coordinates returned in Unreal Engine. For the darkest square in the texture, the barycentric coordinates would largest in the 2nd vertex for Unity, whereas in Unreal the 3rd vertex had the biggest coordinate. I'm not 100% sure why this happens -- maybe it has to do with the difference in the way Unity handles mesh data (e.g. clockwise vs. counter-clockwise winding order).

In any case, I couldn't find a failproof way to swizzle the coordinates while maintaining correctness for every case, so I just implemented the barycentric coordinate logic in cesium-native, and use that in Unity. Now, feature ID picking should be accurate.