### PR TITLE
Don't delete `CesiumCreditSystem` while unloading other scenes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Normal, metallic-roughness, and occlusion textures from glTF models will now be correctly treated as linear rather than sRGB.
+- Fixed a bug where `CesiumCreditSystem` would delete itself from its scene when other additive scenes were unloaded.
 
 ### v1.8.0 - 2023-03-01
 

--- a/Runtime/CesiumCreditSystem.cs
+++ b/Runtime/CesiumCreditSystem.cs
@@ -7,7 +7,6 @@ using UnityEngine.SceneManagement;
 using UnityEngine.Networking;
 
 #if UNITY_EDITOR
-using UnityEditor;
 using UnityEditor.SceneManagement;
 #endif
 

--- a/Runtime/CesiumCreditSystem.cs
+++ b/Runtime/CesiumCreditSystem.cs
@@ -95,8 +95,16 @@ namespace CesiumForUnity
     [IconAttribute("Packages/com.cesium.unity/Editor/Resources/Cesium-24x24.png")]
     public partial class CesiumCreditSystem : MonoBehaviour
     {
+        private static CesiumCreditSystem _defaultCreditSystem;
+
         private List<CesiumCredit> _onScreenCredits;
         private List<CesiumCredit> _popupCredits;
+        private List<Texture2D> _images;
+        private int _numLoadingImages = 0;
+
+        const string base64Prefix = "data:image/png;base64,";
+        const string defaultName = "CesiumCreditSystemDefault";
+        const string creditSystemPrefabName = "CesiumCreditSystem";
 
         /// <summary>
         /// The current on-screen credits, represented as <see cref="CesiumCredit"/>s.
@@ -114,8 +122,6 @@ namespace CesiumForUnity
         {
             get => this._popupCredits;
         }
-
-        private List<Texture2D> _images;
 
         /// <summary>
         /// The images loaded by this credit system.
@@ -185,11 +191,6 @@ namespace CesiumForUnity
             }
         }
 
-        const string defaultName = "CesiumCreditSystemDefault";
-        const string creditSystemPrefabName = "CesiumCreditSystem";
-
-        private static CesiumCreditSystem _defaultCreditSystem;
-
         /// <summary>
         /// Creates an instance of the default credit system prefab.
         /// </summary>
@@ -236,14 +237,10 @@ namespace CesiumForUnity
             return _defaultCreditSystem;
         }
 
-        private int _numLoadingImages = 0;
-
         internal bool HasLoadingImages()
         {
             return this._numLoadingImages > 0;
         }
-
-        const string base64Prefix = "data:image/png;base64,";
 
         internal IEnumerator LoadImage(string url)
         {
@@ -323,13 +320,13 @@ namespace CesiumForUnity
         }
 
         /// <summary>
-        /// This handles the destruction of the credit system whenever a scene is unloaded at runtime.
+        /// This handles the destruction of the credit system whenever its scene is unloaded at runtime.
         /// </summary>
         /// <param name="scene">The scene being unloaded.</param>
         private void OnSceneUnloaded(Scene scene)
         {
             SceneManager.sceneUnloaded -= this.OnSceneUnloaded;
-            if (this != null && this.gameObject != null)
+            if (this != null && this.gameObject != null && this.gameObject.scene == scene)
                 UnityLifetime.Destroy(this.gameObject);
         }
 
@@ -343,7 +340,7 @@ namespace CesiumForUnity
         /// <param name="removingScene">Whether or not the closing scene is also being removed.</param>
         private static void HandleClosingScene(Scene scene, bool removingScene)
         {
-            if (_defaultCreditSystem != null)
+            if (_defaultCreditSystem != null && _defaultCreditSystem.gameObject.scene == scene)
             {
                 UnityLifetime.Destroy(_defaultCreditSystem.gameObject);
             }

--- a/Runtime/CesiumCreditSystemUI.cs
+++ b/Runtime/CesiumCreditSystemUI.cs
@@ -307,12 +307,15 @@ namespace CesiumForUnity
 
         private void SetCredits(List<CesiumCredit> onScreenCredits, List<CesiumCredit> popupCredits)
         {
-            this.SetCreditsOnVisualElements(
-                this._onScreenCredits,
-                onScreenCredits,
-                this._popupCredits,
-                popupCredits,
-                true);
+            if (this._onScreenCredits != null && this._popupCredits != null)
+            {
+                this.SetCreditsOnVisualElements(
+                    this._onScreenCredits,
+                    onScreenCredits,
+                    this._popupCredits,
+                    popupCredits,
+                    true);
+            }
 
 #if UNITY_EDITOR
             ArrayList sceneViews = SceneView.sceneViews;

--- a/Runtime/CesiumCreditSystemUI.cs
+++ b/Runtime/CesiumCreditSystemUI.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using UnityEngine.Networking;
 using UnityEngine.UIElements;
 
 #if ENABLE_INPUT_SYSTEM
@@ -75,7 +74,6 @@ namespace CesiumForUnity
 #endif
             }
         }
