### PR TITLE
Fix shared image crash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that could cause a crash or incorrect textures when multiple `Cesium3DTileset` tiles referenced the same image by URL.
+
 ## v1.14.0 - 2024-12-02
 
 ##### Additions :tada:

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -268,6 +268,15 @@ void generateMipMaps(
       const Sampler* pSampler =
           Model::getSafe(&pModel->samplers, pTexture->sampler);
       if (pImage && pSampler) {
+        // We currently do not support shared resources, so if this image is
+        // associated with a depot, unshare it. This is necessary to avoid a
+        // race condition where multiple threads attempt to generate mipmaps for
+        // the same shared image simultaneously.
+        if (pImage->pAsset && pImage->pAsset->getDepot() != nullptr) {
+          // Copy the asset.
+          pImage->pAsset.emplace(*pImage->pAsset);
+        }
+
         switch (pSampler->minFilter.value_or(
             CesiumGltf::Sampler::MinFilter::LINEAR_MIPMAP_LINEAR)) {
         case CesiumGltf::Sampler::MinFilter::LINEAR_MIPMAP_LINEAR:


### PR DESCRIPTION
Fixes #537 

This is pretty much the simplest possible fix. It copies shared images so that they are no longer shared.