### PR TITLE
Fix loading problems for models without normals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 ##### Fixes :wrench:
 
 - Fixed a bug that could cause a crash or incorrect textures when multiple `Cesium3DTileset` tiles referenced the same image by URL.
+- Fixed a bug that could cause incorrect colors in a model that did have vertex colors but did not have normals.
+- Fixed a bug that could cause a hang when attempting to load a model with UINT16 indices where generating flat normals required more than 2^16 vertices.
 
 ## v1.14.0 - 2024-12-02
 

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -161,11 +161,11 @@ template <typename TIndex> struct CopyVertexColors {
     bool success = true;
     if (duplicateVertices) {
       for (size_t i = 0; success && i < vertexCount; ++i) {
-        if (i >= colorView.size()) {
+        TIndex vertexIndex = indices[i];
+        if (vertexIndex < 0 || vertexIndex >= colorView.size()) {
           success = false;
         } else {
           Color32& packedColor = *reinterpret_cast<Color32*>(pWritePos);
-          TIndex vertexIndex = indices[i];
           success = CopyVertexColors::convertColor(
               colorView[vertexIndex],
               packedColor);


### PR DESCRIPTION
Fixes #540 

* Upgrades cesium-native to incorporate https://github.com/CesiumGS/cesium-native/pull/1050.
* Fixes a problem where vertex colors were populated incorrectly when flat normals needed to be generated.
* Fixes an endless loop when flat normals needed to be generated and this made the number of vertices too large to be addressable with UINT16 indices.
