### PR TITLE
Add extra WMTS properties

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### ? - ?
 
+##### Additions :tada:
+
+- Added `CesiumWebMapTileServiceRasterOverlay`, which enables Web Map Tile Service (WMTS) imagery to be draped on a `Cesium3DTileset`.
+
 ##### Fixes :wrench:
 
 - Normal, metallic-roughness, and occlusion textures from glTF models will now be correctly treated as linear rather than sRGB.

--- a/Editor/Cesium3DTilesetEditor.cs
+++ b/Editor/Cesium3DTilesetEditor.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 

--- a/Editor/CesiumWebMapServiceRasterOverlayEditor.cs
+++ b/Editor/CesiumWebMapServiceRasterOverlayEditor.cs
@@ -6,7 +6,6 @@ namespace CesiumForUnity
     [CustomEditor(typeof(CesiumWebMapServiceRasterOverlay))]
     public class CesiumWebMapServiceRasterOverlayEditor : Editor
     {
-        private CesiumWebMapServiceRasterOverlay _webMapServiceOverlay;
         private CesiumRasterOverlayEditor _rasterOverlayEditor;
 
         private SerializedProperty _baseUrl;
@@ -18,8 +17,6 @@ namespace CesiumForUnity
 
         private void OnEnable()
         {
-            this._webMapServiceOverlay =
-                (CesiumWebMapServiceRasterOverlay)this.target;
             this._rasterOverlayEditor =
                 (CesiumRasterOverlayEditor)Editor.CreateEditor(
                                                      this.target,

--- a/Editor/CesiumWebMapTileServiceRasterOverlayEditor.cs
+++ b/Editor/CesiumWebMapTileServiceRasterOverlayEditor.cs
@@ -6,39 +6,58 @@ namespace CesiumForUnity
     [CustomEditor(typeof(CesiumWebMapTileServiceRasterOverlay))]
     public class CesiumWebMapTileServiceRasterOverlayEditor : Editor
     {
-        private CesiumWebMapTileServiceRasterOverlay _webMapTileServiceOverlay;
         private CesiumRasterOverlayEditor _rasterOverlayEditor;
-        
+
         private SerializedProperty _baseUrl;
+        private SerializedProperty _layer;
+        private SerializedProperty _style;
+        private SerializedProperty _format;
+        private SerializedProperty _tileMatrixSetID;
+        private SerializedProperty _tileMatrixSetLabelPrefix;
+        private SerializedProperty _specifyTileMatrixSetLabels;
+        private SerializedProperty _tileMatrixSetLabels;
+        private SerializedProperty _projection;
+        private SerializedProperty _specifyTilingScheme;
+        private SerializedProperty _rootTilesX;
+        private SerializedProperty _rootTilesY;
+        private SerializedProperty _rectangleWest;
+        private SerializedProperty _rectangleSouth;
+        private SerializedProperty _rectangleEast;
+        private SerializedProperty _rectangleNorth;
         private SerializedProperty _tileWidth;
         private SerializedProperty _tileHeight;
+        private SerializedProperty _specifyZoomLevels;
         private SerializedProperty _minimumLevel;
         private SerializedProperty _maximumLevel;
-        private SerializedProperty _format;
-        private SerializedProperty _style;
-        private SerializedProperty _layer;
-        private SerializedProperty _tileMatrixSetID;
-        private SerializedProperty _useGeographicProjection;
 
         private void OnEnable()
         {
-            this._webMapTileServiceOverlay =
-                (CesiumWebMapTileServiceRasterOverlay)this.target;
             this._rasterOverlayEditor =
                 (CesiumRasterOverlayEditor)Editor.CreateEditor(
                                                      this.target,
                                                      typeof(CesiumRasterOverlayEditor));
 
             this._baseUrl = this.serializedObject.FindProperty("_baseUrl");
+            this._layer = this.serializedObject.FindProperty("_layer");
+            this._style = this.serializedObject.FindProperty("_style");
+            this._format = this.serializedObject.FindProperty("_format");
+            this._tileMatrixSetID = this.serializedObject.FindProperty("_tileMatrixSetID");
+            this._tileMatrixSetLabelPrefix = this.serializedObject.FindProperty("_tileMatrixSetLabelPrefix");
+            this._specifyTileMatrixSetLabels = this.serializedObject.FindProperty("_specifyTileMatrixSetLabels");
+            this._tileMatrixSetLabels = this.serializedObject.FindProperty("_tileMatrixSetLabels");
+            this._projection = this.serializedObject.FindProperty("_projection");
+            this._specifyTilingScheme = this.serializedObject.FindProperty("_specifyTilingScheme");
+            this._rootTilesX = this.serializedObject.FindProperty("_rootTilesX");
+            this._rootTilesY = this.serializedObject.FindProperty("_rootTilesY");
+            this._rectangleWest = this.serializedObject.FindProperty("_rectangleWest");
+            this._rectangleSouth = this.serializedObject.FindProperty("_rectangleSouth");
+            this._rectangleEast = this.serializedObject.FindProperty("_rectangleEast");
+            this._rectangleNorth = this.serializedObject.FindProperty("_rectangleNorth");
             this._tileWidth = this.serializedObject.FindProperty("_tileWidth");
             this._tileHeight = this.serializedObject.FindProperty("_tileHeight");
+            this._specifyZoomLevels = this.serializedObject.FindProperty("_specifyZoomLevels");
             this._minimumLevel = this.serializedObject.FindProperty("_minimumLevel");
             this._maximumLevel = this.serializedObject.FindProperty("_maximumLevel");
-            this._format = this.serializedObject.FindProperty("_format");
-            this._style = this.serializedObject.FindProperty("_style");
-            this._layer = this.serializedObject.FindProperty("_layer");
-            this._tileMatrixSetID = this.serializedObject.FindProperty("_tileMatrixSetID");
-            this._useGeographicProjection = this.serializedObject.FindProperty("_useGeographicProjection");
         }
 
         private void OnDisable()
@@ -54,14 +73,20 @@ namespace CesiumForUnity
             this.serializedObject.Update();
 
             EditorGUIUtility.labelWidth = CesiumEditorStyle.inspectorLabelWidth;
-            DrawWebMapTileServiceProperties();
+            this.DrawBasicProperties();
             EditorGUILayout.Space(5);
-            DrawRasterOverlayProperties();
+            this.DrawTileMatrixSetProperties();
+            EditorGUILayout.Space(5);
+            this.DrawTilingSchemeProperties();
+            EditorGUILayout.Space(5);
+            this.DrawLevelOfDetailContent();
+            EditorGUILayout.Space(5);
+            this.DrawRasterOverlayProperties();
 
             this.serializedObject.ApplyModifiedProperties();
         }
 
-        private void DrawWebMapTileServiceProperties()
+        private void DrawBasicProperties()
         {
             GUIContent baseUrlContent = new GUIContent(
                 "Base URL",
@@ -71,32 +96,155 @@ namespace CesiumForUnity
                 "\n\n" +
                 "https://tile.openstreetmap.org/{TileMatrix}/{TileCol}/{TileRow}.png");
             EditorGUILayout.DelayedTextField(this._baseUrl, baseUrlContent);
-            
+
             GUIContent layerContent = new GUIContent(
                 "Layer",
                 "The layer name for WMTS requests.");
             EditorGUILayout.DelayedTextField(this._layer, layerContent);
-            
+
             GUIContent styleContent = new GUIContent(
                 "Style",
                 "The style name for WMTS requests.");
             EditorGUILayout.DelayedTextField(this._style, styleContent);
-            
+
             GUIContent formatContent = new GUIContent(
                 "Format",
                 "The MIME type for images to retrieve from the server.");
             EditorGUILayout.DelayedTextField(this._format, formatContent);
-            
+        }
+
+        private void DrawTileMatrixSetProperties()
+        {
+            GUILayout.Label("Tile Matrix Set Descriptors", EditorStyles.boldLabel);
+
             GUIContent tileMatrixSetIDContent = new GUIContent(
                 "Tile Matrix Set ID",
                 "The tile matrix set identifier for WMTS requests.");
             EditorGUILayout.DelayedTextField(this._tileMatrixSetID, tileMatrixSetIDContent);
-            
-            GUIContent useGeographicProjectionContent = new GUIContent(
-                "Use Geographic Projection",
-                "If true, the overlay will be projected using a geographic projection. " +
-                "If false, the overlay will be projected using a web mercator projection.");
-            EditorGUILayout.PropertyField(this._useGeographicProjection, useGeographicProjectionContent);
+
+            EditorGUI.BeginDisabledGroup(this._specifyTileMatrixSetLabels.boolValue);
+            GUIContent tileMatrixSetLabelPrefixContent = new GUIContent(
+                "Tile Matrix Set Label Prefix",
+                "The prefix to use for the tile matrix set labels. For instance, setting \"EPSG:4326:\" " +
+                "as the prefix generates the list [\"EPSG:4326:0\", \"EPSG:4326:1\", \"EPSG:4326:2\", ...]." +
+                "\n\n" +
+                "Only applicable when \"Specify Tile Matrix Set Labels\" is false.");
+            EditorGUILayout.PropertyField(this._tileMatrixSetLabelPrefix, tileMatrixSetLabelPrefixContent);
+            EditorGUI.EndDisabledGroup();
+
+            GUIContent specifyTileMatrixSetLabelsContent = new GUIContent(
+                "Specify Tile Matrix Set Labels",
+                "Set this to true to manually specify the tile matrix set labels. If false, the labels " +
+                "will be constructed from the specified levels and prefix (if one is specified).");
+            EditorGUILayout.PropertyField(this._specifyTileMatrixSetLabels, specifyTileMatrixSetLabelsContent);
+
+            EditorGUI.BeginDisabledGroup(!this._specifyTileMatrixSetLabels.boolValue);
+            GUIContent tileMatrixSetLabelsContent = new GUIContent(
+                "Tile Matrix Set Label",
+                "The manually specified tile matrix set labels." +
+                "\n\n" +
+                "Only applicable when \"Specify Tile Matrix Set Labels\" is true.");
+            EditorGUILayout.PropertyField(this._tileMatrixSetLabels, tileMatrixSetLabelsContent);
+            EditorGUI.EndDisabledGroup();
+        }
+
+        private void DrawTilingSchemeProperties()
+        {
+            GUILayout.Label("Tiling Scheme", EditorStyles.boldLabel);
+
+            GUIContent projectionContent = new GUIContent(
+                "Projection",
+                "The type of projection used to project the WMTS imagery onto the globe. " +
+                "For instance, EPSG:4326 uses geographic projection and EPSG:3857 uses Web Mercator.");
+            EditorGUILayout.PropertyField(this._projection, projectionContent);
+
+            GUIContent specifyTilingSchemeContent = new GUIContent(
+                "Specify Tiling Scheme",
+                "Set this to true to specify the quadtree tiling scheme according to the specified root " +
+                "tile numbers and projected bounding rectangle. If false, the tiling scheme will be " +
+                "deduced from the projection.");
+            EditorGUILayout.PropertyField(this._specifyTilingScheme, specifyTilingSchemeContent);
+
+            EditorGUI.BeginDisabledGroup(!this._specifyTilingScheme.boolValue);
+            GUIContent rootTilesXContent = new GUIContent(
+                "Root Tiles X",
+                "The number of tiles corresponding to TileCol, also known as TileMatrixWidth. " +
+                "If specified, this determines the number of tiles at the root of the quadtree " +
+                "tiling scheme in the X direction." +
+                "\n\n" +
+                "Only applicable if \"Specify Tiling Scheme\" is set to true.");
+            EditorGUILayout.PropertyField(this._rootTilesX, rootTilesXContent);
+
+            GUIContent rootTilesYContent = new GUIContent(
+                "Root Tiles Y",
+                "The number of tiles corresponding to TileRow, also known as TileMatrixHeight. " +
+                "If specified, this determines the number of tiles at the root of the quadtree " +
+                "tiling scheme in the Y direction." +
+                "\n\n" +
+                "Only applicable if \"Specify Tiling Scheme\" is set to true.");
+            EditorGUILayout.PropertyField(this._rootTilesY, rootTilesYContent);
+
+            GUIContent rectangleWest = new GUIContent(
+                "Rectangle West",
+                "The west boundary of the bounding rectangle used for the quadtree tiling scheme. " +
+                "Specified in longitude degrees in the range [-180, 180]." +
+                "\n\n" +
+                "Only applicable if \"Specify Tiling Scheme\" is set to true.");
+            CesiumInspectorGUI.ClampedDoubleField(this._rectangleWest, -180, 180, rectangleWest, true);
+
+            GUIContent rectangleSouth = new GUIContent(
+                "Rectangle South",
+                "The south boundary of the bounding rectangle used for the quadtree tiling scheme. " +
+                "Specified in latitude degrees in the range [-90, 90]." +
+                "\n\n" +
+                "Only applicable if \"Specify Tiling Scheme\" is set to true.");
+            CesiumInspectorGUI.ClampedDoubleField(this._rectangleSouth, -90, 90, rectangleSouth, true);
+
+            GUIContent rectangleEast = new GUIContent(
+                "Rectangle East",
+                "The east boundary of the bounding rectangle used for the quadtree tiling scheme. " +
+                "Specified in longitude degrees in the range [-180, 180]." +
+                "\n\n" +
+                "Only applicable if \"Specify Tiling Scheme\" is set to true.");
+            CesiumInspectorGUI.ClampedDoubleField(this._rectangleEast, -180, 180, rectangleEast, true);
+
+            GUIContent rectangleNorth = new GUIContent(
+                "Rectangle North",
+                "The north boundary of the bounding rectangle used for the quadtree tiling scheme. " +
+                "Specified in latitude degrees in the range [-90, 90]." +
+                "\n\n" +
+                "Only applicable if \"Specify Tiling Scheme\" is set to true.");
+            CesiumInspectorGUI.ClampedDoubleField(this._rectangleNorth, -90, 90, rectangleNorth, true);
+            EditorGUI.EndDisabledGroup();
+        }
+
+        private void DrawLevelOfDetailContent()
+        {
+            GUILayout.Label("Level of Detail", EditorStyles.boldLabel);
+
+            GUIContent specifyZoomLevelsContent = new GUIContent(
+                "Specify Zoom Levels",
+                "Set this to true to directly specify the minimum and maximum zoom levels available " +
+                "from the server. If false, the minimum and maximum zoom levels will be retrieved " +
+                "from the server's tilemapresource.xml file."
+                );
+            EditorGUILayout.PropertyField(this._specifyZoomLevels, specifyZoomLevelsContent);
+
+            EditorGUI.BeginDisabledGroup(!this._specifyZoomLevels.boolValue);
+            GUIContent minimumLevelContent = new GUIContent(
+                "Minimum Level",
+                "Minimum zoom level." +
+                "\n\n" +
+                "Take care when specifying this that the number of tiles at the " +
+                "minimum level is small, such as four or less. A larger number " +
+                "is likely to result in rendering problems.");
+            EditorGUILayout.PropertyField(this._minimumLevel, minimumLevelContent);
+
+            GUIContent maximumLevelContent = new GUIContent(
+                "Maximum Level",
+                "Maximum zoom level.");
+            EditorGUILayout.PropertyField(this._maximumLevel, maximumLevelContent);
+            EditorGUI.EndDisabledGroup();
 
             GUIContent tileWidthContent = new GUIContent(
                 "Tile Width",
@@ -115,20 +263,6 @@ namespace CesiumForUnity
                 64,
                 2048,
                 tileHeightContent);
-
-            GUIContent minimumLevelContent = new GUIContent(
-                "Minimum Level",
-                "Minimum zoom level." +
-                "\n\n" +
-                "Take care when specifying this that the number of tiles at the " +
-                "minimum level is small, such as four or less. A larger number " +
-                "is likely to result in rendering problems.");
-            EditorGUILayout.PropertyField(this._minimumLevel, minimumLevelContent);
-
-            GUIContent maximumLevelContent = new GUIContent(
-                "Maximum Level",
-                "Maximum zoom level.");
-            EditorGUILayout.PropertyField(this._maximumLevel, maximumLevelContent);
         }
 
         private void DrawRasterOverlayProperties()

--- a/Runtime/CesiumGeoreference.cs
+++ b/Runtime/CesiumGeoreference.cs
@@ -133,7 +133,7 @@ namespace CesiumForUnity
             get => this._latitude;
             set
             {
-                this._latitude = value;
+                this._latitude = Math.Clamp(value, -90, 90);
                 this.originAuthority = CesiumGeoreferenceOriginAuthority.LongitudeLatitudeHeight;
             }
         }
@@ -149,7 +149,7 @@ namespace CesiumForUnity
             get => this._longitude;
             set
             {
-                this._longitude = value;
+                this._longitude = Math.Clamp(value, -180, 180);
                 this.originAuthority = CesiumGeoreferenceOriginAuthority.LongitudeLatitudeHeight;
             }
         }

--- a/Runtime/CesiumWebMapTileServiceRasterOverlay.cs
+++ b/Runtime/CesiumWebMapTileServiceRasterOverlay.cs
@@ -1,8 +1,26 @@
 ﻿using Reinterop;
+using System.Collections.Generic;
+using System;
 using UnityEngine;
 
 namespace CesiumForUnity
 {
+    /// <summary>
+    /// Specifies the type of projection used for projecting a Web Map Tile Service raster overlay.
+    /// </summary>
+    public enum CesiumWebMapTileServiceRasterOverlayProjection
+    {
+        /// <summary>
+        /// The raster overlay is projected using Web Mercator.
+        /// </summary>
+        WebMercator,
+
+        /// <summary>
+        /// The raster overlay is projected using a geographic projection.
+        /// </summary>
+        Geographic
+    }
+
     /// <summary>
     /// A raster overlay that directly accesses a Web Map Tile Service (WMTS) server.
     /// https://www.ogc.org/standards/wmts
@@ -14,7 +32,10 @@ namespace CesiumForUnity
     [IconAttribute("Packages/com.cesium.unity/Editor/Resources/Cesium-24x24.png")]
     public partial class CesiumWebMapTileServiceRasterOverlay : CesiumRasterOverlay
     {
-        [SerializeField] private string _baseUrl = "";
+        #region Fields
+
+        [SerializeField]
+        private string _baseUrl = "";
 
         /// <summary>
         /// The base URL of the Web Map Tile Service (WMTS).
@@ -33,10 +54,11 @@ namespace CesiumForUnity
             }
         }
 
-        [SerializeField] private string _layer = "";
+        [SerializeField]
+        private string _layer = "";
 
         /// <summary>
-        /// The layer name for WMTS requests.
+        /// The layer name to use for WMTS requests.
         /// </summary>
         public string layer
         {
@@ -48,10 +70,11 @@ namespace CesiumForUnity
             }
         }
 
