### PR TITLE
Fix crash resulting from GameObject being deleted before load thread finishes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that could cause a crash when reloading a scene or tileset repeatedly.
+
 ## v1.15.4 - 2025-03-03
 
 ##### Fixes :wrench:

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -920,6 +920,15 @@ UnityPrepareRendererResources::prepareInLoadThread(
       .thenInMainThread(
           [asyncSystem, tileset = this->_tilesetGameObject](
               IntermediateLoadThreadResult&& workerResult) mutable {
+            if (tileset == nullptr) {
+              // Tileset GameObject was deleted while we were loading a tile
+              // (possibly play mode was exited or another cause).
+              return asyncSystem.createResolvedFuture(
+                  TileLoadResultAndRenderResources{
+                      std::move(workerResult.tileLoadResult),
+                      nullptr});
+            }
+
             bool shouldCreatePhysicsMeshes = false;
             bool shouldShowTilesInHierarchy = false;
 


### PR DESCRIPTION
A [user reported on our forums](https://community.cesium.com/t/editor-crash-issue-with-cesium-for-unity-package-1-15-4/39424) a crash in Cesium for Unity while reloading the scene repeatedly. I was able to reproduce this issue and track it down to `UntiyPrepareRendererResources::prepareInLoadThread`. When Unity toggles between play mode and edit mode, GameObjects in the scene are deleted and recreated. The problem this causes is that, if this happens right at the moment we're in the `thenInWorkerThread` part of `prepareInLoadThread`, the tileset GameObject is cleaned up by the time we return to the main thread and try to grab a component from it. All we need to do to avoid this is to check if the GameObject is valid before attempting to call `GetComponent` on it. Of course, as is the case with race conditions, I'm not positive I completely solved the issue here, but I was no longer able to reproduce the error after this fix.