### PR TITLE
Improve stability on AppDomain reloads.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that could cause a crash on AppDomain reloads.
+
 ## v1.14.0 - 2024-12-02
 
 ##### Additions :tada:

--- a/Reinterop~/CSharpObjectHandleUtility.cs
+++ b/Reinterop~/CSharpObjectHandleUtility.cs
@@ -37,8 +37,15 @@ namespace Reinterop
                             return handle;
 
                         // Allocate a new GCHandle pointing to the same object.
-                        GCHandle gcHandle = GCHandle.FromIntPtr(handle);
-                        return GCHandle.ToIntPtr(GCHandle.Alloc(gcHandle.Target));
+                        try
+                        {
+                            GCHandle gcHandle = GCHandle.FromIntPtr(handle);
+                            return GCHandle.ToIntPtr(GCHandle.Alloc(gcHandle.Target));
+                        }
+                        catch (Exception)
+                        {
+                            return IntPtr.Zero;
+                        }
                     }
 
                     public static void FreeHandle(IntPtr handle)
@@ -50,14 +57,13 @@ namespace Reinterop
                         {
                             GCHandle.FromIntPtr(handle).Free();
                         }
-                        catch (ArgumentException e)
+                        catch (Exception)
                         {
                             // The "GCHandle value belongs to a different domain" exception tends
                             // to happen on AppDomain reload, which is common in Unity.
                             // Catch the exception to prevent it propagating through our native
                             // code and blowing things up.
                             // See: https://github.com/CesiumGS/cesium-unity/issues/18
-                            System.Console.WriteLine(e.ToString());
                         }
                     }
 
@@ -66,7 +72,14 @@ namespace Reinterop
                         if (handle == IntPtr.Zero)
                             return null;
 
-                        return GCHandle.FromIntPtr(handle).Target;
+                        try
+                        {
+                            return GCHandle.FromIntPtr(handle).Target;
+                        }
+                        catch (Exception)
+                        {
+                            return null;
+                        }
                     }
 
                     public static object GetObjectAndFreeHandle(IntPtr handle)
@@ -74,10 +87,17 @@ namespace Reinterop
                         if (handle == IntPtr.Zero)
                             return null;
 
-                        GCHandle gcHandle = GCHandle.FromIntPtr(handle);
-                        object result = gcHandle.Target;
-                        gcHandle.Free();
-                        return result;
+                        try
+                        {
+                            GCHandle gcHandle = GCHandle.FromIntPtr(handle);
+                            object result = gcHandle.Target;
+                            gcHandle.Free();
+                            return result;
+                        }
+                        catch (Exception)
+                        {
+                            return null;
+                        }
                     }
 
                     public static void ResetHandleObject(IntPtr handle, object newValue)

--- a/native~/Shared/src/CesiumImpl.h
+++ b/native~/Shared/src/CesiumImpl.h
@@ -5,7 +5,7 @@
 namespace CesiumForUnityNative {
 
 template <typename TDerived>
-class CesiumImpl : public CesiumUtility::ReferenceCounted<TDerived> {
+class CesiumImpl : public CesiumUtility::ReferenceCountedThreadSafe<TDerived> {
 public:
   CesiumImpl() = default;
 


### PR DESCRIPTION
Fixes #525 
(at least, it should be much better!)

This PR makes two changes that should significantly decrease the chances of a crash when Unity reloads AppDomains:

* Uses the Impl class reference counting added in #503 to ensure that the `CesiumIonSessionImpl` instance will not be destroyed while the network requests it starts are in progress.
* Catches the exception in more cases that is returned by `GCHandle.FromIntPtr` when the AppDomain has been reloaded and the IntPtr corresponds to an object from the old domain. Exceptions are disastrous and often create instability because of #18.

Unity reloads AppDomains a _lot_, so anything we can do to more it work more reliably is likely to be a big win for users. Unfortunately, this probably isn't a 100% solution. We really need #18, for one thing. For another, it's not clear to me (even after looking at the Mono source code) whether the "object is from a previous AppDomain" detection is 100% reliable. It might be best effort, and sometimes just give you the "wrong" object instead of throwing an exception. 

* https://github.com/Unity-Technologies/mono/blob/2021.3.13f1/mcs/class/corlib/System.Runtime.InteropServices/GCHandle.cs#L134
* https://github.com/Unity-Technologies/mono/blob/2021.3.13f1/mono/metadata/gc.c#L822
* https://github.com/Unity-Technologies/mono/blob/2021.3.13f1/mono/metadata/null-gc-handles.c#L356

If that's the case, we might ultimately need to either: 1) implement a way to reliably stop and unload _all_ of the Native world when the AppDomain unloads, or 2) extend our native `ObjectHandle` to record the [AppDomain.Id](https://learn.microsoft.com/en-us/dotnet/api/system.appdomain.id) and verify it's still correct before dereferencing. Option (2) is probably more realistic.

This PR also updates cesium-native to the current head of main.