### PR TITLE
Fix token selector panel problems

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that caused Cesium ion tokens selected on the Tokens panel to fail to save.
+- Fixed a bug that caused the "Select Cesium ion Token" panel to show the wrong state when the current token is not from the currently-signed-in Cesium ion account and the signed-in account has a token named after the current Unity project.
+
 ### v1.10.1 - 2024-06-03
 
 This release updates [cesium-native](https://github.com/CesiumGS/cesium-native) from v0.35.0 to v0.36.0. See the [changelog](https://github.com/CesiumGS/cesium-native/blob/main/CHANGES.md) for a complete list of changes in cesium-native.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug that caused Cesium ion tokens selected on the Tokens panel to fail to save.
-- Fixed a bug that caused the "Select Cesium ion Token" panel to show the wrong state when the current token is not from the currently-signed-in Cesium ion account and the signed-in account has a token named after the current Unity project.
+- Fixed a bug that caused the "Select Cesium ion Token" panel to show the wrong state when the current token was not from the currently-signed-in Cesium ion account, but the signed-in account had a token named after the current Unity project.
 
 ### v1.10.1 - 2024-06-03
 

--- a/Editor/ConfigureReinterop.cs
+++ b/Editor/ConfigureReinterop.cs
@@ -245,6 +245,8 @@ namespace CesiumForUnity
             assetDetails.loaded = true;
 
             EditorApplication.ExecuteMenuItem("Window/General/Hierarchy");
+
+            EditorUtility.SetDirty(null);
         }
     }
 }

--- a/Editor/SelectIonTokenWindow.cs
+++ b/Editor/SelectIonTokenWindow.cs
@@ -106,9 +106,14 @@ namespace CesiumForUnity
 
                 this._createdTokenName = GetDefaultNewTokenName();
                 this._specifiedToken = this.server.defaultIonAccessToken;
-                this._source = session.IsConnected()
-                    ? IonTokenSource.Create
-                    : IonTokenSource.Specify;
+                
+                // The source will be set to "UseExisting" later by RefreshTokens
+                // if the _specifiedToken is from the currently signed-in ion account.
+                this._source = IonTokenSource.Specify;
+                if (this._specifiedToken.Length == 0 && session.IsConnected())
+                {
+                    this._source = IonTokenSource.Create;
+                }
 
                 session.RefreshTokens();
 

--- a/native~/Editor/src/SelectIonTokenWindowImpl.cpp
+++ b/native~/Editor/src/SelectIonTokenWindowImpl.cpp
@@ -15,6 +15,7 @@
 #include <DotNet/System/Array1.h>
 #include <DotNet/System/Collections/Generic/List1.h>
 #include <DotNet/System/Object.h>
+#include <DotNet/UnityEditor/EditorUtility.h>
 #include <DotNet/UnityEngine/Debug.h>
 #include <DotNet/UnityEngine/GameObject.h>
 #include <DotNet/UnityEngine/Object.h>
