### PR TITLE
Reflect new Unity 2022.3+ requirement in developer-setup.md

### DIFF
--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -116,7 +116,7 @@ The cesium-unity-samples project has several scenes that help you to quickly get
 To create a release package of Cesium for Unity, suitable to be installed with the Unity Package Manager, do the following (adjust the Unity path for your system):
 
 ```
-$ENV:UNITY="C:\Program Files\Unity\Hub\Editor\2021.3.13f1\Editor\Unity.exe"
+$ENV:UNITY="C:\Program Files\Unity\Hub\Editor\2022.3.41f1\Editor\Unity.exe"
 mkdir -p c:\cesium\CesiumForUnityBuildProject\Packages
 cd c:\cesium\CesiumForUnityBuildProject\Packages
 git clone --recurse-submodules git@github.com:CesiumGS/cesium-unity.git com.cesium.unity

--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -10,7 +10,7 @@ This is a summary of the setup and workflows for developers who want to modify t
 * [.NET SDK v6.0 or later](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
 * If you're using Visual Studio, you need Visual Studio 2022.
 * No matter what compiler you're using, it needs to have solid support for C++20.
-* Unity 2021.3+ (the latest version of the Unity 2021.3 LTS release is recommended)
+* Unity 2022.3+ (the latest version of the Unity 2022.3 LTS release is recommended)
 * On Windows, support for long file paths must be enabled, or you are likely to see build errors. See [Maximum Path Length Limitation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later).
 * For best JPEG-decoding performance, you must have [nasm](https://www.nasm.us/) installed so that CMake can find it. Everything will work fine without it, just slower.
 


### PR DESCRIPTION
Hi,

Regarding https://github.com/CesiumGS/cesium-unity/issues/517, here is an updated `developer-setup.md` including the correct required version for Unity.