### PR TITLE
Fix "Quick Checks" step on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,6 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Install clang-format
-        run: pip install clang-format
       - name: Check source formatting
         run: |
           find native~/Runtime native~/Editor native~/Shared \( -iname '*.cpp' -o -iname '*.h' \) -print0 | xargs -0 clang-format --dry-run -Werror


### PR DESCRIPTION
We use `ubuntu-latest` to run the "Quick Checks" step, and `ubuntu-latest` very recently switched to Ubuntu 24.04. On 24.04, attempting to install clang-format via pip gives this error:

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP [6](https://github.com/CesiumGS/cesium-unity/actions/runs/11059061896/job/30737490347#step:3:7)68 for the detailed specification.
```

We could fix this by following the instructions in the error message. But there's really no need, because the GH Actions image already has clang-format installed. So this PR just removes that install step completely.
