### PR TITLE
Reference counting and accidental copy prevention for Impl classes

### DIFF
--- a/Reinterop~/MethodsImplementedInCpp.cs
+++ b/Reinterop~/MethodsImplementedInCpp.cs
@@ -33,7 +33,9 @@ namespace Reinterop
                     #endif
                     void* {{createName}}(void* handle) {
                       const {{wrapperType.GetFullyQualifiedName()}} wrapper{{{objectHandleType.GetFullyQualifiedName()}}(handle)};
-                      return reinterpret_cast<void*>(new {{implType.GetFullyQualifiedName()}}(wrapper));
+                      auto pImpl = new {{implType.GetFullyQualifiedName()}}(wrapper);
+                      pImpl->addReference();
+                      return reinterpret_cast<void*>(pImpl);
                     }
                     """,
                     TypeDefinitionsReferenced: new[]
@@ -68,7 +70,7 @@ namespace Reinterop
                     #endif
                     void {{destroyName}}(void* pImpl) {
                       auto pImplTyped = reinterpret_cast<{{implType.GetFullyQualifiedName()}}*>(pImpl);
-                      delete pImplTyped;
+                      if (pImplTyped) pImplTyped->releaseReference();
                     }
                     """,
                     TypeDefinitionsReferenced: new[]

--- a/native~/Editor/src/CesiumEditorWindowImpl.h
+++ b/native~/Editor/src/CesiumEditorWindowImpl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <CesiumUtility/ReferenceCounted.h>
+
 #include <DotNet/CesiumForUnity/Cesium3DTileset.h>
 #include <DotNet/System/String.h>
 #include <DotNet/UnityEngine/GameObject.h>