-        [SerializeField] private string _style = "";
+        [SerializeField]
+        private string _style = "";
 
         /// <summary>
-        /// The style name for WMTS requests, default value is "default".
+        /// The style name to use for WMTS requests.
         /// </summary>
         public string style
         {
@@ -63,7 +86,8 @@ namespace CesiumForUnity
             }
         }
 
-        [SerializeField] private string _format = "image/jpeg";
+        [SerializeField]
+        private string _format = "image/jpeg";
 
         /// <summary>
         /// The MIME type for images to retrieve from the server. The default value is "image/jpeg".
@@ -78,7 +102,8 @@ namespace CesiumForUnity
             }
         }
 
-        [SerializeField] private string _tileMatrixSetID = "";
+        [SerializeField]
+        private string _tileMatrixSetID = "";
 
         /// <summary>
         /// The identifier of the TileMatrixSet to use for WMTS requests.
@@ -92,26 +117,232 @@ namespace CesiumForUnity
                 this.Refresh();
             }
         }
-        
-        [SerializeField] private bool _useGeographicProjection = false;
+
+        [SerializeField]
+        private string _tileMatrixSetLabelPrefix;
 
         /// <summary>
-        /// Change projection to GeographicProjection (the default is WebMercatorProjection).
+        /// The prefix to use for the tile matrix set labels. For instance, setting 
+        /// "EPSG:4326:" as the prefix generates the list ["EPSG:4326:0", "EPSG:4326:1",
+        /// "EPSG:4326:2", ...].
+        /// Only applicable when <see cref="specifyTileMatrixSetLabels"/> is false.
         /// </summary>
