### PR TITLE
WIP Added Vision Pro build support

### DIFF
--- a/Editor/CompileCesiumForUnityNative.cs
+++ b/Editor/CompileCesiumForUnityNative.cs
@@ -173,6 +173,18 @@ namespace CesiumForUnity
             else if (library.Platform == BuildTarget.VisionOS)
             {
                 importer.SetPlatformData(library.Platform, "CPU", "ARM64");
+
+                var projectPath = Application.dataPath.Replace("Assets", "");
+                foreach (var libFilePath in Directory.EnumerateFiles(library.InstallDirectory, "*.a", SearchOption.AllDirectories))
+                {
+                    var libRelativeFilePath = libFilePath.Replace(projectPath, "");
+                    var libPluginImporter = AssetImporter.GetAtPath(libRelativeFilePath) as PluginImporter;
+                    
+                    if (libPluginImporter != null)
+                    {
+                        libPluginImporter.SetPlatformData(library.Platform, "CPU", "ARM64");
+                    }
+                }
             }
         }
 

--- a/Editor/CompileCesiumForUnityNative.cs
+++ b/Editor/CompileCesiumForUnityNative.cs
@@ -502,9 +502,16 @@ namespace CesiumForUnity
                     if (IsVisionOS(library.PlatformGroup, library.Platform))
                     {
                         var xcodeProjectPath = Path.Combine(library.BuildDirectory, "CesiumForUnityNative.xcodeproj/project.pbxproj");
-                        var originalXcodeContents = File.ReadAllText(xcodeProjectPath);
-                        var xcodeContentsTargetedToXros = originalXcodeContents.Replace("SDKROOT = iphoneos;", "SDKROOT = xros;");
-                        File.WriteAllText(xcodeProjectPath, xcodeContentsTargetedToXros);
+                        if (File.Exists(xcodeProjectPath))
+                        {
+                            var originalXcodeContents = File.ReadAllText(xcodeProjectPath);
+                            var xcodeContentsTargetedToXros = originalXcodeContents.Replace("SDKROOT = iphoneos;", "SDKROOT = xros;");
+                            File.WriteAllText(xcodeProjectPath, xcodeContentsTargetedToXros);
+                        }
+                        else
+                        {
+                            UnityEngine.Debug.Log("Xcode project does not exist, unable to change target to VisionOs");
+                        }
                     }
                     
                     args = new List<string>()

--- a/Editor/CompileCesiumForUnityNative.cs
+++ b/Editor/CompileCesiumForUnityNative.cs
@@ -377,9 +377,7 @@ namespace CesiumForUnity
                     library.ExtraConfigureArgs.Add("-DCMAKE_ANDROID_ARCH_ABI=arm64-v8a");
             }
 
