### PR TITLE
Replace `gsl::span` with `std::span`

### DIFF
--- a/native~/Runtime/src/TestGltfModelImpl.cpp
+++ b/native~/Runtime/src/TestGltfModelImpl.cpp
@@ -186,7 +186,7 @@ TestGltfModelImpl::AddBooleanPropertyTableProperty(
       property,
       classProperty,
       size,
-      gsl::span<const std::byte>(
+      std::span<const std::byte>(
           buffer.cesium.data.data(),
           buffer.cesium.data.size()));
 
@@ -221,7 +221,7 @@ TestGltfModelImpl::AddIntPropertyTableProperty(
         property,
         classProperty,
         size,
-        gsl::span<const std::byte>(
+        std::span<const std::byte>(
             buffer.cesium.data.data(),
             buffer.cesium.data.size()));
 
@@ -233,7 +233,7 @@ TestGltfModelImpl::AddIntPropertyTableProperty(
       property,
       classProperty,
       size,
-      gsl::span<const std::byte>(
+      std::span<const std::byte>(
           buffer.cesium.data.data(),
           buffer.cesium.data.size()));
 
@@ -265,7 +265,7 @@ TestGltfModelImpl::AddDoublePropertyTableProperty(
       property,
       classProperty,
       size,
-      gsl::span<const std::byte>(
+      std::span<const std::byte>(
           buffer.cesium.data.data(),
           buffer.cesium.data.size()));
 
@@ -298,7 +298,7 @@ TestGltfModelImpl::AddVec2PropertyTableProperty(
       property,
       classProperty,
       size,
-      gsl::span<const std::byte>(
+      std::span<const std::byte>(
           buffer.cesium.data.data(),
           buffer.cesium.data.size()));
 
@@ -331,7 +331,7 @@ TestGltfModelImpl::AddVec3PropertyTableProperty(
       property,
       classProperty,
       size,
-      gsl::span<const std::byte>(
+      std::span<const std::byte>(
           buffer.cesium.data.data(),
           buffer.cesium.data.size()));
 
@@ -368,7 +368,7 @@ TestGltfModelImpl::AddVec4PropertyTableProperty(
       property,
       classProperty,
       size,
-      gsl::span<const std::byte>(
+      std::span<const std::byte>(
           buffer.cesium.data.data(),
           buffer.cesium.data.size()));
 
@@ -406,7 +406,7 @@ TestGltfModelImpl::AddMat2PropertyTableProperty(
       property,
       classProperty,
       size,
-      gsl::span<const std::byte>(
+      std::span<const std::byte>(
           buffer.cesium.data.data(),
           buffer.cesium.data.size()));
 
@@ -445,7 +445,7 @@ TestGltfModelImpl::AddMat3PropertyTableProperty(
       property,
       classProperty,
       size,
-      gsl::span<const std::byte>(
+      std::span<const std::byte>(
           buffer.cesium.data.data(),
           buffer.cesium.data.size()));
 
@@ -485,7 +485,7 @@ TestGltfModelImpl::AddMat4PropertyTableProperty(
       property,
       classProperty,
       size,
-      gsl::span<const std::byte>(
+      std::span<const std::byte>(
           buffer.cesium.data.data(),
           buffer.cesium.data.size()));
 
@@ -545,11 +545,11 @@ TestGltfModelImpl::AddStringPropertyTableProperty(
       property,
       classProperty,
       size,
-      gsl::span<const std::byte>(
+      std::span<const std::byte>(
           stringBuffer.cesium.data.data(),
           stringBuffer.cesium.data.size()),
-      gsl::span<const std::byte>(),
-      gsl::span<const std::byte>(
+      std::span<const std::byte>(),
+      std::span<const std::byte>(
           offsetBuffer.cesium.data.data(),
           offsetBuffer.cesium.data.size()),
       CesiumGltf::PropertyComponentType::None,
@@ -588,7 +588,7 @@ TestGltfModelImpl::AddFixedLengthArrayPropertyTableProperty(
           property,
           classProperty,
           numValues / count,
-          gsl::span<const std::byte>(
+          std::span<const std::byte>(
               buffer.cesium.data.data(),
               buffer.cesium.data.size()));
 
@@ -642,13 +642,13 @@ TestGltfModelImpl::AddVariableLengthArrayPropertyTableProperty(
           property,
           classProperty,
           size,
-          gsl::span<const std::byte>(
+          std::span<const std::byte>(
               buffer.cesium.data.data(),
               buffer.cesium.data.size()),
-          gsl::span<const std::byte>(
+          std::span<const std::byte>(
               offsetBuffer.cesium.data.data(),
               offsetBuffer.cesium.data.size()),
-          gsl::span<const std::byte>(),
+          std::span<const std::byte>(),
           CesiumGltf::PropertyComponentType::Uint16,
           CesiumGltf::PropertyComponentType::None);
 

--- a/native~/Shared/src/NativeDownloadHandlerImpl.h
+++ b/native~/Shared/src/NativeDownloadHandlerImpl.h
@@ -2,7 +2,7 @@
 
 #include "CesiumImpl.h"
 
-#include <gsl/span>
+#include <span>
 
 #include <cstddef>
 #include <cstdint>

--- a/native~/Shared/src/NativeDownloadHandlerImpl.h
+++ b/native~/Shared/src/NativeDownloadHandlerImpl.h
@@ -2,10 +2,9 @@
 
 #include "CesiumImpl.h"
 
-#include <span>
-
 #include <cstddef>
 #include <cstdint>
+#include <span>
 #include <vector>
 
 namespace DotNet::CesiumForUnity {

--- a/native~/Shared/src/UnityAssetAccessor.cpp
+++ b/native~/Shared/src/UnityAssetAccessor.cpp
@@ -66,7 +66,7 @@ public:
 
   virtual const HttpHeaders& headers() const override { return _headers; }
 
-  virtual gsl::span<const std::byte> data() const override {
+  virtual std::span<const std::byte> data() const override {
     return this->_data;
   }
 
@@ -202,7 +202,7 @@ UnityAssetAccessor::request(
     const std::string& verb,
     const std::string& url,
     const std::vector<THeader>& headers,
-    const gsl::span<const std::byte>& contentPayload) {
+    const std::span<const std::byte>& contentPayload) {
   if (contentPayload.size() >
       size_t(std::numeric_limits<std::int32_t>::max())) {
     // This implementation cannot be used to send more than 2 gigabytes - just

--- a/native~/Shared/src/UnityAssetAccessor.h
+++ b/native~/Shared/src/UnityAssetAccessor.h
@@ -19,7 +19,7 @@ public:
       const std::string& verb,
       const std::string& url,
       const std::vector<THeader>& headers = std::vector<THeader>(),
-      const gsl::span<const std::byte>& contentPayload = {}) override;
+      const std::span<const std::byte>& contentPayload = {}) override;
 
   virtual void tick() noexcept override;
 

--- a/native~/vcpkg/ports/abseil/portfile.cmake
+++ b/native~/vcpkg/ports/abseil/portfile.cmake
@@ -1,0 +1,72 @@
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO abseil/abseil-cpp
+    REF "20240722.0"
+    SHA512 bd2cca8f007f2eee66f51c95a979371622b850ceb2ce3608d00ba826f7c494a1da0fba3c1427728f2c173fe50d59b701da35c2c9fdad2752a5a49746b1c8ef31
+    HEAD_REF master
+)
+
+# With ABSL_PROPAGATE_CXX_STD=ON abseil automatically detect if it is being
+# compiled with C++14 or C++17, and modifies the installed `absl/base/options.h`
+# header accordingly. This works even if CMAKE_CXX_STANDARD is not set. Abseil
+# uses the compiler default behavior to update `absl/base/options.h` as needed.
+set(ABSL_USE_CXX17_OPTION "")
+if("cxx17" IN_LIST FEATURES)
+    set(ABSL_USE_CXX17_OPTION "-DCMAKE_CXX_STANDARD=17")
+endif()
+
+set(ABSL_STATIC_RUNTIME_OPTION "")
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_CRT_LINKAGE STREQUAL "static")
+    set(ABSL_STATIC_RUNTIME_OPTION "-DABSL_MSVC_STATIC_RUNTIME=ON")
+endif()
+
+# Don't let Abseil clobber our CMAKE_MSVC_RUNTIME_LIBRARY choice.
+vcpkg_replace_string("${SOURCE_PATH}/CMakeLists.txt" "set(CMAKE_MSVC_RUNTIME_LIBRARY \"MultiThreaded$<$<CONFIG:Debug>:Debug>DLL\")" "#set(CMAKE_MSVC_RUNTIME_LIBRARY \"MultiThreaded$<$<CONFIG:Debug>:Debug>DLL\")")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DABSL_PROPAGATE_CXX_STD=OFF
+        -DCMAKE_CXX_STANDARD=14
+        ${ABSL_USE_CXX17_OPTION}
+        ${ABSL_STATIC_RUNTIME_OPTION}
+)
+
+# Don't let our customized version of Abseil pose as the real thing.
+vcpkg_replace_string("${SOURCE_PATH}/absl/base/options.h" "ABSL_OPTION_INLINE_NAMESPACE_NAME lts_20240722" "ABSL_OPTION_INLINE_NAMESPACE_NAME lts_20240722_cesium_for_unreal")
+vcpkg_replace_string("${SOURCE_PATH}/absl/base/options.h" "ABSL_OPTION_USE_STD_ANY 2" "ABSL_OPTION_USE_STD_ANY 0")
+vcpkg_replace_string("${SOURCE_PATH}/absl/base/options.h" "ABSL_OPTION_USE_STD_OPTIONAL 2" "ABSL_OPTION_USE_STD_OPTIONAL 0")
+vcpkg_replace_string("${SOURCE_PATH}/absl/base/options.h" "ABSL_OPTION_USE_STD_STRING_VIEW 2" "ABSL_OPTION_USE_STD_STRING_VIEW 0")
+vcpkg_replace_string("${SOURCE_PATH}/absl/base/options.h" "ABSL_OPTION_USE_STD_VARIANT 2" "ABSL_OPTION_USE_STD_VARIANT 0")
+vcpkg_replace_string("${SOURCE_PATH}/absl/base/options.h" "ABSL_OPTION_USE_STD_ORDERING 2" "ABSL_OPTION_USE_STD_ORDERING 0")
+vcpkg_replace_string("${SOURCE_PATH}/absl/base/config.h" "#define ABSL_LTS_RELEASE_VERSION 20240722" "//#define ABSL_LTS_RELEASE_VERSION 20240722")
+vcpkg_replace_string("${SOURCE_PATH}/absl/base/config.h" "#define ABSL_LTS_RELEASE_PATCH_LEVEL 0" "//#define ABSL_LTS_RELEASE_PATCH_LEVEL 0")
+
+# Apply this patch to fix C++20 build with Android NDK r25
+# https://github.com/abseil/abseil-cpp/pull/1728
+vcpkg_replace_string("${SOURCE_PATH}/absl/time/time.h" "__cpp_impl_three_way_comparison" "__cpp_lib_three_way_comparison")
+vcpkg_replace_string("${SOURCE_PATH}/absl/strings/cord.h" "__cpp_impl_three_way_comparison" "__cpp_lib_three_way_comparison")
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME absl CONFIG_PATH lib/cmake/absl)
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include"
+                    "${CURRENT_PACKAGES_DIR}/include/absl/copts"
+                    "${CURRENT_PACKAGES_DIR}/include/absl/strings/testdata"
+                    "${CURRENT_PACKAGES_DIR}/include/absl/time/internal/cctz/testdata"
+)
+
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/absl/base/config.h" "defined(ABSL_CONSUME_DLL)" "1")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/absl/base/internal/thread_identity.h" "defined(ABSL_CONSUME_DLL)" "1")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/native~/vcpkg/ports/abseil/vcpkg.json
+++ b/native~/vcpkg/ports/abseil/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "abseil",
+  "version": "20240722.0-cesium-for-unreal",
+  "description": [
+    "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",
+    "In some cases, Abseil provides pieces missing from the C++ standard; in others, Abseil provides alternatives to the standard for special needs we've found through usage in the Google code base. We denote those cases clearly within the library code we provide you.",
+    "Abseil is not meant to be a competitor to the standard library; we've just found that many of these utilities serve a purpose within our code base, and we now want to provide those resources to the C++ community as a whole."
+  ],
+  "homepage": "https://github.com/abseil/abseil-cpp",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "cxx17": {
+      "description": "Enable compiler C++17."
+    }
+  }
+}


### PR DESCRIPTION
This updates cesium-native to the latest main, and removes mentions of `gsl` now that https://github.com/CesiumGS/cesium-native/pull/977 is merged.