### PR TITLE
Fix another crash caused by destroying CesiumIonSession while it is doing network requests

### DIFF
--- a/native~/Editor/src/CesiumIonSessionImpl.cpp
+++ b/native~/Editor/src/CesiumIonSessionImpl.cpp
@@ -436,6 +436,9 @@ void CesiumIonSessionImpl::refreshProfile(
       .thenInMainThread(
           [this, session](
               CesiumIonClient::Response<CesiumIonClient::Profile>&& profile) {
+            if (session == nullptr)
+              return;
+
             this->_isLoadingProfile = false;
             this->_profile = std::move(profile.value);
             this->broadcastProfileUpdate();
@@ -443,6 +446,9 @@ void CesiumIonSessionImpl::refreshProfile(
               this->refreshProfile(session);
           })
       .catchInMainThread([this, session](std::exception&& e) {
+        if (session == nullptr)
+          return;
+
         this->_isLoadingProfile = false;
         this->_profile = std::nullopt;
         this->broadcastProfileUpdate();
@@ -470,6 +476,9 @@ void CesiumIonSessionImpl::refreshAssets(
       .thenInMainThread(
           [this, session](
               CesiumIonClient::Response<CesiumIonClient::Assets>&& assets) {
+            if (session == nullptr)
+              return;
+
             this->_isLoadingAssets = false;
             this->_assets = std::move(assets.value);
             this->broadcastAssetsUpdate();
@@ -477,6 +486,9 @@ void CesiumIonSessionImpl::refreshAssets(
               this->refreshAssets(session);
           })
       .catchInMainThread([this, session](std::exception&& e) {
+        if (session == nullptr)
+          return;
+
         this->_isLoadingAssets = false;
         this->_assets = std::nullopt;
         this->broadcastAssetsUpdate();
@@ -509,6 +521,9 @@ void CesiumIonSessionImpl::refreshTokens(
       .thenInMainThread(
           [this, session](
               CesiumIonClient::Response<CesiumIonClient::TokenList>&& tokens) {
+            if (session == nullptr)
+              return;
+
             this->_isLoadingTokens = false;
             this->_tokens =
                 tokens.value
@@ -519,6 +534,9 @@ void CesiumIonSessionImpl::refreshTokens(
               this->refreshTokens(session);
           })
       .catchInMainThread([this, session](std::exception&& e) {
+        if (session == nullptr)
+          return;
+
         this->_isLoadingTokens = false;
         this->_tokens = std::nullopt;
         this->broadcastTokensUpdate();
@@ -541,6 +559,9 @@ void CesiumIonSessionImpl::refreshDefaults(
       .thenInMainThread(
           [this, session](
               CesiumIonClient::Response<CesiumIonClient::Defaults>&& defaults) {
+            if (session == nullptr)
+              return;
+
             logResponseErrors(defaults);
             this->_isLoadingDefaults = false;
             this->_defaults = std::move(defaults.value);
@@ -550,6 +571,9 @@ void CesiumIonSessionImpl::refreshDefaults(
               this->refreshDefaults(session);
           })
       .catchInMainThread([this, session](std::exception&& e) {
+        if (session == nullptr)
+          return;
+
         logResponseErrors(e);
         this->_isLoadingDefaults = false;
         this->_defaults = std::nullopt;


### PR DESCRIPTION
In #479, I made some improvements to `CesiumIonSession` to a) keep the managed object alive while requests are in progress, and b) check that they haven't been destroyed (such as by an AppDomain unload) when the request completes. This significantly improved the stability of the tests, but I was still seeing an occasional access violation when running tests. For example, here:
https://github.com/CesiumGS/cesium-unity/actions/runs/10658298813/job/29539138580

I was able to reproduce this on my machine by running the tests repeatedly, and the cause was that the CesiumIonSession was being destroyed while one of the `refresh` methods was running. Looks like I missed those when making the previous changes.

This fix is an improvement, but still isn't perfect. During AppDomain unload, it's possible for the finalizer to run in another thread in between when the validaty of the session is checked and when we use the corresponding native object, which will still result in a crash. This PR narrows the window. The only complete solution, as far as I can see, will be allowing the native world to share ownership of the Impl objects with the managed world, via reference counting.