### PR TITLE
Add asmdef Restrictions to Unity Runtime

### DIFF
--- a/Runtime/CesiumRuntime.asmdef
+++ b/Runtime/CesiumRuntime.asmdef
@@ -6,7 +6,15 @@
         "Unity.Mathematics",
         "Unity.Splines"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Android",
+        "Editor",
+        "iOS",
+        "macOSStandalone",
+        "WSA",
+        "WindowsStandalone32",
+        "WindowsStandalone64"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
     "overrideReferences": false,


### PR DESCRIPTION
Solution to issue [https://github.com/CesiumGS/cesium-unity/issues/516](url)

* feature: Added restrictions to the CesiumRuntime.asmdef to prevent it from attempting to load on platforms that don't have a valid CesiumForUnity native plugin