-        public bool useGeographicProjection
+        public string tileMatrixSetLabelPrefix
         {
-            get => this._useGeographicProjection;
+            get => this._tileMatrixSetLabelPrefix;
             set
             {
-                this._useGeographicProjection = value;
+                this._tileMatrixSetLabelPrefix = value;
                 this.Refresh();
             }
         }
 
-        [SerializeField] private int _minimumLevel = 0;
+
+        [SerializeField]
+        private bool _specifyTileMatrixSetLabels = false;
+
+        /// <summary>
+        /// Set this to true to manually specify the tile matrix set labels. If false, 
+        /// the labels will be constructed from the specified levels and prefix (if one is specified).
+        /// </summary>
+        public bool specifyTileMatrixSetLabels
+        {
+            get => this._specifyTileMatrixSetLabels;
+            set
+            {
+                this._specifyTileMatrixSetLabels = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private List<string> _tileMatrixSetLabels;
+
+        /**
+         * The manually specified tile matrix set labels. Only applicable when 
+         * <see cref="specifyTileMatrixSetLabels"/> is true.
+         */
+        public List<string> tileMatrixSetLabels
+        {
+            get => this._tileMatrixSetLabels;
+            set
+            {
+                this._tileMatrixSetLabels = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private CesiumWebMapTileServiceRasterOverlayProjection _projection = CesiumWebMapTileServiceRasterOverlayProjection.WebMercator;
+
+        /// <summary>
+        /// The type of projection used to project the WMTS imagery onto the globe. 
+        /// For instance, EPSG:4326 uses geographic projection and EPSG:3857 uses Web Mercator.
+        /// </summary>
+        public CesiumWebMapTileServiceRasterOverlayProjection projection
+        {
+            get => this._projection;
+            set
+            {
+                this._projection = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        bool _specifyTilingScheme = false;
+
+        /// <summary>
+        /// Set this to true to specify the quadtree tiling scheme according to the 
+        /// specified projection, root tile numbers, and bounding rectangle.
+        /// If false, the tiling scheme will be deduced from the projection.
+        /// </summary>
+        public bool specifyTilingScheme
+        {
+            get => this._specifyTilingScheme;
+            set
+            {
+                this._specifyTilingScheme = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        [Min(1)]
+        private int _rootTilesX = 1;
+
+        /// <summary>
+        /// The number of tiles corresponding to TileCol, also known as TileMatrixWidth. If specified,
+        /// this determines the number of tiles at the root of the quadtree tiling scheme in the X 
+        /// direction.
+        /// Only applicable if <see cref="specifyTilingScheme"/> is set to true.
+        /// </summary>
+        public int rootTilesX
+        {
+            get => this._rootTilesX;
+            set
+            {
+                this._rootTilesX = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        [Min(1)]
+        private int _rootTilesY = 1;
+
+        /// <summary>
+        /// The number of tiles corresponding to TileRow, also known as TileMatrixHeight. If specified,
+        /// this determines the number of tiles at the root of the quadtree tiling scheme in the Y 
+        /// direction.
+        /// Only applicable if <see cref="specifyTilingScheme"/> is set to true.
+        /// </summary>
+        public int rootTilesY
+        {
+            get => this._rootTilesY;
+            set
+            {
+                this._rootTilesY = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private double _rectangleWest = -180;
+
+        /// <summary>
+        /// The west boundary of the bounding rectangle used for the quadtree tiling scheme. 
+        /// Specified in longitude degrees in the range [-180, 180].
+        /// Only applicable if <see cref="specifyTilingScheme"/> is set to true.
+        /// </summary>
+        public double rectangleWest
+        {
+            get => this._rectangleWest;
+            set
+            {
+                this._rectangleWest = Math.Clamp(value, -180, 180);
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private double _rectangleSouth = -90;
+
+        /// <summary>
+        /// The south boundary of the bounding rectangle used for the quadtree tiling scheme. 
+        /// Specified in latitude degrees in the range [-90, 90]. 
+        /// Only applicable if <see cref="specifyTilingScheme"/> is set to true.
+        /// </summary>
+        public double rectangleSouth
+        {
+            get => this._rectangleSouth;
+            set
+            {
+                this._rectangleSouth = Math.Clamp(value, -90, 90);
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private double _rectangleEast = 180;
+
+        /// <summary>
+        /// The east boundary of the bounding rectangle used for the quadtree tiling scheme. 
+        /// Specified in longitude degrees in the range [-180, 180].
+        /// Only applicable if <see cref="specifyTilingScheme"/> is set to true.
+        /// </summary>
+        public double rectangleEast
+        {
+            get => this._rectangleEast;
+            set
+            {
+                this._rectangleEast = Math.Clamp(value, -180, 180);
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private double _rectangleNorth = 90;
+
+        /// <summary>
+        /// The north boundary of the bounding rectangle used for the quadtree tiling scheme. 
+        /// Specified in latitude degrees in the range [-90, 90].
+        /// Only applicable if <see cref="specifyTilingScheme"/> is set to true.
+        /// </summary>
+        public double rectangleNorth
+        {
+            get => this._rectangleNorth;
+            set
+            {
+                this._rectangleNorth = Math.Clamp(value, -90, 90);
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private bool _specifyZoomLevels = false;
+
+        /// <summary>
+        /// Set this to true to directly specify the minimum and maximum zoom levels available
+        /// from the server. If false, the minimum and maximum zoom levels will be retrieved
+        /// from the server's tilemapresource.xml file.
+        /// </summary>
+        public bool specifyZoomLevels
+        {
+            get => this._specifyZoomLevels;
+            set
+            {
+                this._specifyZoomLevels = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private int _minimumLevel = 0;
 
         /// <summary>
         /// The minimum level-of-detail supported by the imagery provider.
+        /// Only applicable if <see cref="specifyZoomLevels"/> is set to true.
         /// </summary>
         public int minimumLevel
         {
@@ -123,10 +354,12 @@ namespace CesiumForUnity
             }
         }
 
-        [SerializeField] private int _maximumLevel = 25;
+        [SerializeField]
+        private int _maximumLevel = 25;
 
         /// <summary>
         /// The maximum level-of-detail supported by the imagery provider.
+        /// Only applicable if <see cref="specifyZoomLevels"/> is set to true.
         /// </summary>
         public int maximumLevel
         {
@@ -138,7 +371,8 @@ namespace CesiumForUnity
             }
         }
 
-        [SerializeField] private int _tileWidth = 256;
+        [SerializeField]
+        private int _tileWidth = 256;
 
         /// <summary>
         /// The pixel width of the image tiles.
@@ -153,7 +387,8 @@ namespace CesiumForUnity
             }
         }
 
-        [SerializeField] private int _tileHeight = 256;
+        [SerializeField]
+        private int _tileHeight = 256;
 
         /// <summary>
         /// The pixel height of the image tiles.
@@ -167,6 +402,8 @@ namespace CesiumForUnity
                 this.Refresh();
             }
         }
+
+        #endregion
 
         /// <inheritdoc/>
         protected override partial void AddToTileset(Cesium3DTileset tileset);

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -331,22 +331,31 @@ namespace CesiumForUnity
             webMapServiceRasterOverlay.tileHeight = webMapServiceRasterOverlay.tileHeight;
             webMapServiceRasterOverlay.minimumLevel = webMapServiceRasterOverlay.minimumLevel;
             webMapServiceRasterOverlay.maximumLevel = webMapServiceRasterOverlay.maximumLevel;
-            
             baseOverlay = webMapServiceRasterOverlay;
-            
+
             CesiumWebMapTileServiceRasterOverlay webMapTileServiceRasterOverlay =
                 go.GetComponent<CesiumWebMapTileServiceRasterOverlay>();
             webMapTileServiceRasterOverlay.baseUrl = webMapTileServiceRasterOverlay.baseUrl;
-            webMapTileServiceRasterOverlay.tileWidth = webMapTileServiceRasterOverlay.tileWidth;
-            webMapTileServiceRasterOverlay.tileHeight = webMapTileServiceRasterOverlay.tileHeight;
+            webMapTileServiceRasterOverlay.layer = webMapTileServiceRasterOverlay.layer;
+            webMapTileServiceRasterOverlay.style = webMapTileServiceRasterOverlay.style;
+            webMapTileServiceRasterOverlay.format = webMapTileServiceRasterOverlay.format;
+            webMapTileServiceRasterOverlay.tileMatrixSetID = webMapTileServiceRasterOverlay.tileMatrixSetID;
+            webMapTileServiceRasterOverlay.tileMatrixSetLabelPrefix = webMapTileServiceRasterOverlay.tileMatrixSetLabelPrefix;
+            webMapTileServiceRasterOverlay.specifyTileMatrixSetLabels = webMapTileServiceRasterOverlay.specifyTileMatrixSetLabels;
+            webMapTileServiceRasterOverlay.tileMatrixSetLabels = webMapTileServiceRasterOverlay.tileMatrixSetLabels;
+            webMapTileServiceRasterOverlay.projection = webMapTileServiceRasterOverlay.projection;
+            webMapTileServiceRasterOverlay.specifyTilingScheme = webMapTileServiceRasterOverlay.specifyTilingScheme;
+            webMapTileServiceRasterOverlay.rootTilesX = webMapTileServiceRasterOverlay.rootTilesX;
+            webMapTileServiceRasterOverlay.rootTilesY = webMapTileServiceRasterOverlay.rootTilesY;
+            webMapTileServiceRasterOverlay.rectangleEast = webMapTileServiceRasterOverlay.rectangleEast;
+            webMapTileServiceRasterOverlay.rectangleSouth = webMapTileServiceRasterOverlay.rectangleSouth;
+            webMapTileServiceRasterOverlay.rectangleWest = webMapTileServiceRasterOverlay.rectangleWest;
+            webMapTileServiceRasterOverlay.rectangleNorth = webMapTileServiceRasterOverlay.rectangleNorth;
+            webMapTileServiceRasterOverlay.specifyZoomLevels = webMapTileServiceRasterOverlay.specifyZoomLevels;
             webMapTileServiceRasterOverlay.minimumLevel = webMapTileServiceRasterOverlay.minimumLevel;
             webMapTileServiceRasterOverlay.maximumLevel = webMapTileServiceRasterOverlay.maximumLevel;
-            webMapTileServiceRasterOverlay.format = webMapTileServiceRasterOverlay.format;
-            webMapTileServiceRasterOverlay.style = webMapTileServiceRasterOverlay.style;
-            webMapTileServiceRasterOverlay.layer = webMapTileServiceRasterOverlay.layer;
-            webMapTileServiceRasterOverlay.tileMatrixSetID = webMapTileServiceRasterOverlay.tileMatrixSetID;
-            webMapTileServiceRasterOverlay.useGeographicProjection = webMapTileServiceRasterOverlay.useGeographicProjection;
-            
+            webMapTileServiceRasterOverlay.tileWidth = webMapTileServiceRasterOverlay.tileWidth;
+            webMapTileServiceRasterOverlay.tileHeight = webMapTileServiceRasterOverlay.tileHeight;
             baseOverlay = webMapTileServiceRasterOverlay;
 
             CesiumRasterOverlay[] overlaysArray = go.GetComponents<CesiumRasterOverlay>();
@@ -468,10 +477,12 @@ namespace CesiumForUnity
             List<string> stringList = new List<string>();
             stringList.Add("item");
             stringList.Clear();
+            count = stringList.Count;
 
             string test = string.Concat("string", "string2");
             string[] stringArray = stringList.ToArray();
             test = stringArray[0];
+            test = stringList[0];
             test = string.Join(" ", stringArray);
             string.IsNullOrEmpty("value");
             string.IsNullOrWhiteSpace("value");

--- a/native~/Runtime/src/CesiumWebMapServiceRasterOverlayImpl.cpp
+++ b/native~/Runtime/src/CesiumWebMapServiceRasterOverlayImpl.cpp
@@ -46,6 +46,7 @@ void CesiumWebMapServiceRasterOverlayImpl::AddToTileset(
     wmsOptions.minimumLevel = overlay.minimumLevel();
     wmsOptions.maximumLevel = overlay.maximumLevel();
   }
+
   wmsOptions.layers = overlay.layers().ToStlString();
   wmsOptions.tileWidth = overlay.tileWidth();
   wmsOptions.tileHeight = overlay.tileHeight();

--- a/native~/Runtime/src/CesiumWebMapTileServiceRasterOverlayImpl.cpp
+++ b/native~/Runtime/src/CesiumWebMapTileServiceRasterOverlayImpl.cpp
@@ -9,11 +9,15 @@
 #include <DotNet/CesiumForUnity/Cesium3DTileset.h>
 #include <DotNet/CesiumForUnity/CesiumRasterOverlay.h>
 #include <DotNet/CesiumForUnity/CesiumWebMapTileServiceRasterOverlay.h>
+#include <DotNet/CesiumForUnity/CesiumWebMapTileServiceRasterOverlayProjection.h>
+#include <DotNet/System/Collections/Generic/List1.h>
 #include <DotNet/System/String.h>
 
 using namespace Cesium3DTilesSelection;
 using namespace CesiumRasterOverlays;
 using namespace DotNet;
+using namespace DotNet::CesiumForUnity;
+using namespace DotNet::System::Collections::Generic;
 
 namespace CesiumForUnityNative {
 
@@ -52,13 +56,61 @@ void CesiumWebMapTileServiceRasterOverlayImpl::AddToTileset(
   wmtsOptions.layer = overlay.layer().ToStlString();
   wmtsOptions.style = overlay.style().ToStlString();
   wmtsOptions.tileMatrixSetID = overlay.tileMatrixSetID().ToStlString();
-  wmtsOptions.minimumLevel = overlay.minimumLevel();
-  wmtsOptions.maximumLevel = overlay.maximumLevel();
+
+  if (overlay.specifyZoomLevels() &&
+      overlay.maximumLevel() > overlay.minimumLevel()) {
+    wmtsOptions.minimumLevel = overlay.minimumLevel();
+    wmtsOptions.maximumLevel = overlay.maximumLevel();
+  }
+
   wmtsOptions.tileWidth = overlay.tileWidth();
   wmtsOptions.tileHeight = overlay.tileHeight();
 
-  if (overlay.useGeographicProjection()) {
+  if (overlay.projection() ==
+      CesiumWebMapTileServiceRasterOverlayProjection::Geographic) {
     wmtsOptions.projection = CesiumGeospatial::GeographicProjection();
+  } else {
+    wmtsOptions.projection = CesiumGeospatial::WebMercatorProjection();
+  }
+
+  if (overlay.specifyTilingScheme()) {
+    CesiumGeospatial::GlobeRectangle globeRectangle =
+        CesiumGeospatial::GlobeRectangle::fromDegrees(
+            overlay.rectangleWest(),
+            overlay.rectangleSouth(),
+            overlay.rectangleEast(),
+            overlay.rectangleNorth());
+    CesiumGeometry::Rectangle coverageRectangle =
+        CesiumGeospatial::projectRectangleSimple(
+            *wmtsOptions.projection,
+            globeRectangle);
+    wmtsOptions.coverageRectangle = coverageRectangle;
+    wmtsOptions.tilingScheme = CesiumGeometry::QuadtreeTilingScheme(
+        coverageRectangle,
+        overlay.rootTilesX(),
+        overlay.rootTilesY());
+  }
+
+  if (overlay.specifyTileMatrixSetLabels()) {
+    List1<DotNet::System::String> unityLabels = overlay.tileMatrixSetLabels();
+    if (unityLabels.Count() > 0) {
+      std::vector<std::string> labels(unityLabels.Count());
+      for (int i = 0; i < unityLabels.Count(); i++) {
+        DotNet::System::String unityLabel = unityLabels[i];
+        labels[i] = unityLabel.ToStlString();
+      }
+      wmtsOptions.tileMatrixLabels = labels;
+    }
+  } else {
+    if (!DotNet::System::String::IsNullOrEmpty(
+            overlay.tileMatrixSetLabelPrefix())) {
+      std::string prefix = overlay.tileMatrixSetLabelPrefix().ToStlString();
+      std::vector<std::string> labels(26);
+      for (size_t level = 0; level <= 25; ++level) {
+        labels.emplace_back(prefix + std::to_string(level));
+      }
+      wmtsOptions.tileMatrixLabels = labels;
+    }
   }
 
   CesiumForUnity::CesiumRasterOverlay genericOverlay = overlay;


### PR DESCRIPTION
This PR follows #430, which added basic support for WMTS overlays. The goal of this PR was to achieve parity with Cesium for Unreal, which boasts many more settings on the WMTS overlay.

Here's a screenshot of the new UI:

<img src="https://github.com/CesiumGS/cesium-unity/assets/32226860/4281224a-29a1-452d-b451-f11c1b168f6c" width="500px"/>

There are some differences from the Unreal one:
- Instead of the `useWebMercatorProjection` or `useGeographicProjection` flag, I made it formal enum so that the intent was much clearer.
- I've prefixed the "West", "South", etc. variables so they now read "Rectangle West", "Rectangle South", etc. I'm open to better names, but I thought it was better to be explicit in this way.

I'd like to update the Unreal UI to match Unity's, namely the enum change, but it's not an urgent change that has to make it into the next release.
