### PR TITLE
Fix automatic generation of WMTS Tile Matrix Set Labels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 - Added a "From Ellipsoid" option to `Cesium3DTileset` to generate a tileset by tesselating the surface of the ellipsoid, producing a simple globe tileset without terrain features.
 
+##### Fixes :wrench:
+
+- Fixed a bug in `CesiumWebMapTileServiceRasterOverlay` that caused automatic Tile Matrix Set Labels to be created incorrectly, leading to incorrect tile request URLs.
+
 ## v1.13.1 - 2024-11-01
 
 ##### Fixes :wrench:

--- a/native~/Runtime/src/CesiumWebMapTileServiceRasterOverlayImpl.cpp
+++ b/native~/Runtime/src/CesiumWebMapTileServiceRasterOverlayImpl.cpp
@@ -107,7 +107,8 @@ void CesiumWebMapTileServiceRasterOverlayImpl::AddToTileset(
     if (!DotNet::System::String::IsNullOrEmpty(
             overlay.tileMatrixSetLabelPrefix())) {
       std::string prefix = overlay.tileMatrixSetLabelPrefix().ToStlString();
-      std::vector<std::string> labels(26);
+      std::vector<std::string> labels;
+      labels.reserve(26);
       for (size_t level = 0; level <= 25; ++level) {
         labels.emplace_back(prefix + std::to_string(level));
       }


### PR DESCRIPTION
This was causing WMTS URLs to be built incorrectly, and so the overlay would fail to work.
Reported here:
https://community.cesium.com/t/ue5-3-unity2021/36516
