### PR TITLE
Use rotation from globe anchor in CesiumFlyToController

### DIFF
--- a/Runtime/CesiumFlyToController.cs
+++ b/Runtime/CesiumFlyToController.cs
@@ -357,7 +357,7 @@ namespace CesiumForUnity
         {
             // The source and destination rotations are expressed in East-Up-North coordinates.
             pitchAtDestination = Mathf.Clamp(pitchAtDestination, -89.99f, 89.99f);
-            this._sourceRotation = this.transform.rotation;
+            this._sourceRotation = this._globeAnchor.transform.rotation;
             this._destinationRotation = Quaternion.Euler(pitchAtDestination, yawAtDestination, 0.0f);
             this._destinationECEF = destinationECEF;
 


### PR DESCRIPTION
Something that got overlooked in changing CesiumFlyToController to be able to use a parent CesiumGlobeAnchor. Instead of using the local transform, we want to use the rotation of whatever transform the CesiumGlobeAnchor is attached to for the source rotation on our flight, since this is the object that the rotation is going to be applied to as it flies. 