@@ -222,42 +223,70 @@ void SelectIonTokenWindowImpl::RefreshTokens(
 
   CesiumForUnity::CesiumIonServer server = getServer(window);
 
-  const std::string& createName =
+  const std::string createName =
       CesiumForUnity::SelectIonTokenWindow::GetDefaultNewTokenName()
           .ToStlString();
-  const std::string& defaultTokenId =
+  const std::string defaultTokenId =
       server.defaultIonAccessTokenId().ToStlString();
-  const std::string& specifiedToken = window.specifiedToken().ToStlString();
+  const std::string specifiedToken = window.specifiedToken().ToStlString();
+
+  std::optional<size_t> selectedTokenById;
+  std::optional<size_t> selectedTokenByValue;
+  std::optional<size_t> selectedTokenByCreateName;
 
   for (size_t i = 0; i < tokens.size(); ++i) {
     if (this->_tokens[i]) {
-      *this->_tokens[i] = std::move(tokens[i]);
+      *this->_tokens[i] = tokens[i];
     } else {
-      this->_tokens[i] =
-          std::make_shared<CesiumIonClient::Token>(std::move(tokens[i]));
+      this->_tokens[i] = std::make_shared<CesiumIonClient::Token>(tokens[i]);
     }
 
     if (this->_tokens[i]->id == defaultTokenId) {
-      window.selectedExistingTokenIndex(i);
-      window.tokenSource(CesiumForUnity::IonTokenSource::UseExisting);
+      selectedTokenById = i;
     }
 
-    // If there's already a token with the default name we would use to create
-    // a new one, default to selecting that rather than creating a new one.
-    if (window.tokenSource() == CesiumForUnity::IonTokenSource::Create &&
-        this->_tokens[i]->name == createName) {
-      window.selectedExistingTokenIndex(i);
-      window.tokenSource(CesiumForUnity::IonTokenSource::UseExisting);
+    if (this->_tokens[i]->token == specifiedToken) {
+      selectedTokenByValue = i;
     }
 
-    // If this happens to be the specified token, select it.
-    if (window.tokenSource() == CesiumForUnity::IonTokenSource::Specify &&
-        this->_tokens[i]->token == specifiedToken) {
-      window.selectedExistingTokenIndex(i);
-      window.tokenSource(CesiumForUnity::IonTokenSource::UseExisting);
+    if (this->_tokens[i]->name == createName) {
+      selectedTokenByCreateName = i;
     }
 
     tokenNames.Add(System::String(this->_tokens[i]->name));
+  }
+
+  // If there is already a token selected, the panel should reflect that
+  // accurately. But if there is no token selected, the panel should reflect a
+  // _recommendation_: either create a new one or select the existing one with
+  // the name we would create.
+  if (!specifiedToken.empty()) {
+    if (selectedTokenByValue) {
+      window.selectedExistingTokenIndex(*selectedTokenByValue);
+      window.tokenSource(CesiumForUnity::IonTokenSource::UseExisting);
+    } else if (selectedTokenById) {
+      window.selectedExistingTokenIndex(*selectedTokenById);
+      window.tokenSource(CesiumForUnity::IonTokenSource::UseExisting);
+    } else {
+      // The specified token does not exist in the user's account.
+      window.tokenSource(CesiumForUnity::IonTokenSource::Specify);
+
+      // If the user's account does have a token that matches the default name
+      // we would use if we created one for this project, then select that token
+      // in the "Use Existing" dropdown, for convenience.
+      if (selectedTokenByCreateName) {
+        window.selectedExistingTokenIndex(*selectedTokenByCreateName);
+      }
+    }
+  } else {
+    if (selectedTokenByCreateName) {
+      // A token already exists that has the name we recommend for a new token.
+      // So recommend selecting that existing one.
+      window.selectedExistingTokenIndex(*selectedTokenByCreateName);
+      window.tokenSource(CesiumForUnity::IonTokenSource::UseExisting);
+    } else {
+      window.tokenSource(CesiumForUnity::IonTokenSource::Create);
+    }
   }
 
   window.RefreshExistingTokenList();
@@ -274,6 +303,7 @@ void updateDefaultToken(
 
     server.defaultIonAccessToken(System::String(response.value->token));
     server.defaultIonAccessTokenId(System::String(response.value->id));
+    UnityEditor::EditorUtility::SetDirty(server);
 
     // TODO: source control
 

--- a/native~/Editor/src/SelectIonTokenWindowImpl.cpp
+++ b/native~/Editor/src/SelectIonTokenWindowImpl.cpp
@@ -305,8 +305,6 @@ void updateDefaultToken(
     server.defaultIonAccessTokenId(System::String(response.value->id));
     UnityEditor::EditorUtility::SetDirty(server);
 
-    // TODO: source control
-
     // Refresh all tilesets and overlays that are using the project
     // default token.
     System::Array1 tilesets = UnityEngine::Object::FindObjectsOfType<


### PR DESCRIPTION
Fixes #469 

Also fixed up some code that was assigning by-value returns from a function to references (setting up a likely use-after-free, though I didn't see any actual problems as a result of this). And some other code that was attempting to std::move away `CesiumIonClient::Token` records owned by someone else (luckily the source was const so the std::move was only misleading, not harmful).

The state tracking on the Tokens panel was also a little bit broken, and I hopefully fixed it up. As a reminder, the panel looks like this:

![image](https://github.com/CesiumGS/cesium-unity/assets/924374/5ead177a-f6b5-4a37-8458-f3f7ff6296b9)

This panel is a little confusing because it has two purposes and they are sometimes slightly conflicting. First, it should show the user how the project default token is _currently_ configured for their project. Second - particularly when no token is selected yet - it should make it easy for the user to choose a suitable project default token.

Take a look at the changed code and the comments to understand how I think this should all come together. Previously the panel could pop up with "Use an existing token" checked and some token selected in the dropdown below it, while _actually_ using some totally different token displayed in the Specify a token section.