### PR TITLE
Fix CI formatting issues (clang-format 18)

### DIFF
--- a/native~/Runtime/src/CesiumFeatureIdAttributeImpl.cpp
+++ b/native~/Runtime/src/CesiumFeatureIdAttributeImpl.cpp
@@ -6,6 +6,12 @@
 using namespace DotNet::CesiumForUnity;
 
 namespace CesiumForUnityNative {
+CesiumFeatureIdAttributeImpl::CesiumFeatureIdAttributeImpl(
+    const DotNet::CesiumForUnity::CesiumFeatureIdAttribute&
+        featureIdAttribute) {}
+
+CesiumFeatureIdAttributeImpl::~CesiumFeatureIdAttributeImpl() {}
+
 /*static*/ DotNet::CesiumForUnity::CesiumFeatureIdAttribute
 CesiumFeatureIdAttributeImpl::CreateAttribute(
     const CesiumGltf::Model& model,

--- a/native~/Runtime/src/CesiumFeatureIdAttributeImpl.h
+++ b/native~/Runtime/src/CesiumFeatureIdAttributeImpl.h
@@ -14,12 +14,10 @@ struct MeshPrimitive;
 namespace CesiumForUnityNative {
 class CesiumFeatureIdAttributeImpl {
 public:
-  ~CesiumFeatureIdAttributeImpl(){};
   CesiumFeatureIdAttributeImpl(
       const DotNet::CesiumForUnity::CesiumFeatureIdAttribute&
-          featureIdAttribute){};
-  void JustBeforeDelete(const DotNet::CesiumForUnity::CesiumFeatureIdAttribute&
-                            featureIdAttribute){};
+          featureIdAttribute);
+  ~CesiumFeatureIdAttributeImpl();
 
   static DotNet::CesiumForUnity::CesiumFeatureIdAttribute CreateAttribute(
       const CesiumGltf::Model& model,

--- a/native~/Runtime/src/CesiumFeatureIdTextureImpl.cpp
+++ b/native~/Runtime/src/CesiumFeatureIdTextureImpl.cpp
@@ -11,6 +11,12 @@
 using namespace DotNet::CesiumForUnity;
 
 namespace CesiumForUnityNative {
+
+CesiumFeatureIdTextureImpl::CesiumFeatureIdTextureImpl(
+    const DotNet::CesiumForUnity::CesiumFeatureIdTexture& featureIdTexture) {}
+
+CesiumFeatureIdTextureImpl::~CesiumFeatureIdTextureImpl() {}
+
 /*static*/ DotNet::CesiumForUnity::CesiumFeatureIdTexture
 CesiumFeatureIdTextureImpl::CreateTexture(
     const CesiumGltf::Model& model,

--- a/native~/Runtime/src/CesiumFeatureIdTextureImpl.h
+++ b/native~/Runtime/src/CesiumFeatureIdTextureImpl.h
@@ -21,11 +21,9 @@ struct FeatureIdTexture;
 namespace CesiumForUnityNative {
 class CesiumFeatureIdTextureImpl {
 public:
-  ~CesiumFeatureIdTextureImpl(){};
   CesiumFeatureIdTextureImpl(
-      const DotNet::CesiumForUnity::CesiumFeatureIdTexture& featureIdTexture){};
-  void JustBeforeDelete(
-      const DotNet::CesiumForUnity::CesiumFeatureIdTexture& featureIdTexture){};
+      const DotNet::CesiumForUnity::CesiumFeatureIdTexture& featureIdTexture);
+  ~CesiumFeatureIdTextureImpl();
 
   static DotNet::CesiumForUnity::CesiumFeatureIdTexture CreateTexture(
       const CesiumGltf::Model& model,

--- a/native~/Runtime/src/CesiumMetadataImpl.cpp
+++ b/native~/Runtime/src/CesiumMetadataImpl.cpp
@@ -52,6 +52,11 @@ int64_t getFeatureIdFromVertex(
 
 } // namespace
 
+CesiumMetadataImpl::CesiumMetadataImpl(
+    const DotNet::CesiumForUnity::CesiumMetadata& metadata) {}
+
+CesiumMetadataImpl::~CesiumMetadataImpl() {}
+
 void CesiumMetadataImpl::addMetadata(
     int32_t instanceID,
     const CesiumGltf::Model* pModel,

--- a/native~/Runtime/src/CesiumMetadataImpl.h
+++ b/native~/Runtime/src/CesiumMetadataImpl.h
@@ -23,10 +23,8 @@ namespace CesiumForUnityNative {
 
 class CesiumMetadataImpl {
 public:
-  ~CesiumMetadataImpl(){};
-  CesiumMetadataImpl(const DotNet::CesiumForUnity::CesiumMetadata& metadata){};
-  void
-  JustBeforeDelete(const DotNet::CesiumForUnity::CesiumMetadata& metadata){};
+  CesiumMetadataImpl(const DotNet::CesiumForUnity::CesiumMetadata& metadata);
+  ~CesiumMetadataImpl();
 
   void addMetadata(
       int32_t instanceID,

--- a/native~/Runtime/src/CesiumPropertyTablePropertyImpl.cpp
+++ b/native~/Runtime/src/CesiumPropertyTablePropertyImpl.cpp
@@ -867,6 +867,11 @@ TResult propertyTablePropertyCallback(
 
 } // namespace
 
+CesiumPropertyTablePropertyImpl::CesiumPropertyTablePropertyImpl(
+    const DotNet::CesiumForUnity::CesiumPropertyTableProperty& property) {}
+
+CesiumPropertyTablePropertyImpl::~CesiumPropertyTablePropertyImpl() {}
+
 bool CesiumPropertyTablePropertyImpl::GetBoolean(
     const DotNet::CesiumForUnity::CesiumPropertyTableProperty& property,
     std::int64_t featureID,

--- a/native~/Runtime/src/CesiumPropertyTablePropertyImpl.h
+++ b/native~/Runtime/src/CesiumPropertyTablePropertyImpl.h
@@ -44,11 +44,9 @@ namespace CesiumForUnityNative {
 
 class CesiumPropertyTablePropertyImpl {
 public:
-  ~CesiumPropertyTablePropertyImpl(){};
   CesiumPropertyTablePropertyImpl(
-      const DotNet::CesiumForUnity::CesiumPropertyTableProperty& property){};
-  void JustBeforeDelete(
-      const DotNet::CesiumForUnity::CesiumPropertyTableProperty& property){};
+      const DotNet::CesiumForUnity::CesiumPropertyTableProperty& property);
+  ~CesiumPropertyTablePropertyImpl();
 
   bool GetBoolean(
       const DotNet::CesiumForUnity::CesiumPropertyTableProperty& property,


### PR DESCRIPTION
This PR fixes the CI formatting errors currently on main.

CI has started using clang-format 18, which is unhappy about the `JustBeforeDelete` function defined in the .h files. Although I could have installed and ran clang-format 18, I realized that this function wasn't even necessary for the classes it was defined in. I have hence removed the function from those files.

I also moved the other empty function definitions to the `.cpp` files, to keep stylistically consistent with other classes in the plugin.