### PR TITLE
handle CesiumGeometry::BoundingCylinderRegion in std::variant visitor

### DIFF
--- a/native~/Runtime/src/Cesium3DTilesetImpl.cpp
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.cpp
@@ -279,6 +279,10 @@ struct CalculateECEFCameraPosition {
   glm::dvec3 operator()(const CesiumGeospatial::S2CellBoundingVolume& s2) {
     return (*this)(s2.computeBoundingRegion(ellipsoid));
   }
+
+  glm::dvec3 operator()(const CesiumGeometry::BoundingCylinderRegion& cyl) {
+    return (*this)(cyl.toOrientedBoundingBox());
+  }
 };
 } // namespace
 


### PR DESCRIPTION
This won't work until, but will be necessary when, https://github.com/CesiumGS/cesium-native#1111 is included in cesium-unity's cesium-native.