-
 
 #if UNITY_EDITOR
         private void AddCreditsToSceneView(SceneView sceneView)

--- a/native~/Runtime/src/Cesium3DTilesetImpl.cpp
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.cpp
@@ -108,6 +108,10 @@ void Cesium3DTilesetImpl::Update(
   }
 
 #endif
+  if (this->_creditSystem == nullptr) {
+    // Refresh the tileset so it creates and uses a new credit system.
+    this->DestroyTileset(tileset);
+  }
 
   if (!this->_pTileset) {
     this->LoadTileset(tileset);

--- a/native~/Runtime/src/Cesium3DTilesetImpl.h
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.h
@@ -50,7 +50,18 @@ public:
   Cesium3DTilesSelection::Tileset* getTileset();
   const Cesium3DTilesSelection::Tileset* getTileset() const;
 
+  /**
+   * Gets the Unity credit system for this tileset to pass credits to.
+   */
   const DotNet::CesiumForUnity::CesiumCreditSystem& getCreditSystem() const;
+  /**
+   * Sets the Unity credit system for this tileset to pass credits to.
+   * This is done when a new credit system is created in Unity.
+   *
+   * This is necessary to keep track of the Unity credit system's lifetime. If
+   * the credit system in Unity is destroyed, then the native one should update
+   * accordingly.
+   */
   void setCreditSystem(
       const DotNet::CesiumForUnity::CesiumCreditSystem& creditSystem);
 

--- a/native~/Runtime/src/CesiumCreditSystemImpl.cpp
+++ b/native~/Runtime/src/CesiumCreditSystemImpl.cpp
@@ -71,32 +71,32 @@ void CesiumCreditSystemImpl::UpdateCredits(
       const CesiumUtility::Credit& credit = creditsToShowThisFrame[i];
 
       DotNet::CesiumForUnity::CesiumCredit unityCredit;
-      const std::string& html = _pCreditSystem->getHtml(credit);
+      const std::string& html = this->_pCreditSystem->getHtml(credit);
 
-      auto htmlFind = _htmlToUnityCredit.find(html);
-      if (htmlFind != _htmlToUnityCredit.end()) {
+      auto htmlFind = this->_htmlToUnityCredit.find(html);
+      if (htmlFind != this->_htmlToUnityCredit.end()) {
         unityCredit = htmlFind->second;
       } else {
         unityCredit = convertHtmlToUnityCredit(html, creditSystem);
-        _htmlToUnityCredit.insert({html, unityCredit});
+        this->_htmlToUnityCredit.insert({html, unityCredit});
       }
 
       if (unityCredit.components().Count() == 0) {
         continue;
       }
 
-      if (_pCreditSystem->shouldBeShownOnScreen(credit)) {
+      if (this->_pCreditSystem->shouldBeShownOnScreen(credit)) {
         onScreenCredits.Add(unityCredit);
       } else {
         popupCredits.Add(unityCredit);
       }
     }
 
-    _creditsUpdated = true;
-    _lastCreditsCount = creditsCount;
+    this->_creditsUpdated = true;
+    this->_lastCreditsCount = creditsCount;
   }
 
-  _pCreditSystem->startNextFrame();
+  this->_pCreditSystem->startNextFrame();
 }
 
 namespace {
@@ -211,8 +211,8 @@ CesiumCreditSystemImpl::convertHtmlToUnityCredit(
 }
 
 const std::shared_ptr<CesiumUtility::CreditSystem>&
-CesiumCreditSystemImpl::getExternalCreditSystem() const {
-  return _pCreditSystem;
+CesiumCreditSystemImpl::getNativeCreditSystem() const {
+  return this->_pCreditSystem;
 }
 
 } // namespace CesiumForUnityNative

--- a/native~/Runtime/src/CesiumCreditSystemImpl.cpp
+++ b/native~/Runtime/src/CesiumCreditSystemImpl.cpp
@@ -39,26 +39,26 @@ CesiumCreditSystemImpl::~CesiumCreditSystemImpl() {}
 void CesiumCreditSystemImpl::UpdateCredits(
     const CesiumForUnity::CesiumCreditSystem& creditSystem,
     bool forceUpdate) {
-  if (!_pCreditSystem) {
+  if (!this->_pCreditSystem) {
     return;
   }
 
   // If the credits were updated in a previous frame, the update will not get
   // broadcasted until all of the images are fully loaded. Broadcast the
   // previous update first before handling the next one.
-  if (_creditsUpdated && !creditSystem.HasLoadingImages()) {
+  if (this->_creditsUpdated && !creditSystem.HasLoadingImages()) {
     creditSystem.BroadcastCreditsUpdate();
-    _creditsUpdated = false;
+    this->_creditsUpdated = false;
   }
 
   const std::vector<CesiumUtility::Credit>& creditsToShowThisFrame =
-      _pCreditSystem->getCreditsToShowThisFrame();
+      this->_pCreditSystem->getCreditsToShowThisFrame();
   size_t creditsCount = creditsToShowThisFrame.size();
-  _creditsUpdated =
-      forceUpdate || creditsCount != _lastCreditsCount ||
-      _pCreditSystem->getCreditsToNoLongerShowThisFrame().size() > 0;
+  this->_creditsUpdated =
+      forceUpdate || creditsCount != this->_lastCreditsCount ||
+      this->_pCreditSystem->getCreditsToNoLongerShowThisFrame().size() > 0;
 
-  if (_creditsUpdated) {
+  if (this->_creditsUpdated) {
     List1<CesiumForUnity::CesiumCredit> popupCredits =
         creditSystem.popupCredits();
     List1<CesiumForUnity::CesiumCredit> onScreenCredits =

--- a/native~/Runtime/src/CesiumCreditSystemImpl.h
+++ b/native~/Runtime/src/CesiumCreditSystemImpl.h
@@ -32,7 +32,7 @@ public:
       bool forceUpdate);
 
   const std::shared_ptr<CesiumUtility::CreditSystem>&
-  getExternalCreditSystem() const;
+  getNativeCreditSystem() const;
 
 private:
   // The underlying cesium-native credit system.

--- a/native~/Runtime/src/UnityTilesetExternals.h
+++ b/native~/Runtime/src/UnityTilesetExternals.h
@@ -4,13 +4,15 @@
 
 #include <DotNet/CesiumForUnity/Cesium3DTileset.h>
 
+#include <memory>
+
 namespace Cesium3DTilesSelection {
 class TilesetExternals;
 } // namespace Cesium3DTilesSelection
 
 namespace CesiumUtility {
 class CreditSystem;
-}
+} // namespace CesiumUtility
 
 namespace CesiumAsync {
 class AsyncSystem;
@@ -27,6 +29,11 @@ namespace CesiumForUnityNative {
 const std::shared_ptr<CesiumAsync::IAssetAccessor>& getAssetAccessor();
 const std::shared_ptr<CesiumAsync::ITaskProcessor>& getTaskProcessor();
 CesiumAsync::AsyncSystem getAsyncSystem();
+
+// Gets the credit system on the input Cesium3DTileset. If it does not exist,
+// this will create a new default credit system for the tileset.
+const std::shared_ptr<CesiumUtility::CreditSystem>&
+getOrCreateCreditSystem(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
 
 Cesium3DTilesSelection::TilesetExternals
 createTilesetExternals(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);


### PR DESCRIPTION
Fixes #436. This PR prevents `CesiumCreditSystem` from being destroyed in its scene when other additive scenes are loaded / unloaded.

To test, I created a new scene called "TestScene" and put a cube in it. I added it under the scenes in Build Settings, then created a script called "LoadUnloadScene.cs" with this code:

```
using UnityEngine;
using UnityEngine.InputSystem;
using UnityEngine.SceneManagement;

public class LoadUnloadScene : MonoBehaviour
{
    // Start is called before the first frame update
    void Start()
    {
        SceneManager.LoadScene("TestScene", LoadSceneMode.Additive);
    }

    // Update is called once per frame
    void Update()
    {
        if (Keyboard.current.digit1Key.wasPressedThisFrame)
        {
            SceneManager.UnloadSceneAsync("TestScene");
        }
    }
}
```

Then, I attached `LoadUnloadScene` as a component to the `CesiumGeoreference`. When you first run in Play mode, the test scene will load in. After pressing "1", the scene will unload. The credits UI should not disappear.

I even got this to work when the additive scene contained a tileset! In the first Cesium for Unity Sample scene, I moved Cesium OSM Buildings to a new georeference (same coordinates) under TestScene. Loading / unloading the scene properly updates the credit system in the original scene, without removing the UI. You can enable "Show Credits On Screen" to confirm that the original credit system updates for the tileset in the additive scene.

One problem here is, this all assumes the original credit system will not be unloaded. It's possible (though I don't know how practical) that the original scene is unloaded while additive ones remain. I tried fixing this but can't get it to work quite yet, so I'll write an issue and naybe address it in a follow-up PR.