-            if (platform.platformGroup == BuildTargetGroup.iOS 
-                //VisionOS will use IOS config and SDKROOT will be changed after as currently 3rd party libs could not be compiled for xros
-                || platform.platformGroup == BuildTargetGroup.VisionOS) 
+            if (platform.platformGroup == BuildTargetGroup.iOS || platform.platformGroup == BuildTargetGroup.VisionOS) 
             {
                 library.Toolchain = "extern/ios-toolchain.cmake";
                 library.ExtraConfigureArgs.Add("-GXcode");

--- a/Editor/CompileCesiumForUnityNative.cs
+++ b/Editor/CompileCesiumForUnityNative.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Text;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 #if UNITY_ANDROID
 using UnityEditor.Android;
 #endif
@@ -174,9 +175,18 @@ namespace CesiumForUnity
             {
                 importer.SetPlatformData(library.Platform, "CPU", "ARM64");
 
+                // TODO: WARN: this will likely cause issues, why native build generates those libs? Where are they needed?
+                var duplicatedSymbolsExcludeLibs = new string[] {
+                    "libjpeg.a",
+                    "libwebp.a"
+                };
+                
                 var projectPath = Application.dataPath.Replace("Assets", "");
                 foreach (var libFilePath in Directory.EnumerateFiles(library.InstallDirectory, "*.a", SearchOption.AllDirectories))
                 {
+                    if(duplicatedSymbolsExcludeLibs.Any(l =>  libFilePath.EndsWith(l)))
+                        continue;
+                    
                     var libRelativeFilePath = libFilePath.Replace(projectPath, "");
                     var libPluginImporter = AssetImporter.GetAtPath(libRelativeFilePath) as PluginImporter;
                     

--- a/Editor/CompileCesiumForUnityNative.cs
+++ b/Editor/CompileCesiumForUnityNative.cs
@@ -170,6 +170,10 @@ namespace CesiumForUnity
                     UnityEngine.Debug.LogAssertion("Unsupported processor: " + library.Cpu);
                 importer.SetPlatformData(library.Platform, "CPU", wsaPlatform);
             }
+            else if (library.Platform == BuildTarget.VisionOS)
+            {
+                importer.SetPlatformData(library.Platform, "CPU", "ARM64");
+            }
         }
 
         private static void OnPostprocessAllAssets(

--- a/Editor/ConfigureReinterop.cs
+++ b/Editor/ConfigureReinterop.cs
@@ -22,6 +22,8 @@ namespace CesiumForUnity
         public const string CppOutputPath = "../native~/Editor/generated-Android";
 #elif UNITY_IOS
         public const string CppOutputPath = "../native~/Editor/generated-iOS";
+#elif UNITY_VISIONOS
+        public const string CppOutputPath = "../native~/Editor/generated-VisionOS";
 #elif UNITY_WSA
         public const string CppOutputPath = "../native~/Runtime/generated-WSA";
 #elif UNITY_64
@@ -37,7 +39,7 @@ namespace CesiumForUnity
 
         // The name of the DLL or SO containing the C++ code.
         public const string NativeLibraryName = "CesiumForUnityNative-Editor";
-
+        
         // Comma-separated types to treat as non-blittable, even if their fields would
         // otherwise cause Reinterop to treat them as blittable.
         public const string NonBlittableTypes = "Unity.Collections.LowLevel.Unsafe.AtomicSafetyHandle,Unity.Collections.NativeArray,UnityEngine.MeshData,UnityEngine.MeshDataArray";

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -31,6 +31,8 @@ namespace CesiumForUnity
         public const string CppOutputPath = "../native~/Runtime/generated-Android";
 #elif UNITY_IOS
         public const string CppOutputPath = "../native~/Runtime/generated-iOS";
+#elif UNITY_VISIONOS
+        public const string CppOutputPath = "../native~/Runtime/generated-VisionOS";
 #elif UNITY_WSA
         public const string CppOutputPath = "../native~/Runtime/generated-WSA";
 #elif UNITY_64
@@ -45,7 +47,7 @@ namespace CesiumForUnity
         public const string BaseNamespace = "DotNet";
 
         // The name of the DLL or SO containing the C++ code.
-#if UNITY_IOS && !UNITY_EDITOR
+#if (UNITY_IOS || UNITY_VISIONOS) && !UNITY_EDITOR
         public const string NativeLibraryName = "__Internal";
 #else
         public const string NativeLibraryName = "CesiumForUnityNative-Runtime";
@@ -336,7 +338,7 @@ namespace CesiumForUnity
 
             CesiumWebMapTileServiceRasterOverlay webMapTileServiceRasterOverlay =
                 go.GetComponent<CesiumWebMapTileServiceRasterOverlay>();
-            webMapTileServiceRasterOverlay.baseUrl = webMapTileServiceRasterOverlay.baseUrl;
+            webMapTileServiceRasterOverlay.baseUrl = webMapTileServiceRasterOverlay.baseUrl; 
             webMapTileServiceRasterOverlay.layer = webMapTileServiceRasterOverlay.layer;
             webMapTileServiceRasterOverlay.style = webMapTileServiceRasterOverlay.style;
             webMapTileServiceRasterOverlay.format = webMapTileServiceRasterOverlay.format;


### PR DESCRIPTION
Added Vision Pro build support, this is done by:

- getting Reinterop to build libs to `Generated-VisionOS`
- building native library with IOS configuration
- changing XCode SDK to xros (after generation, workaround)
- fixing issue where Unity would not copy generated Cesium libs to Xcode project (by setting CPU to ARM64 explicitly)
- excluding some native libs from final XCode build (workaround)

Still work in progress but should be good starting place for anyone looking to use Cesium for Unity on Vision Pro / Polyspatial.

Approach taken here contains some workarounds - happy to continue on this one but would need some guidance.

1) Cesium native is built using IOS config and XCode project is later re-targetted to xros, ideally we'd have separate xros toolchain for cmake, eg `extern/xros-toolchain.cmake` when I tried to build that it'd fail when resolving triplets
```
*** The output from the command was:
Computing installation plan...
The following packages will be built and installed:
    asyncplusplus:arm64-ios-unity@1.1#2 -- /Volumes/External/src/cesium-unity-samples-vp/Packages/com.cesium.unity/native~/vcpkg/ports/asyncplusplus
  * vcpkg-cmake:arm64-osx@2024-04-23
  * vcpkg-cmake-config:arm64-osx@2024-05-23
Additional packages (*) will be modified to complete this operation.
Detecting compiler hash for triplet arm64-osx...
Compiler found: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
Unable to determine toolchain use for arm64-ios-unity with with CMAKE_SYSTEM_NAME visionOS. Did you mean to use VCPKG_CHAINLOAD_TOOLCHAIN_FILE?
note: updating vcpkg by rerunning bootstrap-vcpkg may resolve this failure.
```

Could resolve that properly to build for VisionOS from start.

2) Needed to hardcode some generated libs to be exlcuded from build
```
"libjpeg.a",
"libwebp.a"
```
As they fail to compile (duplicated symbols) - not 100% sure if that exclusion will cause issues.

Also looks like native project for this PR installs into Plugins folder quite a lot of libraries that I've not seen built in other forum threads, notably 86 libs build for `libabsl_XXX.a` eg `libabsl_bad_any_cast_impl.a`, `libabsl_string_view.a`, `libabsl_throw_delegate.a` 
