### PR TITLE
Fix incorrect ECEF->LLH transformation in CesiumCartographicPolygon.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug that caused a `NullReferenceException` when attempting to get or set the `longitudeLatitudeHeight` property on a disabled `CesiumGlobeAnchor`.
+- Fixed a bug introduced in v1.11.0 that caused `CesiumCartographicPolygon` positions to be interpreted incorrectly, making polygon clipping unusable.
 
 ### v1.11.0 - 2024-07-01
 

--- a/Runtime/CesiumCartographicPolygon.cs
+++ b/Runtime/CesiumCartographicPolygon.cs
@@ -138,7 +138,7 @@ namespace CesiumForUnity
                 float3 worldPosition = knot.Transform(localToWorld).Position;
                 float3 unityPosition = worldToTileset.MultiplyPoint3x4(worldPosition);
                 double3 ecefPosition = georeference.TransformUnityPositionToEarthCenteredEarthFixed(unityPosition);
-                double3 cartographicPosition = georeference.ellipsoid.LongitudeLatitudeHeightToCenteredFixed(ecefPosition);
+                double3 cartographicPosition = georeference.ellipsoid.CenteredFixedToLongitudeLatitudeHeight(ecefPosition);
 
                 cartographicPoints.Add(cartographicPosition.xy);
             }

--- a/Tests/CesiumTests.asmdef
+++ b/Tests/CesiumTests.asmdef
@@ -5,7 +5,8 @@
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
         "CesiumRuntime",
-        "Unity.Mathematics"
+        "Unity.Mathematics",
+        "Unity.Splines"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -18,6 +19,12 @@
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"
     ],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.splines",
+            "expression": "1.0.0",
+            "define": "SUPPORTS_SPLINES"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Tests/TestCesiumCartographicPolygon.cs
+++ b/Tests/TestCesiumCartographicPolygon.cs
@@ -1,0 +1,62 @@
+using CesiumForUnity;
+using NUnit.Framework;
+using System.Collections.Generic;
+using Unity.Mathematics;
+using UnityEngine;
+
+#if SUPPORTS_SPLINES
+using UnityEngine.Splines;
+#endif
+
+public class TestCesiumCartographicPolygon
+{
+#if SUPPORTS_SPLINES
+    [Test]
+    public void GetCartographicPoints()
+    {
+        GameObject go = new GameObject("Game Object");
+
+        CesiumGeoreference georeference = go.AddComponent<CesiumGeoreference>();
+        georeference.SetOriginLongitudeLatitudeHeight(12.0, 23.0, 456.0);
+
+        CesiumCartographicPolygon polygonComponent = go.AddComponent<CesiumCartographicPolygon>();
+        SplineContainer splineContainer = go.GetComponent<SplineContainer>();
+
+        // Remove existing spline(s).
+        IReadOnlyList<Spline> splines = splineContainer.Splines;
+        for (int i = splines.Count - 1; i >= 0; i--)
+        {
+            splineContainer.RemoveSpline(splines[i]);
+        }
+
+        // Add a new spline.
+        Spline defaultSpline = new Spline();
+
+        BezierKnot[] knots = new BezierKnot[] {
+            new BezierKnot(new float3(-100.0f, 0f, -100.0f)),
+            new BezierKnot(new float3(100.0f, 0f, -100.0f)),
+            new BezierKnot(new float3(100.0f, 0f, 100.0f)),
+            new BezierKnot(new float3(-100.0f, 0f, 100.0f)),
+        };
+
+        defaultSpline.Knots = knots;
+        defaultSpline.Closed = true;
+        defaultSpline.SetTangentMode(TangentMode.Linear);
+
+        splineContainer.AddSpline(defaultSpline);
+
+        List<double2> cartographicPoints = polygonComponent.GetCartographicPoints(Matrix4x4.identity);
+        Assert.AreEqual(cartographicPoints.Count, 4);
+
+        // All points are near the georeference origin
+        Assert.AreEqual(cartographicPoints[0].x, 12.0, 0.01);
+        Assert.AreEqual(cartographicPoints[0].y, 23.0, 0.01);
+        Assert.AreEqual(cartographicPoints[1].x, 12.0, 0.01);
+        Assert.AreEqual(cartographicPoints[1].y, 23.0, 0.01);
+        Assert.AreEqual(cartographicPoints[2].x, 12.0, 0.01);
+        Assert.AreEqual(cartographicPoints[2].y, 23.0, 0.01);
+        Assert.AreEqual(cartographicPoints[3].x, 12.0, 0.01);
+        Assert.AreEqual(cartographicPoints[3].y, 23.0, 0.01);
+    }
+#endif
+}

--- a/Tests/TestCesiumCartographicPolygon.cs.meta
+++ b/Tests/TestCesiumCartographicPolygon.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e72a29cb07fcfcd4ab2f7891914a7626
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
After #465, `CesiumCartographicPolygon` was incorrectly calling `LongitudeLatitudeHeightToCenteredFixed` when attempting to transform ECEF to Longitude/Latitude/Height. That is, it was transforming in the wrong direction. This made the vertex positions in the polygon incorrect, breaking the polygon functionality completely.

Reported here:
https://community.cesium.com/t/cesiumpolygonrasteroverlay-can-not-clip-vectortilemap-in-v1-11/34093
