### PR TITLE
Make cesium-unity compatible with the shared asset changes in cesium-native.

### DIFF
--- a/native~/Runtime/src/TestGltfModelImpl.cpp
+++ b/native~/Runtime/src/TestGltfModelImpl.cpp
@@ -87,14 +87,14 @@ TestGltfModelImpl::AddFeatureIdTexture(
 
   // Copy feature IDs to texture.
   CesiumGltf::Image& image = this->_nativeModel.images.emplace_back();
-  image.cesium.width = 2;
-  image.cesium.height = 2;
-  image.cesium.bytesPerChannel = 1;
-  image.cesium.channels = 2;
-  image.cesium.pixelData.resize(featureIdsLength * sizeof(std::uint16_t));
+  image.pCesium->width = 2;
+  image.pCesium->height = 2;
+  image.pCesium->bytesPerChannel = 1;
+  image.pCesium->channels = 2;
+  image.pCesium->pixelData.resize(featureIdsLength * sizeof(std::uint16_t));
 
   std::uint16_t* pFeatureId =
-      reinterpret_cast<std::uint16_t*>(image.cesium.pixelData.data());
+      reinterpret_cast<std::uint16_t*>(image.pCesium->pixelData.data());
   for (int32_t i = 0; i < featureIdsLength; i++) {
     *pFeatureId = featureIds[i];
     pFeatureId++;

--- a/native~/Runtime/src/TestGltfModelImpl.cpp
+++ b/native~/Runtime/src/TestGltfModelImpl.cpp
@@ -87,6 +87,7 @@ TestGltfModelImpl::AddFeatureIdTexture(
 
   // Copy feature IDs to texture.
   CesiumGltf::Image& image = this->_nativeModel.images.emplace_back();
+  image.pCesium.emplace();
   image.pCesium->width = 2;
   image.pCesium->height = 2;
   image.pCesium->bytesPerChannel = 1;

--- a/native~/Runtime/src/TextureLoader.cpp
+++ b/native~/Runtime/src/TextureLoader.cpp
@@ -21,7 +21,7 @@ namespace CesiumForUnityNative {
 
 namespace {
 UnityEngine::TextureFormat
-getCompressedPixelFormat(const CesiumGltf::ImageCesium& image) {
+getCompressedPixelFormat(const CesiumGltf::ImageAsset& image) {
   switch (image.compressedPixelFormat) {
   case GpuCompressedPixelFormat::ETC1_RGB:
     return UnityEngine::TextureFormat::ETC_RGB4;
@@ -55,7 +55,7 @@ getCompressedPixelFormat(const CesiumGltf::ImageCesium& image) {
 }
 
 UnityEngine::TextureFormat
-getUncompressedPixelFormat(const CesiumGltf::ImageCesium& image) {
+getUncompressedPixelFormat(const CesiumGltf::ImageAsset& image) {
   switch (image.channels) {
   case 1:
     return UnityEngine::TextureFormat::R8;
@@ -72,7 +72,7 @@ getUncompressedPixelFormat(const CesiumGltf::ImageCesium& image) {
 } // namespace
 
 UnityEngine::Texture
-TextureLoader::loadTexture(const CesiumGltf::ImageCesium& image, bool sRGB) {
+TextureLoader::loadTexture(const CesiumGltf::ImageAsset& image, bool sRGB) {
   CESIUM_TRACE("TextureLoader::loadTexture");
   std::int32_t mipCount =
       image.mipPositions.empty() ? 1 : std::int32_t(image.mipPositions.size());
@@ -107,7 +107,7 @@ TextureLoader::loadTexture(const CesiumGltf::ImageCesium& image, bool sRGB) {
     std::uint8_t* pWritePosition = pixels;
     const std::byte* pReadBuffer = image.pixelData.data();
 
-    for (const ImageCesiumMipPosition& mip : image.mipPositions) {
+    for (const ImageAssetMipPosition& mip : image.mipPositions) {
       size_t start = mip.byteOffset;
       size_t end = mip.byteOffset + mip.byteSize;
       if (start >= textureLength || end > textureLength)
@@ -144,7 +144,7 @@ UnityEngine::Texture TextureLoader::loadTexture(
     return UnityEngine::Texture(nullptr);
   }
 
-  const ImageCesium& imageCesium = pImage->cesium;
+  const ImageAsset& imageCesium = *pImage->pCesium;
   UnityEngine::Texture unityTexture = loadTexture(imageCesium, sRGB);
 
   const Sampler* pSampler = Model::getSafe(&model.samplers, texture.sampler);

--- a/native~/Runtime/src/TextureLoader.h
+++ b/native~/Runtime/src/TextureLoader.h
@@ -5,7 +5,7 @@
 namespace CesiumGltf {
 struct Model;
 struct Texture;
-struct ImageCesium;
+struct ImageAsset;
 } // namespace CesiumGltf
 
 namespace DotNet::UnityEngine {
@@ -17,7 +17,7 @@ namespace CesiumForUnityNative {
 class TextureLoader {
 public:
   static ::DotNet::UnityEngine::Texture
-  loadTexture(const CesiumGltf::ImageCesium& image, bool sRGB);
+  loadTexture(const CesiumGltf::ImageAsset& image, bool sRGB);
 
   static ::DotNet::UnityEngine::Texture loadTexture(
       const CesiumGltf::Model& model,

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -274,7 +274,7 @@ void generateMipMaps(
         case CesiumGltf::Sampler::MinFilter::LINEAR_MIPMAP_NEAREST:
         case CesiumGltf::Sampler::MinFilter::NEAREST_MIPMAP_LINEAR:
         case CesiumGltf::Sampler::MinFilter::NEAREST_MIPMAP_NEAREST:
-          CesiumGltfReader::GltfReader::generateMipMaps(pImage->cesium);
+          CesiumGltfReader::GltfReader::generateMipMaps(*pImage->pCesium);
         }
       }
     }
@@ -1722,7 +1722,7 @@ void UnityPrepareRendererResources::free(
 }
 
 void* UnityPrepareRendererResources::prepareRasterInLoadThread(
-    CesiumGltf::ImageCesium& image,
+    CesiumGltf::ImageAsset& image,
     const std::any& rendererOptions) {
   CesiumGltfReader::GltfReader::generateMipMaps(image);
   return nullptr;
@@ -1732,7 +1732,7 @@ void* UnityPrepareRendererResources::prepareRasterInMainThread(
     CesiumRasterOverlays::RasterOverlayTile& rasterTile,
     void* pLoadThreadResult) {
   auto pTexture = std::make_unique<UnityEngine::Texture>(
-      TextureLoader::loadTexture(rasterTile.getImage(), true));
+      TextureLoader::loadTexture(*rasterTile.getImage(), true));
   pTexture->wrapMode(UnityEngine::TextureWrapMode::Clamp);
   pTexture->filterMode(UnityEngine::FilterMode::Trilinear);
   pTexture->anisoLevel(16);

--- a/native~/Runtime/src/UnityPrepareRendererResources.h
+++ b/native~/Runtime/src/UnityPrepareRendererResources.h
@@ -84,7 +84,7 @@ public:
       void* pMainThreadResult) noexcept override;
 
   virtual void* prepareRasterInLoadThread(
-      CesiumGltf::ImageCesium& image,
+      CesiumGltf::ImageAsset& image,
       const std::any& rendererOptions) override;
 
   virtual void* prepareRasterInMainThread(


### PR DESCRIPTION
As we've discussed previously, we're not intending to fully implement the shared assets system in Unity at this point, as there are currently higher priority items that we need to get to. However, the changes made in cesium-native to support shared assets currently break the cesium-unity build. This change is the absolute minimum required to get cesium-unity working with the shared-assets branch of cesium-native. It doesn't implement the shared asset depot or change texture creation in any way. 