### PR TITLE
Add 'True Origin' placement mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ##### Additions :tada:
 
 - Editor builds for macOS now target macOS 10.15+. Previously, macOS 12.7+ was required.
+- Added `originPlacement` property to `CesiumGeoreference` to toggle between "Cartographic Origin" and "True Origin" reference modes. Whereas "Cartographic Origin" is the default for georeferenced tilesets, "True Origin" may be used for non-georeferenced tilesets centered at the origin.
 
 ##### Fixes :wrench:
 

--- a/Editor/CesiumGeoreferenceEditor.cs
+++ b/Editor/CesiumGeoreferenceEditor.cs
@@ -72,16 +72,15 @@ namespace CesiumForUnity
 
             DrawInspectorButtons();
             EditorGUILayout.Space(5);
-
-            this.DrawOriginPlacementProperty();
-            this.DrawOriginAuthorityProperty();
+            
+            this.DrawOriginModeProperties();
             EditorGUILayout.Space(5);
             this.DrawLongitudeLatitudeHeightProperties();
             EditorGUILayout.Space(5);
             this.DrawEarthCenteredEarthFixedProperties();
             EditorGUILayout.Space(5);
+            
             this.DrawScaleProperty();
-            EditorGUILayout.Space(5);
             this.DrawEllipsoidOverrideProperty();
 
             this.serializedObject.ApplyModifiedProperties();
@@ -90,7 +89,9 @@ namespace CesiumForUnity
         private void DrawInspectorButtons()
         {
             // Don't modify the georeference if the editor is in play mode.
-            EditorGUI.BeginDisabledGroup(EditorApplication.isPlaying);
+            EditorGUI.BeginDisabledGroup(
+                EditorApplication.isPlaying
+                || this.originPlacement != CesiumGeoreferenceOriginPlacement.CartographicOrigin);
 
             GUILayout.BeginHorizontal();
             GUIContent placeOriginHereContent = new GUIContent(
@@ -109,8 +110,6 @@ namespace CesiumForUnity
                 CesiumEditorUtility.PlaceGeoreferenceAtCameraPosition(this._georeference);
             }
 
-            EditorGUI.BeginDisabledGroup(
-                this.originPlacement != CesiumGeoreferenceOriginPlacement.CartographicOrigin);
             GUIContent createSubSceneContent = new GUIContent(
                 "Create Sub-Scene Here",
                 "Creates a child GameObject with a \"CesiumSubScene\" component whose origin " +
@@ -123,17 +122,18 @@ namespace CesiumForUnity
             {
                 CesiumEditorUtility.CreateSubScene(this._georeference);
             }
-            EditorGUI.EndDisabledGroup();
 
             GUILayout.EndHorizontal();
 
             EditorGUI.EndDisabledGroup();
         }
 
-        private void DrawOriginPlacementProperty()
+        private void DrawOriginModeProperties()
         {
+            GUILayout.Label("Origin Mode", EditorStyles.boldLabel);
+
             GUIContent originPlacementContent = new GUIContent(
-                "Origin Placement",
+                "Placement",
                 "The placement of this GameObject's origin (0,0,0) within the tileset." +
                 "\n\n" +
                 "3D Tiles tilesets often use Earth-centered, Earth-fixed coordinates, such that " +
@@ -144,6 +144,17 @@ namespace CesiumForUnity
                 "preserve vertex precision (and thus avoid jittering) much better than setting the " +
                 "GameObject's Transform property.");
             EditorGUILayout.PropertyField(this._originPlacement, originPlacementContent);
+            
+            EditorGUI.BeginDisabledGroup(
+                this.originPlacement != CesiumGeoreferenceOriginPlacement.CartographicOrigin);
+
+            GUIContent originAuthorityContent = new GUIContent(
+                "Authority",
+                "The set of coordinates that authoritatively define the origin of " +
+                "this georeference.");
+            EditorGUILayout.PropertyField(this._originAuthority, originAuthorityContent);
+
+            EditorGUI.EndDisabledGroup();
         }
 
         private void DrawEllipsoidOverrideProperty()
@@ -176,20 +187,6 @@ namespace CesiumForUnity
                 "The globe can also be scaled by modifying the georeference's Transform, " +
                 "but setting this property instead will do a better job of preserving precision.");
             EditorGUILayout.PropertyField(this._scale, scaleContent);
-        }
-
-        private void DrawOriginAuthorityProperty()
-        {
-            EditorGUI.BeginDisabledGroup(
-                this.originPlacement != CesiumGeoreferenceOriginPlacement.CartographicOrigin);
-
-            GUIContent originAuthorityContent = new GUIContent(
-                "Origin Authority",
-                "The set of coordinates that authoritatively define the origin of " +
-                "this georeference.");
-            EditorGUILayout.PropertyField(this._originAuthority, originAuthorityContent);
-
-            EditorGUI.EndDisabledGroup();
         }
 
         private void DrawLongitudeLatitudeHeightProperties()

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -393,6 +393,7 @@ namespace CesiumForUnity
             georeference.ecefX = georeference.ecefX;
             georeference.ecefY = georeference.ecefY;
             georeference.ecefZ = georeference.ecefZ;
+            georeference.originPlacement = georeference.originPlacement;
             georeference.originAuthority = georeference.originAuthority;
             georeference.scale = georeference.scale;
             double4x4 ecefToLocal = georeference.ecefToLocalMatrix;


### PR DESCRIPTION
Closes #426.

This replicates the "True Origin" placement mode we have in Cesium for Unreal. This will be helpful for users with non-georeferenced tilesets.

I rearranged the `CesiumGeoreference`'s Inspector UI so the order was more intuitive. Here's what it looks like on both modes:

| Cartographic Origin | True Origin |
| ---------------------- | ------------ |
| ![image](https://github.com/user-attachments/assets/40321f06-5740-4c58-886a-6174b1359f78) | ![image](https://github.com/user-attachments/assets/2474d157-45fd-41bc-9258-ed2be5efa21e) |