@@ -13,7 +15,8 @@ class CesiumEditorWindow;
 
 namespace CesiumForUnityNative {
 
-class CesiumEditorWindowImpl {
+class CesiumEditorWindowImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<CesiumEditorWindowImpl> {
 
 public:
   CesiumEditorWindowImpl(

--- a/native~/Editor/src/CesiumEditorWindowImpl.h
+++ b/native~/Editor/src/CesiumEditorWindowImpl.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <CesiumUtility/ReferenceCounted.h>
+#include "CesiumImpl.h"
 
 #include <DotNet/CesiumForUnity/Cesium3DTileset.h>
 #include <DotNet/System/String.h>
@@ -15,8 +15,7 @@ class CesiumEditorWindow;
 
 namespace CesiumForUnityNative {
 
-class CesiumEditorWindowImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<CesiumEditorWindowImpl> {
+class CesiumEditorWindowImpl : public CesiumImpl<CesiumEditorWindowImpl> {
 
 public:
   CesiumEditorWindowImpl(

--- a/native~/Editor/src/CesiumIonSessionImpl.h
+++ b/native~/Editor/src/CesiumIonSessionImpl.h
@@ -8,6 +8,7 @@
 #include <CesiumIonClient/Defaults.h>
 #include <CesiumIonClient/Profile.h>
 #include <CesiumIonClient/Token.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/System/Collections/Generic/List1.h>
 #include <DotNet/System/String.h>
@@ -33,7 +34,8 @@ class Token;
 } // namespace CesiumIonClient
 
 namespace CesiumForUnityNative {
-class CesiumIonSessionImpl {
+class CesiumIonSessionImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<CesiumIonSessionImpl> {
 public:
   CesiumIonSessionImpl(const DotNet::CesiumForUnity::CesiumIonSession& session);
   ~CesiumIonSessionImpl();

--- a/native~/Editor/src/CesiumIonSessionImpl.h
+++ b/native~/Editor/src/CesiumIonSessionImpl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumAsync/AsyncSystem.h>
 #include <CesiumAsync/IAssetAccessor.h>
 #include <CesiumAsync/SharedFuture.h>
@@ -8,7 +10,6 @@
 #include <CesiumIonClient/Defaults.h>
 #include <CesiumIonClient/Profile.h>
 #include <CesiumIonClient/Token.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/System/Collections/Generic/List1.h>
 #include <DotNet/System/String.h>
@@ -34,8 +35,7 @@ class Token;
 } // namespace CesiumIonClient
 
 namespace CesiumForUnityNative {
-class CesiumIonSessionImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<CesiumIonSessionImpl> {
+class CesiumIonSessionImpl : public CesiumImpl<CesiumIonSessionImpl> {
 public:
   CesiumIonSessionImpl(const DotNet::CesiumForUnity::CesiumIonSession& session);
   ~CesiumIonSessionImpl();

--- a/native~/Editor/src/IonAssetsTreeViewImpl.h
+++ b/native~/Editor/src/IonAssetsTreeViewImpl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CesiumIonClient/Assets.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/CesiumForUnity/IonAssetsColumn.h>
 #include <DotNet/System/String.h>
@@ -15,7 +16,8 @@ class IonAssetsTreeView;
 
 namespace CesiumForUnityNative {
 
-class IonAssetsTreeViewImpl {
+class IonAssetsTreeViewImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<IonAssetsTreeViewImpl> {
 public:
   IonAssetsTreeViewImpl(
       const DotNet::CesiumForUnity::IonAssetsTreeView& treeView);

--- a/native~/Editor/src/IonAssetsTreeViewImpl.h
+++ b/native~/Editor/src/IonAssetsTreeViewImpl.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumIonClient/Assets.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/CesiumForUnity/IonAssetsColumn.h>
 #include <DotNet/System/String.h>
@@ -16,8 +17,7 @@ class IonAssetsTreeView;
 
 namespace CesiumForUnityNative {
 
-class IonAssetsTreeViewImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<IonAssetsTreeViewImpl> {
+class IonAssetsTreeViewImpl : public CesiumImpl<IonAssetsTreeViewImpl> {
 public:
   IonAssetsTreeViewImpl(
       const DotNet::CesiumForUnity::IonAssetsTreeView& treeView);

--- a/native~/Editor/src/SelectIonTokenWindowImpl.h
+++ b/native~/Editor/src/SelectIonTokenWindowImpl.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumAsync/AsyncSystem.h>
 #include <CesiumIonClient/Token.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/CesiumForUnity/IonTokenSource.h>
 #include <DotNet/System/String.h>
@@ -18,9 +19,7 @@ class CesiumIonServer;
 
 namespace CesiumForUnityNative {
 
-class SelectIonTokenWindowImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<
-          SelectIonTokenWindowImpl> {
+class SelectIonTokenWindowImpl : public CesiumImpl<SelectIonTokenWindowImpl> {
 
 public:
   static CesiumAsync::SharedFuture<std::optional<CesiumIonClient::Token>>

--- a/native~/Editor/src/SelectIonTokenWindowImpl.h
+++ b/native~/Editor/src/SelectIonTokenWindowImpl.h
@@ -2,6 +2,7 @@
 
 #include <CesiumAsync/AsyncSystem.h>
 #include <CesiumIonClient/Token.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/CesiumForUnity/IonTokenSource.h>
 #include <DotNet/System/String.h>
@@ -17,7 +18,9 @@ class CesiumIonServer;
 
 namespace CesiumForUnityNative {
 
-class SelectIonTokenWindowImpl {
+class SelectIonTokenWindowImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<
+          SelectIonTokenWindowImpl> {
 
 public:
   static CesiumAsync::SharedFuture<std::optional<CesiumIonClient::Token>>

--- a/native~/Runtime/src/Cesium3DTilesetImpl.h
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Cesium3DTilesSelection/ViewUpdateResult.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/CesiumForUnity/CesiumCreditSystem.h>
 #include <DotNet/CesiumForUnity/CesiumGeoreference.h>
@@ -25,7 +26,8 @@ class Tileset;
 
 namespace CesiumForUnityNative {
 
-class Cesium3DTilesetImpl {
+class Cesium3DTilesetImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<Cesium3DTilesetImpl> {
 public:
   Cesium3DTilesetImpl(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
   ~Cesium3DTilesetImpl();

--- a/native~/Runtime/src/Cesium3DTilesetImpl.h
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <Cesium3DTilesSelection/ViewUpdateResult.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/CesiumForUnity/CesiumCreditSystem.h>
 #include <DotNet/CesiumForUnity/CesiumGeoreference.h>
@@ -26,8 +27,7 @@ class Tileset;
 
 namespace CesiumForUnityNative {
 
-class Cesium3DTilesetImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<Cesium3DTilesetImpl> {
+class Cesium3DTilesetImpl : public CesiumImpl<Cesium3DTilesetImpl> {
 public:
   Cesium3DTilesetImpl(const DotNet::CesiumForUnity::Cesium3DTileset& tileset);
   ~Cesium3DTilesetImpl();

--- a/native~/Runtime/src/CesiumBingMapsRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumBingMapsRasterOverlayImpl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CesiumUtility/IntrusivePointer.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 namespace DotNet::CesiumForUnity {
 class Cesium3DTileset;
@@ -13,7 +14,9 @@ class BingMapsRasterOverlay;
 
 namespace CesiumForUnityNative {
 
-class CesiumBingMapsRasterOverlayImpl {
+class CesiumBingMapsRasterOverlayImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<
+          CesiumBingMapsRasterOverlayImpl> {
 public:
   CesiumBingMapsRasterOverlayImpl(
       const DotNet::CesiumForUnity::CesiumBingMapsRasterOverlay& overlay);

--- a/native~/Runtime/src/CesiumBingMapsRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumBingMapsRasterOverlayImpl.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumUtility/IntrusivePointer.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 namespace DotNet::CesiumForUnity {
 class Cesium3DTileset;
@@ -15,8 +16,7 @@ class BingMapsRasterOverlay;
 namespace CesiumForUnityNative {
 
 class CesiumBingMapsRasterOverlayImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<
-          CesiumBingMapsRasterOverlayImpl> {
+    : public CesiumImpl<CesiumBingMapsRasterOverlayImpl> {
 public:
   CesiumBingMapsRasterOverlayImpl(
       const DotNet::CesiumForUnity::CesiumBingMapsRasterOverlay& overlay);

--- a/native~/Runtime/src/CesiumCreditSystemImpl.h
+++ b/native~/Runtime/src/CesiumCreditSystemImpl.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumUtility/CreditSystem.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/CesiumForUnity/CesiumCredit.h>
 #include <DotNet/System/Collections/Generic/List1.h>
@@ -22,8 +23,7 @@ struct Credit;
 
 namespace CesiumForUnityNative {
 
-class CesiumCreditSystemImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<CesiumCreditSystemImpl> {
+class CesiumCreditSystemImpl : public CesiumImpl<CesiumCreditSystemImpl> {
 public:
   CesiumCreditSystemImpl(
       const DotNet::CesiumForUnity::CesiumCreditSystem& creditSystem);

--- a/native~/Runtime/src/CesiumCreditSystemImpl.h
+++ b/native~/Runtime/src/CesiumCreditSystemImpl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CesiumUtility/CreditSystem.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/CesiumForUnity/CesiumCredit.h>
 #include <DotNet/System/Collections/Generic/List1.h>
@@ -21,7 +22,8 @@ struct Credit;
 
 namespace CesiumForUnityNative {
 
-class CesiumCreditSystemImpl {
+class CesiumCreditSystemImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<CesiumCreditSystemImpl> {
 public:
   CesiumCreditSystemImpl(
       const DotNet::CesiumForUnity::CesiumCreditSystem& creditSystem);

--- a/native~/Runtime/src/CesiumDebugColorizeTilesRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumDebugColorizeTilesRasterOverlayImpl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CesiumUtility/IntrusivePointer.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 namespace DotNet::CesiumForUnity {
 class Cesium3DTileset;
@@ -13,7 +14,9 @@ class DebugColorizeTilesRasterOverlay;
 
 namespace CesiumForUnityNative {
 
-class CesiumDebugColorizeTilesRasterOverlayImpl {
+class CesiumDebugColorizeTilesRasterOverlayImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<
+          CesiumDebugColorizeTilesRasterOverlayImpl> {
 public:
   CesiumDebugColorizeTilesRasterOverlayImpl(
       const DotNet::CesiumForUnity::CesiumDebugColorizeTilesRasterOverlay&

--- a/native~/Runtime/src/CesiumDebugColorizeTilesRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumDebugColorizeTilesRasterOverlayImpl.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumUtility/IntrusivePointer.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 namespace DotNet::CesiumForUnity {
 class Cesium3DTileset;
@@ -15,8 +16,7 @@ class DebugColorizeTilesRasterOverlay;
 namespace CesiumForUnityNative {
 
 class CesiumDebugColorizeTilesRasterOverlayImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<
-          CesiumDebugColorizeTilesRasterOverlayImpl> {
+    : public CesiumImpl<CesiumDebugColorizeTilesRasterOverlayImpl> {
 public:
   CesiumDebugColorizeTilesRasterOverlayImpl(
       const DotNet::CesiumForUnity::CesiumDebugColorizeTilesRasterOverlay&

--- a/native~/Runtime/src/CesiumEllipsoidImpl.h
+++ b/native~/Runtime/src/CesiumEllipsoidImpl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CesiumGeospatial/Ellipsoid.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/Unity/Mathematics/double3.h>
 
@@ -12,7 +13,8 @@ class CesiumEllipsoid;
 
 namespace CesiumForUnityNative {
 
-class CesiumEllipsoidImpl {
+class CesiumEllipsoidImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<CesiumEllipsoidImpl> {
 public:
   CesiumEllipsoidImpl(
       const DotNet::CesiumForUnity::CesiumEllipsoid& unityEllipsoid);

--- a/native~/Runtime/src/CesiumEllipsoidImpl.h
+++ b/native~/Runtime/src/CesiumEllipsoidImpl.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumGeospatial/Ellipsoid.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/Unity/Mathematics/double3.h>
 
@@ -13,8 +14,7 @@ class CesiumEllipsoid;
 
 namespace CesiumForUnityNative {
 
-class CesiumEllipsoidImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<CesiumEllipsoidImpl> {
+class CesiumEllipsoidImpl : public CesiumImpl<CesiumEllipsoidImpl> {
 public:
   CesiumEllipsoidImpl(
       const DotNet::CesiumForUnity::CesiumEllipsoid& unityEllipsoid);

--- a/native~/Runtime/src/CesiumFeatureIdAttributeImpl.h
+++ b/native~/Runtime/src/CesiumFeatureIdAttributeImpl.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumGltf/AccessorUtility.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 namespace DotNet::CesiumForUnity {
 class CesiumFeatureIdAttribute;
@@ -14,8 +15,7 @@ struct MeshPrimitive;
 
 namespace CesiumForUnityNative {
 class CesiumFeatureIdAttributeImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<
-          CesiumFeatureIdAttributeImpl> {
+    : public CesiumImpl<CesiumFeatureIdAttributeImpl> {
 public:
   CesiumFeatureIdAttributeImpl(
       const DotNet::CesiumForUnity::CesiumFeatureIdAttribute&

--- a/native~/Runtime/src/CesiumFeatureIdAttributeImpl.h
+++ b/native~/Runtime/src/CesiumFeatureIdAttributeImpl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CesiumGltf/AccessorUtility.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 namespace DotNet::CesiumForUnity {
 class CesiumFeatureIdAttribute;
@@ -12,7 +13,9 @@ struct MeshPrimitive;
 } // namespace CesiumGltf
 
 namespace CesiumForUnityNative {
-class CesiumFeatureIdAttributeImpl {
+class CesiumFeatureIdAttributeImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<
+          CesiumFeatureIdAttributeImpl> {
 public:
   CesiumFeatureIdAttributeImpl(
       const DotNet::CesiumForUnity::CesiumFeatureIdAttribute&

--- a/native~/Runtime/src/CesiumFeatureIdTextureImpl.h
+++ b/native~/Runtime/src/CesiumFeatureIdTextureImpl.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumGltf/AccessorUtility.h>
 #include <CesiumGltf/FeatureIdTextureView.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 namespace DotNet::CesiumForUnity {
 class CesiumFeatureIdTexture;
@@ -21,8 +22,7 @@ struct FeatureIdTexture;
 
 namespace CesiumForUnityNative {
 class CesiumFeatureIdTextureImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<
-          CesiumFeatureIdTextureImpl> {
+    : public CesiumImpl<CesiumFeatureIdTextureImpl> {
 public:
   CesiumFeatureIdTextureImpl(
       const DotNet::CesiumForUnity::CesiumFeatureIdTexture& featureIdTexture);

--- a/native~/Runtime/src/CesiumFeatureIdTextureImpl.h
+++ b/native~/Runtime/src/CesiumFeatureIdTextureImpl.h
@@ -2,6 +2,7 @@
 
 #include <CesiumGltf/AccessorUtility.h>
 #include <CesiumGltf/FeatureIdTextureView.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 namespace DotNet::CesiumForUnity {
 class CesiumFeatureIdTexture;
@@ -19,7 +20,9 @@ struct FeatureIdTexture;
 } // namespace CesiumGltf
 
 namespace CesiumForUnityNative {
-class CesiumFeatureIdTextureImpl {
+class CesiumFeatureIdTextureImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<
+          CesiumFeatureIdTextureImpl> {
 public:
   CesiumFeatureIdTextureImpl(
       const DotNet::CesiumForUnity::CesiumFeatureIdTexture& featureIdTexture);

--- a/native~/Runtime/src/CesiumFeatureImpl.h
+++ b/native~/Runtime/src/CesiumFeatureImpl.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumGltf/PropertyTablePropertyView.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/CesiumForUnity/CesiumMetadataValue.h>
 #include <DotNet/CesiumForUnity/MetadataType.h>
@@ -45,8 +46,7 @@ using ValueType = swl::variant<
     CesiumGltf::PropertyArrayView<bool>,
     CesiumGltf::PropertyArrayView<std::string_view>>;
 
-class CesiumFeatureImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<CesiumFeatureImpl> {
+class CesiumFeatureImpl : public CesiumImpl<CesiumFeatureImpl> {
 public:
   CesiumFeatureImpl(const DotNet::CesiumForUnity::CesiumFeature& feature);
   ~CesiumFeatureImpl();

--- a/native~/Runtime/src/CesiumFeatureImpl.h
+++ b/native~/Runtime/src/CesiumFeatureImpl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CesiumGltf/PropertyTablePropertyView.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/CesiumForUnity/CesiumMetadataValue.h>
 #include <DotNet/CesiumForUnity/MetadataType.h>
@@ -44,7 +45,8 @@ using ValueType = swl::variant<
     CesiumGltf::PropertyArrayView<bool>,
     CesiumGltf::PropertyArrayView<std::string_view>>;
 
-class CesiumFeatureImpl {
+class CesiumFeatureImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<CesiumFeatureImpl> {
 public:
   CesiumFeatureImpl(const DotNet::CesiumForUnity::CesiumFeature& feature);
   ~CesiumFeatureImpl();

--- a/native~/Runtime/src/CesiumGeoreferenceImpl.h
+++ b/native~/Runtime/src/CesiumGeoreferenceImpl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CesiumGeospatial/LocalHorizontalCoordinateSystem.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/Unity/Mathematics/double3.h>
 #include <DotNet/Unity/Mathematics/double4x4.h>
@@ -16,7 +17,8 @@ class Transform;
 }
 
 namespace CesiumForUnityNative {
-class CesiumGeoreferenceImpl {
+class CesiumGeoreferenceImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<CesiumGeoreferenceImpl> {
 public:
   CesiumGeoreferenceImpl(
       const DotNet::CesiumForUnity::CesiumGeoreference& georeference);

--- a/native~/Runtime/src/CesiumGeoreferenceImpl.h
+++ b/native~/Runtime/src/CesiumGeoreferenceImpl.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumGeospatial/LocalHorizontalCoordinateSystem.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/Unity/Mathematics/double3.h>
 #include <DotNet/Unity/Mathematics/double4x4.h>
@@ -17,8 +18,7 @@ class Transform;
 }
 
 namespace CesiumForUnityNative {
-class CesiumGeoreferenceImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<CesiumGeoreferenceImpl> {
+class CesiumGeoreferenceImpl : public CesiumImpl<CesiumGeoreferenceImpl> {
 public:
   CesiumGeoreferenceImpl(
       const DotNet::CesiumForUnity::CesiumGeoreference& georeference);

--- a/native~/Runtime/src/CesiumIonRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumIonRasterOverlayImpl.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumUtility/IntrusivePointer.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 namespace DotNet::CesiumForUnity {
 class Cesium3DTileset;
@@ -15,8 +16,7 @@ class IonRasterOverlay;
 namespace CesiumForUnityNative {
 
 class CesiumIonRasterOverlayImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<
-          CesiumIonRasterOverlayImpl> {
+    : public CesiumImpl<CesiumIonRasterOverlayImpl> {
 public:
   CesiumIonRasterOverlayImpl(
       const DotNet::CesiumForUnity::CesiumIonRasterOverlay& overlay);

--- a/native~/Runtime/src/CesiumIonRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumIonRasterOverlayImpl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CesiumUtility/IntrusivePointer.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 namespace DotNet::CesiumForUnity {
 class Cesium3DTileset;
@@ -13,7 +14,9 @@ class IonRasterOverlay;
 
 namespace CesiumForUnityNative {
 
-class CesiumIonRasterOverlayImpl {
+class CesiumIonRasterOverlayImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<
+          CesiumIonRasterOverlayImpl> {
 public:
   CesiumIonRasterOverlayImpl(
       const DotNet::CesiumForUnity::CesiumIonRasterOverlay& overlay);

--- a/native~/Runtime/src/CesiumMetadataImpl.h
+++ b/native~/Runtime/src/CesiumMetadataImpl.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumGltf/AccessorUtility.h>
 #include <CesiumGltf/Model.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/CesiumForUnity/CesiumFeature.h>
 #include <DotNet/System/Array1.h>
@@ -22,8 +23,7 @@ class Transform;
 
 namespace CesiumForUnityNative {
 
-class CesiumMetadataImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<CesiumMetadataImpl> {
+class CesiumMetadataImpl : public CesiumImpl<CesiumMetadataImpl> {
 public:
   CesiumMetadataImpl(const DotNet::CesiumForUnity::CesiumMetadata& metadata);
   ~CesiumMetadataImpl();

--- a/native~/Runtime/src/CesiumMetadataImpl.h
+++ b/native~/Runtime/src/CesiumMetadataImpl.h
@@ -2,6 +2,7 @@
 
 #include <CesiumGltf/AccessorUtility.h>
 #include <CesiumGltf/Model.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/CesiumForUnity/CesiumFeature.h>
 #include <DotNet/System/Array1.h>
@@ -21,7 +22,8 @@ class Transform;
 
 namespace CesiumForUnityNative {
 
-class CesiumMetadataImpl {
+class CesiumMetadataImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<CesiumMetadataImpl> {
 public:
   CesiumMetadataImpl(const DotNet::CesiumForUnity::CesiumMetadata& metadata);
   ~CesiumMetadataImpl();

--- a/native~/Runtime/src/CesiumPolygonRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumPolygonRasterOverlayImpl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CesiumUtility/IntrusivePointer.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/System/Collections/Generic/List1.h>
 
@@ -25,7 +26,9 @@ class CartographicPolygon;
 
 namespace CesiumForUnityNative {
 
-class CesiumPolygonRasterOverlayImpl {
+class CesiumPolygonRasterOverlayImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<
+          CesiumPolygonRasterOverlayImpl> {
 public:
   CesiumPolygonRasterOverlayImpl(
       const DotNet::CesiumForUnity::CesiumPolygonRasterOverlay& overlay);

--- a/native~/Runtime/src/CesiumPolygonRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumPolygonRasterOverlayImpl.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumUtility/IntrusivePointer.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/System/Collections/Generic/List1.h>
 
@@ -27,8 +28,7 @@ class CartographicPolygon;
 namespace CesiumForUnityNative {
 
 class CesiumPolygonRasterOverlayImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<
-          CesiumPolygonRasterOverlayImpl> {
+    : public CesiumImpl<CesiumPolygonRasterOverlayImpl> {
 public:
   CesiumPolygonRasterOverlayImpl(
       const DotNet::CesiumForUnity::CesiumPolygonRasterOverlay& overlay);

--- a/native~/Runtime/src/CesiumPropertyTablePropertyImpl.h
+++ b/native~/Runtime/src/CesiumPropertyTablePropertyImpl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <CesiumUtility/ReferenceCounted.h>
+
 #include <any>
 #include <cstdint>
 #include <unordered_map>
@@ -43,7 +45,9 @@ class double4x4;
 
 namespace CesiumForUnityNative {
 
-class CesiumPropertyTablePropertyImpl {
+class CesiumPropertyTablePropertyImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<
+          CesiumPropertyTablePropertyImpl> {
 public:
   CesiumPropertyTablePropertyImpl(
       const DotNet::CesiumForUnity::CesiumPropertyTableProperty& property);

--- a/native~/Runtime/src/CesiumPropertyTablePropertyImpl.h
+++ b/native~/Runtime/src/CesiumPropertyTablePropertyImpl.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <CesiumUtility/ReferenceCounted.h>
+#include "CesiumImpl.h"
 
 #include <any>
 #include <cstdint>
@@ -46,8 +46,7 @@ class double4x4;
 namespace CesiumForUnityNative {
 
 class CesiumPropertyTablePropertyImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<
-          CesiumPropertyTablePropertyImpl> {
+    : public CesiumImpl<CesiumPropertyTablePropertyImpl> {
 public:
   CesiumPropertyTablePropertyImpl(
       const DotNet::CesiumForUnity::CesiumPropertyTableProperty& property);

--- a/native~/Runtime/src/CesiumSimplePlanarEllipsoidCurveImpl.h
+++ b/native~/Runtime/src/CesiumSimplePlanarEllipsoidCurveImpl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CesiumGeospatial/SimplePlanarEllipsoidCurve.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/CesiumForUnity/CesiumEllipsoid.h>
 #include <DotNet/Unity/Mathematics/double3.h>
@@ -17,7 +18,9 @@ struct double3;
 
 namespace CesiumForUnityNative {
 
-class CesiumSimplePlanarEllipsoidCurveImpl {
+class CesiumSimplePlanarEllipsoidCurveImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<
+          CesiumSimplePlanarEllipsoidCurveImpl> {
 public:
   CesiumSimplePlanarEllipsoidCurveImpl(
       const DotNet::CesiumForUnity::CesiumSimplePlanarEllipsoidCurve& path);

--- a/native~/Runtime/src/CesiumSimplePlanarEllipsoidCurveImpl.h
+++ b/native~/Runtime/src/CesiumSimplePlanarEllipsoidCurveImpl.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumGeospatial/SimplePlanarEllipsoidCurve.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/CesiumForUnity/CesiumEllipsoid.h>
 #include <DotNet/Unity/Mathematics/double3.h>
@@ -19,8 +20,7 @@ struct double3;
 namespace CesiumForUnityNative {
 
 class CesiumSimplePlanarEllipsoidCurveImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<
-          CesiumSimplePlanarEllipsoidCurveImpl> {
+    : public CesiumImpl<CesiumSimplePlanarEllipsoidCurveImpl> {
 public:
   CesiumSimplePlanarEllipsoidCurveImpl(
       const DotNet::CesiumForUnity::CesiumSimplePlanarEllipsoidCurve& path);

--- a/native~/Runtime/src/CesiumTileMapServiceRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumTileMapServiceRasterOverlayImpl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CesiumUtility/IntrusivePointer.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 namespace DotNet::CesiumForUnity {
 class Cesium3DTileset;
@@ -13,7 +14,9 @@ class TileMapServiceRasterOverlay;
 
 namespace CesiumForUnityNative {
 
-class CesiumTileMapServiceRasterOverlayImpl {
+class CesiumTileMapServiceRasterOverlayImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<
+          CesiumTileMapServiceRasterOverlayImpl> {
 public:
   CesiumTileMapServiceRasterOverlayImpl(
       const DotNet::CesiumForUnity::CesiumTileMapServiceRasterOverlay& overlay);

--- a/native~/Runtime/src/CesiumTileMapServiceRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumTileMapServiceRasterOverlayImpl.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumUtility/IntrusivePointer.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 namespace DotNet::CesiumForUnity {
 class Cesium3DTileset;
@@ -15,8 +16,7 @@ class TileMapServiceRasterOverlay;
 namespace CesiumForUnityNative {
 
 class CesiumTileMapServiceRasterOverlayImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<
-          CesiumTileMapServiceRasterOverlayImpl> {
+    : public CesiumImpl<CesiumTileMapServiceRasterOverlayImpl> {
 public:
   CesiumTileMapServiceRasterOverlayImpl(
       const DotNet::CesiumForUnity::CesiumTileMapServiceRasterOverlay& overlay);

--- a/native~/Runtime/src/CesiumWebMapServiceRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumWebMapServiceRasterOverlayImpl.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumUtility/IntrusivePointer.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 namespace DotNet::CesiumForUnity {
 class Cesium3DTileset;
@@ -15,8 +16,7 @@ class WebMapServiceRasterOverlay;
 namespace CesiumForUnityNative {
 
 class CesiumWebMapServiceRasterOverlayImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<
-          CesiumWebMapServiceRasterOverlayImpl> {
+    : public CesiumImpl<CesiumWebMapServiceRasterOverlayImpl> {
 public:
   CesiumWebMapServiceRasterOverlayImpl(
       const DotNet::CesiumForUnity::CesiumWebMapServiceRasterOverlay& overlay);

--- a/native~/Runtime/src/CesiumWebMapServiceRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumWebMapServiceRasterOverlayImpl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CesiumUtility/IntrusivePointer.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 namespace DotNet::CesiumForUnity {
 class Cesium3DTileset;
@@ -13,7 +14,9 @@ class WebMapServiceRasterOverlay;
 
 namespace CesiumForUnityNative {
 
-class CesiumWebMapServiceRasterOverlayImpl {
+class CesiumWebMapServiceRasterOverlayImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<
+          CesiumWebMapServiceRasterOverlayImpl> {
 public:
   CesiumWebMapServiceRasterOverlayImpl(
       const DotNet::CesiumForUnity::CesiumWebMapServiceRasterOverlay& overlay);

--- a/native~/Runtime/src/CesiumWebMapTileServiceRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumWebMapTileServiceRasterOverlayImpl.h
@@ -1,7 +1,8 @@
 ﻿#pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumUtility/IntrusivePointer.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 namespace DotNet::CesiumForUnity {
 class Cesium3DTileset;
@@ -15,8 +16,7 @@ class WebMapTileServiceRasterOverlay;
 namespace CesiumForUnityNative {
 
 class CesiumWebMapTileServiceRasterOverlayImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<
-          CesiumWebMapTileServiceRasterOverlayImpl> {
+    : public CesiumImpl<CesiumWebMapTileServiceRasterOverlayImpl> {
 public:
   CesiumWebMapTileServiceRasterOverlayImpl(
       const DotNet::CesiumForUnity::CesiumWebMapTileServiceRasterOverlay&

--- a/native~/Runtime/src/CesiumWebMapTileServiceRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumWebMapTileServiceRasterOverlayImpl.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include <CesiumUtility/IntrusivePointer.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 namespace DotNet::CesiumForUnity {
 class Cesium3DTileset;
@@ -13,7 +14,9 @@ class WebMapTileServiceRasterOverlay;
 
 namespace CesiumForUnityNative {
 
-class CesiumWebMapTileServiceRasterOverlayImpl {
+class CesiumWebMapTileServiceRasterOverlayImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<
+          CesiumWebMapTileServiceRasterOverlayImpl> {
 public:
   CesiumWebMapTileServiceRasterOverlayImpl(
       const DotNet::CesiumForUnity::CesiumWebMapTileServiceRasterOverlay&

--- a/native~/Runtime/src/TestGltfModelImpl.h
+++ b/native~/Runtime/src/TestGltfModelImpl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CesiumGltf/Model.h>
+#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/System/Array1.h>
 
@@ -26,7 +27,8 @@ struct float4x4;
 
 namespace CesiumForUnityNative {
 
-class TestGltfModelImpl {
+class TestGltfModelImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<TestGltfModelImpl> {
 public:
   TestGltfModelImpl(const DotNet::CesiumForUnity::TestGltfModel& model);
   ~TestGltfModelImpl();

--- a/native~/Runtime/src/TestGltfModelImpl.h
+++ b/native~/Runtime/src/TestGltfModelImpl.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "CesiumImpl.h"
+
 #include <CesiumGltf/Model.h>
-#include <CesiumUtility/ReferenceCounted.h>
 
 #include <DotNet/System/Array1.h>
 
@@ -27,8 +28,7 @@ struct float4x4;
 
 namespace CesiumForUnityNative {
 
-class TestGltfModelImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<TestGltfModelImpl> {
+class TestGltfModelImpl : public CesiumImpl<TestGltfModelImpl> {
 public:
   TestGltfModelImpl(const DotNet::CesiumForUnity::TestGltfModel& model);
   ~TestGltfModelImpl();

--- a/native~/Shared/src/CesiumImpl.h
+++ b/native~/Shared/src/CesiumImpl.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <CesiumUtility/ReferenceCounted.h>
+
+namespace CesiumForUnityNative {
+
+template <typename TDerived>
+class CesiumImpl : public CesiumUtility::ReferenceCounted<TDerived> {
+public:
+  CesiumImpl() = default;
+
+  // Prevent copying of impl classes
+  CesiumImpl(CesiumImpl&&) = delete;
+  CesiumImpl(const CesiumImpl&) = delete;
+  CesiumImpl& operator=(CesiumImpl&&) = delete;
+  CesiumImpl& operator=(const CesiumImpl&) = delete;
+};
+
+} // namespace CesiumForUnityNative

--- a/native~/Shared/src/NativeDownloadHandlerImpl.h
+++ b/native~/Shared/src/NativeDownloadHandlerImpl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <CesiumUtility/ReferenceCounted.h>
+
 #include <gsl/span>
 
 #include <cstddef>
@@ -12,7 +14,9 @@ class NativeDownloadHandler;
 
 namespace CesiumForUnityNative {
 
-class NativeDownloadHandlerImpl {
+class NativeDownloadHandlerImpl
+    : public CesiumUtility::ReferenceCountedThreadSafe<
+          NativeDownloadHandlerImpl> {
 public:
   NativeDownloadHandlerImpl(
       const ::DotNet::CesiumForUnity::NativeDownloadHandler& handler);

--- a/native~/Shared/src/NativeDownloadHandlerImpl.h
+++ b/native~/Shared/src/NativeDownloadHandlerImpl.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <CesiumUtility/ReferenceCounted.h>
+#include "CesiumImpl.h"
 
 #include <gsl/span>
 
@@ -14,9 +14,7 @@ class NativeDownloadHandler;
 
 namespace CesiumForUnityNative {
 
-class NativeDownloadHandlerImpl
-    : public CesiumUtility::ReferenceCountedThreadSafe<
-          NativeDownloadHandlerImpl> {
+class NativeDownloadHandlerImpl : public CesiumImpl<NativeDownloadHandlerImpl> {
 public:
   NativeDownloadHandlerImpl(
       const ::DotNet::CesiumForUnity::NativeDownloadHandler& handler);


### PR DESCRIPTION
### Reference Counting

Previously, C# objects backed by a native "Impl" object had strict ownership of the Impl instance. It was `new`'d in the constructor, and `delete`'d in the finalizer. This was mostly fine, but there are a few cases (mostly related to Future continuations) where it's important to keep the Impl instance alive even though the C# instance might get finalized. See #499. Previously this was not really possible because of the strict ownership. In this PR, Impl instances are internally reference counted, so their lifetime can be managed with an `IntrusivePointer`.

Note that I haven't actually done anything to take advantage of this in this PR. This PR is just the mostly-mechanical refactoring to reference counting.

### Copy prevention

This PR also makes it impossible to accidentally copy Impl classes by declaring deleted constructors and assignment operators. Accidental copying has been responsible for at least one bug in the past, and it was really simple to do this as part of the reference counting change, so I did.

Fixes #223
