### PR TITLE
Add `CesiumUrlTemplateRasterOverlay` component

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Change Log
 
-## v1.15.5
+## ? - ?
+
+##### Additions :tada:
+
+- Added `CesiumUrlTemplateRasterOverlay` component, allowing a raster overlay to be added using tiles requested based on a specified URL template.
+
+## v1.15.5 - 2025-04-01
 
 ##### Fixes :wrench:
 

--- a/Editor/CesiumUrlTemplateRasterOverlayEditor.cs
+++ b/Editor/CesiumUrlTemplateRasterOverlayEditor.cs
@@ -1,0 +1,199 @@
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace CesiumForUnity
+{
+    [CustomEditor(typeof(CesiumUrlTemplateRasterOverlay))]
+    public class CesiumUrlTemplateRasterOverlayEditor : Editor
+    {
+        private static readonly (string Template, string Desc)[] TEMPLATE_PARAMS = new (string Template, string Desc)[]
+        {
+            ("x", "The tile X coordinate in the tiling scheme, where 0 is the westernmost tile."),
+            ("y", "The tile Y coordinate in the tiling scheme, where 0 is the nothernmost tile."),
+            ("z", "The level of the tile in the tiling scheme, where 0 is the root of the quadtree pyramid."),
+            ("reverseX", "The tile X coordinate in the tiling scheme, where 0 is the easternmost tile."),
+            ("reverseY", "The tile Y coordinate in the tiling scheme, where 0 is the southernmost tile."),
+            ("reverseZ", "The tile Z coordinate in the tiling scheme, where 0 is equivalent to `maximumLevel`."),
+            ("westDegrees", "The western edge of the tile in geodetic degrees."),
+            ("southDegrees", "The southern edge of the tile in geodetic degrees."),
+            ("eastDegrees", "The eastern edge of the tile in geodetic degrees."),
+            ("northDegrees", "The northern edge of the tile in geodetic degrees."),
+            ("minimumX", "The minimum X coordinate of the tile's projected coordinates."),
+            ("minimumY", "The minimum Y coordinate of the tile's projected coordinates."),
+            ("maximumX", "The maximum X coordinate of the tile's projected coordinates."),
+            ("maximumY", "The maximum Y coordinate of the tile's projected coordinates."),
+            ("width", "The width of each tile in pixels."),
+            ("height", "The height of each tile in pixels.")
+        };
+
+        private CesiumUrlTemplateRasterOverlay _urlTemplateRasterOverlay;
+        private CesiumRasterOverlayEditor _rasterOverlayEditor;
+
+        private SerializedProperty _templateUrl;
+        private SerializedProperty _projection;
+        private SerializedProperty _specifyTilingScheme;
+        private SerializedProperty _rootTilesX;
+        private SerializedProperty _rootTilesY;
+        private SerializedProperty _rectangleWest;
+        private SerializedProperty _rectangleSouth;
+        private SerializedProperty _rectangleEast;
+        private SerializedProperty _rectangleNorth;
+        private SerializedProperty _minimumLevel;
+        private SerializedProperty _maximumLevel;
+        private SerializedProperty _tileWidth;
+        private SerializedProperty _tileHeight;
+        private SerializedProperty _requestHeaders;
+
+        private bool _foldOut = false;
+
+        private void OnEnable()
+        {
+            this._urlTemplateRasterOverlay =
+                (CesiumUrlTemplateRasterOverlay)this.target;
+            this._rasterOverlayEditor =
+                (CesiumRasterOverlayEditor)Editor.CreateEditor(
+                                                    this.target,
+                                                    typeof(CesiumRasterOverlayEditor));
+
+            this._templateUrl = this.serializedObject.FindProperty("_templateUrl");
+            this._projection = this.serializedObject.FindProperty("_projection");
+            this._specifyTilingScheme = this.serializedObject.FindProperty("_specifyTilingScheme");
+            this._rootTilesX = this.serializedObject.FindProperty("_rootTilesX");
+            this._rootTilesY = this.serializedObject.FindProperty("_rootTilesY");
+            this._rectangleWest = this.serializedObject.FindProperty("_rectangleWest");
+            this._rectangleSouth = this.serializedObject.FindProperty("_rectangleSouth");
+            this._rectangleEast = this.serializedObject.FindProperty("_rectangleEast");
+            this._rectangleNorth = this.serializedObject.FindProperty("_rectangleNorth");
+            this._minimumLevel = this.serializedObject.FindProperty("_minimumLevel");
+            this._maximumLevel = this.serializedObject.FindProperty("_maximumLevel");
+            this._tileWidth = this.serializedObject.FindProperty("_tileWidth");
+            this._tileHeight = this.serializedObject.FindProperty("_tileHeight");
+            this._requestHeaders = this.serializedObject.FindProperty("_requestHeaders");
+        }
+
+        private void OnDisable()
+        {
+            if (this._rasterOverlayEditor != null)
+            {
+                DestroyImmediate(this._rasterOverlayEditor);
+            }
+        }
+
+        public override void OnInspectorGUI()
+        {
+            this.serializedObject.Update();
+
+            EditorGUIUtility.labelWidth = CesiumEditorStyle.inspectorLabelWidth;
+            DrawUrlTemplateProperties();
+            EditorGUILayout.Space(5);
+            DrawRasterOverlayProperties();
+
+            this.serializedObject.ApplyModifiedProperties();
+        }
+
+        private void DrawUrlTemplateProperties()
+        {
+            EditorGUILayout.DelayedTextField(this._templateUrl, new GUIContent(
+               "Template URL",
+               @"The URL containing template parameters that will be substituted when loading tiles."));
+            this._foldOut = EditorGUILayout.BeginFoldoutHeaderGroup(this._foldOut, new GUIContent("Supported URL Parameters"));
+
+            if (this._foldOut)
+            {
+                float maxLabelSize = TEMPLATE_PARAMS.Max(param => EditorStyles.boldLabel.CalcSize(new GUIContent("{" + param.Template + "}")).x);
+                foreach (var (name, desc) in TEMPLATE_PARAMS)
+                {
+                    EditorGUILayout.BeginHorizontal();
+                    EditorGUILayout.LabelField("{" + name + "}", EditorStyles.boldLabel, GUILayout.Width(maxLabelSize));
+                    EditorGUILayout.LabelField(desc, EditorStyles.wordWrappedLabel, GUILayout.ExpandHeight(true));
+                    EditorGUILayout.EndHorizontal();
+                }
+            }
+
+            EditorGUILayout.EndFoldoutHeaderGroup();
+
+            EditorGUILayout.Space(5);
+
+            EditorGUILayout.PropertyField(
+                this._projection,
+                new GUIContent("Projection", "The type of projection used to protect the imagery onto the globe."));
+
+            EditorGUILayout.PropertyField(
+                this._specifyTilingScheme,
+                new GUIContent("Specify Tiling Scheme",
+                "Set this to true to specify the quadtree tiling scheme according to the specified root tile" +
+                "numbers and projected bounding rectangle. If false, the tiling scheme will be deduced from" +
+                "the projection."));
+
+            EditorGUI.BeginDisabledGroup(!this._specifyTilingScheme.boolValue);
+            GUIContent rootTilesXContent = new GUIContent(
+                "Root Tiles X",
+                "If specified, this determines the number of tiles at the root of the quadtree tiling scheme in the X direction.");
+            EditorGUILayout.PropertyField(this._rootTilesX, rootTilesXContent);
+            GUIContent rootTilesYContent = new GUIContent(
+                "Root Tiles Y",
+                "If specified, this determines the number of tiles at the root of the quadtree tiling scheme in the Y direction.");
+            EditorGUILayout.PropertyField(this._rootTilesY, rootTilesYContent);
+
+            CesiumInspectorGUI.ClampedDoubleField(
+                this._rectangleWest,
+                -180, 180,
+                new GUIContent(
+                    "Rectangle West",
+                    "The west boundary of the bounding rectangle used for the quadtree tiling" +
+                    "scheme. Specified in longitude degrees in the range [-180, 180]."
+                ));
+            CesiumInspectorGUI.ClampedDoubleField(
+                this._rectangleSouth,
+                -90, 90,
+                new GUIContent(
+                    "Rectangle South",
+                    "The south boundary of the bounding rectangle used for the quadtree tiling" +
+                    "scheme. Specified in longitude degrees in the range [-90, 90]."
+                ));
+            CesiumInspectorGUI.ClampedDoubleField(
+                this._rectangleEast,
+                -180, 180,
+                new GUIContent(
+                    "Rectangle East",
+                    "The east boundary of the bounding rectangle used for the quadtree tiling" +
+                    "scheme. Specified in longitude degrees in the range [-180, 180]."
+                ));
+            CesiumInspectorGUI.ClampedDoubleField(
+                this._rectangleNorth,
+                -90, 90,
+                new GUIContent(
+                    "Rectangle North",
+                    "The north boundary of the bounding rectangle used for the quadtree tiling" +
+                    "scheme. Specified in longitude degrees in the range [-90, 90]."
+                ));
+            EditorGUI.EndDisabledGroup();
+
+            EditorGUILayout.PropertyField(this._minimumLevel, new GUIContent(
+                "Minimum Level",
+                "Minimum zoom level.\n\n" +
+                "Take care when specifying this that the number of tiles at the minimum" +
+                "level is small, such as four or less. A larger number is likely to result" +
+                "in rendering problems."
+                 ));
+            EditorGUILayout.PropertyField(this._maximumLevel, new GUIContent("Maximum Level", "Maximum zoom level."));
+
+            EditorGUILayout.PropertyField(this._tileWidth, new GUIContent("Tile Width", "The pixel width of the image tiles."));
+            EditorGUILayout.PropertyField(this._tileHeight, new GUIContent("Tile Height", "The pixel height of the image tiles."));
+
+            EditorGUILayout.PropertyField(
+                this._requestHeaders,
+                new GUIContent("Request Headers", "HTTP headers to be attached to each request made for this raster overlay."));
+
+        }
+
+        private void DrawRasterOverlayProperties()
+        {
+            if (this._rasterOverlayEditor != null)
+            {
+                this._rasterOverlayEditor.OnInspectorGUI();
+            }
+        }
+    }
+}

--- a/Editor/CesiumUrlTemplateRasterOverlayEditor.cs
+++ b/Editor/CesiumUrlTemplateRasterOverlayEditor.cs
@@ -117,7 +117,7 @@ namespace CesiumForUnity
 
             EditorGUILayout.PropertyField(
                 this._projection,
-                new GUIContent("Projection", "The type of projection used to protect the imagery onto the globe."));
+                new GUIContent("Projection", "The type of projection used to project the imagery onto the globe."));
 
             EditorGUILayout.PropertyField(
                 this._specifyTilingScheme,

--- a/Editor/CesiumUrlTemplateRasterOverlayEditor.cs.meta
+++ b/Editor/CesiumUrlTemplateRasterOverlayEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c3b0d75a8bfd66c419b5a43b7b9e9bd0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/CesiumUrlTemplateRasterOverlay.cs
+++ b/Runtime/CesiumUrlTemplateRasterOverlay.cs
@@ -1,0 +1,336 @@
+using Reinterop;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CesiumForUnity
+{
+    /// <summary>
+    /// A raster overlay that loads tiles from a templated URL.
+    /// </summary>
+    [ReinteropNativeImplementation(
+        "CesiumForUnityNative::CesiumUrlTemplateRasterOverlayImpl", "CesiumUrlTemplateRasterOverlayImpl.h")]
+    [AddComponentMenu("Cesium/Cesium URL Template Raster Overlay")]
+    [IconAttribute("Packages/com.cesium.unity/Editor/Resources/Cesium-24x24.png")]
+    public partial class CesiumUrlTemplateRasterOverlay : CesiumRasterOverlay
+    {
+        [SerializeField]
+        private string _templateUrl;
+
+        /// <summary>
+        /// The URL containing template parameters that will be substituted when
+        /// loading tiles.
+        /// 
+        /// The following template parameters are supported in `url`:
+        /// - `{x}` - The tile X coordinate in the tiling scheme, where 0 is the
+        /// westernmost tile.
+        /// - `{y}` - The tile Y coordinate in the tiling scheme, where 0 is the
+        /// nothernmost tile.
+        /// - `{z}` - The level of the tile in the tiling scheme, where 0 is the root
+        /// of the quadtree pyramid.
+        /// - `{reverseX}` - The tile X coordinate in the tiling scheme, where 0 is the
+        /// easternmost tile.
+        /// - `{reverseY}` - The tile Y coordinate in the tiling scheme, where 0 is the
+        /// southernmost tile.
+        /// - `{reverseZ}` - The tile Z coordinate in the tiling scheme, where 0 is
+        /// equivalent to `urlTemplateOptions.maximumLevel`.
+        /// - `{westDegrees}` - The western edge of the tile in geodetic degrees.
+        /// - `{southDegrees}` - The southern edge of the tile in geodetic degrees.
+        /// - `{eastDegrees}` - The eastern edge of the tile in geodetic degrees.
+        /// - `{northDegrees}` - The northern edge of the tile in geodetic degrees.
+        /// - `{minimumX}` - The minimum X coordinate of the tile's projected
+        /// coordinates.
+        /// - `{minimumY}` - The minimum Y coordinate of the tile's projected
+        /// coordinates.
+        /// - `{maximumX}` - The maximum X coordinate of the tile's projected
+        /// coordinates.
+        /// - `{maximumY}` - The maximum Y coordinate of the tile's projected
+        /// coordinates.
+        /// - `{width}` - The width of each tile in pixels.
+        /// - `{height}` - The height of each tile in pixels.
+        /// </summary>
+        public string templateUrl
+        {
+            get => this._templateUrl;
+            set
+            {
+                this._templateUrl = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private CesiumUrlTemplateRasterOverlayProjection _projection = CesiumUrlTemplateRasterOverlayProjection.WebMercator;
+
+        /// <summary>
+        /// The type of projection used to protect the imagery onto the globe.
+        /// 
+        /// For instance, EPSG:4326 uses geographic projection and EPSG:3857 uses Web Mercator.
+        /// </summary>
+        public CesiumUrlTemplateRasterOverlayProjection projection
+        {
+            get => this._projection;
+            set
+            {
+                this._projection = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private bool _specifyTilingScheme = false;
+
+        /// <summary>
+        /// Set this to true to specify the quadtree tiling scheme according to the specified root 
+        /// tile numbers and projected bounding rectangle. If false, the tiling scheme will be 
+        /// deduced from the projection.
+        /// </summary>
+        public bool specifyTilingScheme
+        {
+            get => this._specifyTilingScheme;
+            set
+            {
+                this._specifyTilingScheme = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        [Min(1)]
+        private int _rootTilesX = 1;
+
+        /// <summary>
+        /// If specified, this determines the number of tiles at the root of the quadtree tiling scheme in the X direction.
+        ///
+        /// Only applicable if "Specify Tiling Scheme" is set to true.
+        /// </summary>
+        public int rootTilesX
+        {
+            get => this._rootTilesX;
+            set
+            {
+                this._rootTilesX = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        [Min(1)]
+        private int _rootTilesY = 1;
+
+        /// <summary>
+        /// If specified, this determines the number of tiles at the root of the quadtree tiling scheme in the Y direction.
+        ///
+        /// Only applicable if "Specify Tiling Scheme" is set to true.
+        /// </summary>
+        public int rootTilesY
+        {
+            get => this._rootTilesY;
+            set
+            {
+                this._rootTilesY = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private double _rectangleWest = -180.0;
+
+        /// <summary>
+        /// The west boundary of the bounding rectangle used for the quadtree tiling
+        /// scheme. Specified in longitude degrees in the range [-180, 180].
+        ///
+        /// Only applicable if "Specify Tiling Scheme" is set to true.
+        /// </summary>
+        public double rectangleWest
+        {
+            get => this._rectangleWest;
+            set
+            {
+                this._rectangleWest = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private double _rectangleSouth = -90.0;
+
+        /// <summary>
+        /// The south boundary of the bounding rectangle used for the quadtree tiling
+        /// scheme. Specified in latitude degrees in the range [-90, 90].
+        ///
+        /// Only applicable if "Specify Tiling Scheme" is set to true.
+        /// </summary>
+        public double rectangleSouth
+        {
+            get => this._rectangleSouth;
+            set
+            {
+                this._rectangleSouth = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private double _rectangleEast = 180.0;
+
+        /// <summary>
+        /// The east boundary of the bounding rectangle used for the quadtree tiling
+        /// scheme. Specified in longitude degrees in the range [-180, 180].
+        ///
+        /// Only applicable if "Specify Tiling Scheme" is set to true.
+        /// </summary>
+        public double rectangleEast
+        {
+            get => this._rectangleEast;
+            set
+            {
+                this._rectangleEast = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private double _rectangleNorth = -90.0;
+
+        /// <summary>
+        /// The north boundary of the bounding rectangle used for the quadtree tiling
+        /// scheme. Specified in latitude degrees in the range [-90, 90].
+        ///
+        /// Only applicable if "Specify Tiling Scheme" is set to true.
+        /// </summary>
+        public double rectangleNorth
+        {
+            get => this._rectangleNorth;
+            set
+            {
+                this._rectangleNorth = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        [Min(0)]
+        private int _minimumLevel = 0;
+
+        /// <summary>
+        /// Minimum zoom level.
+        ///
+        /// Take care when specifying this that the number of tiles at the minimum
+        /// level is small, such as four or less. A larger number is likely to result
+        /// in rendering problems.
+        /// </summary>
+        public int minimumLevel
+        {
+            get => this._minimumLevel;
+            set
+            {
+                this._minimumLevel = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        [Min(0)]
+        private int _maximumLevel = 25;
+
+        /// <summary>
+        /// Maximum zoom level.
+        /// </summary>
+        public int maximumLevel
+        {
+            get => this._maximumLevel;
+            set
+            {
+                this._maximumLevel = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        [Min(64)]
+        private int _tileWidth = 256;
+
+        /// <summary>
+        /// The pixel width of the image tiles.
+        /// </summary>
+        public int tileWidth
+        {
+            get => this._tileWidth;
+            set
+            {
+                this._tileWidth = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        [Min(64)]
+        private int _tileHeight = 256;
+
+        /// <summary>
+        /// The pixel height of the image tiles.
+        /// </summary>
+        public int tileHeight
+        {
+            get => this._tileHeight;
+            set
+            {
+                this._tileHeight = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private List<HeaderEntry> _requestHeaders = new List<HeaderEntry>();
+
+        /// <summary>
+        /// HTTP headers to be attached to each request made for this raster overlay.
+        /// </summary>
+        public List<HeaderEntry> requestHeaders
+        {
+            get => this._requestHeaders;
+            set
+            {
+                this._requestHeaders = value;
+                this.Refresh();
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override partial void AddToTileset(Cesium3DTileset tileset);
+        /// <inheritdoc/>
+        protected override partial void RemoveFromTileset(Cesium3DTileset tileset);
+
+        /// <summary>
+        /// An HTTP header name paired with its specified value.
+        /// </summary>
+        [Serializable]
+        public class HeaderEntry
+        {
+            /// <summary>
+            /// The name of the header.
+            /// </summary>
+            public string Name;
+            /// <summary>
+            /// The value of the header.
+            /// </summary>
+            public string Value;
+        }
+
+        /// <summary>
+        /// Specifies the type of projection used for projecting a URL template raster overlay.
+        /// </summary>
+        public enum CesiumUrlTemplateRasterOverlayProjection
+        {
+            /// <summary>
+            /// The raster overlay is projected using Web Mercator.
+            /// </summary>
+            WebMercator,
+            /// <summary>
+            /// The raster overlay is projected using a geographic projection.
+            /// </summary>
+            Geographic
+        }
+    }
+}

--- a/Runtime/CesiumUrlTemplateRasterOverlay.cs
+++ b/Runtime/CesiumUrlTemplateRasterOverlay.cs
@@ -6,6 +6,21 @@ using UnityEngine;
 namespace CesiumForUnity
 {
     /// <summary>
+    /// Specifies the type of projection used for projecting a URL template raster overlay.
+    /// </summary>
+    public enum CesiumUrlTemplateRasterOverlayProjection
+    {
+        /// <summary>
+        /// The raster overlay is projected using Web Mercator.
+        /// </summary>
+        WebMercator,
+        /// <summary>
+        /// The raster overlay is projected using a geographic projection.
+        /// </summary>
+        Geographic
+    }
+
+    /// <summary>
     /// A raster overlay that loads tiles from a templated URL.
     /// </summary>
     [ReinteropNativeImplementation(
@@ -316,21 +331,6 @@ namespace CesiumForUnity
             /// The value of the header.
             /// </summary>
             public string Value;
-        }
-
-        /// <summary>
-        /// Specifies the type of projection used for projecting a URL template raster overlay.
-        /// </summary>
-        public enum CesiumUrlTemplateRasterOverlayProjection
-        {
-            /// <summary>
-            /// The raster overlay is projected using Web Mercator.
-            /// </summary>
-            WebMercator,
-            /// <summary>
-            /// The raster overlay is projected using a geographic projection.
-            /// </summary>
-            Geographic
         }
     }
 }

--- a/Runtime/CesiumUrlTemplateRasterOverlay.cs
+++ b/Runtime/CesiumUrlTemplateRasterOverlay.cs
@@ -78,7 +78,7 @@ namespace CesiumForUnity
         private CesiumUrlTemplateRasterOverlayProjection _projection = CesiumUrlTemplateRasterOverlayProjection.WebMercator;
 
         /// <summary>
-        /// The type of projection used to protect the imagery onto the globe.
+        /// The type of projection used to project the imagery onto the globe.
         /// 
         /// For instance, EPSG:4326 uses geographic projection and EPSG:3857 uses Web Mercator.
         /// </summary>
@@ -206,7 +206,7 @@ namespace CesiumForUnity
         }
 
         [SerializeField]
-        private double _rectangleNorth = -90.0;
+        private double _rectangleNorth = 90.0;
 
         /// <summary>
         /// The north boundary of the bounding rectangle used for the quadtree tiling

--- a/Runtime/CesiumUrlTemplateRasterOverlay.cs.meta
+++ b/Runtime/CesiumUrlTemplateRasterOverlay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 19f3030f151b6184fb5d0e96c8c582dc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -57,7 +57,7 @@ namespace CesiumForUnity
         public void ExposeToCPP()
         {
             Camera c = Camera.main;
-            
+
             Transform t = c.transform;
             Vector3 u = t.up;
             Vector3 f = t.forward;
@@ -361,6 +361,28 @@ namespace CesiumForUnity
             webMapTileServiceRasterOverlay.tileHeight = webMapTileServiceRasterOverlay.tileHeight;
             baseOverlay = webMapTileServiceRasterOverlay;
 
+            CesiumUrlTemplateRasterOverlay urlTemplateRasterOverlay = go.GetComponent<CesiumUrlTemplateRasterOverlay>();
+            urlTemplateRasterOverlay.templateUrl = urlTemplateRasterOverlay.templateUrl;
+            urlTemplateRasterOverlay.projection = urlTemplateRasterOverlay.projection;
+            urlTemplateRasterOverlay.specifyTilingScheme = urlTemplateRasterOverlay.specifyTilingScheme;
+            urlTemplateRasterOverlay.rootTilesX = urlTemplateRasterOverlay.rootTilesX;
+            urlTemplateRasterOverlay.rootTilesY = urlTemplateRasterOverlay.rootTilesY;
+            urlTemplateRasterOverlay.rectangleWest = urlTemplateRasterOverlay.rectangleWest;
+            urlTemplateRasterOverlay.rectangleSouth = urlTemplateRasterOverlay.rectangleSouth;
+            urlTemplateRasterOverlay.rectangleEast = urlTemplateRasterOverlay.rectangleEast;
+            urlTemplateRasterOverlay.rectangleNorth = urlTemplateRasterOverlay.rectangleNorth;
+            urlTemplateRasterOverlay.minimumLevel = urlTemplateRasterOverlay.minimumLevel;
+            urlTemplateRasterOverlay.maximumLevel = urlTemplateRasterOverlay.maximumLevel;
+            urlTemplateRasterOverlay.tileWidth = urlTemplateRasterOverlay.tileWidth;
+            urlTemplateRasterOverlay.tileHeight = urlTemplateRasterOverlay.tileHeight;
+            urlTemplateRasterOverlay.requestHeaders = urlTemplateRasterOverlay.requestHeaders;
+            baseOverlay = urlTemplateRasterOverlay;
+
+            int headerLen = urlTemplateRasterOverlay.requestHeaders.Count;
+            CesiumUrlTemplateRasterOverlay.HeaderEntry headerEntry = urlTemplateRasterOverlay.requestHeaders[0];
+            string headerName = headerEntry.Name;
+            string headerValue = headerEntry.Value;
+
             CesiumRasterOverlay[] overlaysArray = go.GetComponents<CesiumRasterOverlay>();
             int len = overlaysArray.Length;
             overlay = overlaysArray[0];
@@ -523,7 +545,7 @@ namespace CesiumForUnity
 
             CesiumSimplePlanarEllipsoidCurve planarEllipsoidCurve = CesiumSimplePlanarEllipsoidCurve.FromCenteredFixedCoordinates(
                 CesiumEllipsoid.WGS84,
-                new double3(0, 0, 0), 
+                new double3(0, 0, 0),
                 new double3(0, 0, 0));
             CesiumEllipsoid ellipsoid = CesiumEllipsoid.WGS84;
             ellipsoid.radii = new double3(0.0, 0.0, 0.0);

--- a/native~/Runtime/src/CameraManager.cpp
+++ b/native~/Runtime/src/CameraManager.cpp
@@ -82,7 +82,7 @@ ViewState unityCameraToViewState(
           ? georeference.ellipsoid().NativeImplementation().GetEllipsoid()
           : CesiumGeospatial::Ellipsoid::WGS84;
 
-  return ViewState::create(
+  return ViewState(
       cameraPosition,
       glm::normalize(cameraDirection),
       glm::normalize(cameraUp),

--- a/native~/Runtime/src/CesiumUrlTemplateRasterOverlayImpl.cpp
+++ b/native~/Runtime/src/CesiumUrlTemplateRasterOverlayImpl.cpp
@@ -1,0 +1,143 @@
+#include "CesiumUrlTemplateRasterOverlayImpl.h"
+
+#include "Cesium3DTilesetImpl.h"
+#include "CesiumRasterOverlayUtility.h"
+
+#include <Cesium3DTilesSelection/Tileset.h>
+#include <CesiumAsync/IAssetAccessor.h>
+#include <CesiumGeometry/Rectangle.h>
+#include <CesiumGeospatial/Ellipsoid.h>
+#include <CesiumGeospatial/GlobeRectangle.h>
+#include <CesiumRasterOverlays/UrlTemplateRasterOverlay.h>
+
+#include <DotNet/CesiumForUnity/Cesium3DTileset.h>
+#include <DotNet/CesiumForUnity/CesiumEllipsoid.h>
+#include <DotNet/CesiumForUnity/CesiumRasterOverlay.h>
+#include <DotNet/CesiumForUnity/CesiumUrlTemplateRasterOverlay.h>
+#include <DotNet/CesiumForUnity/CesiumUrlTemplateRasterOverlayProjection.h>
+#include <DotNet/CesiumForUnity/HeaderEntry.h>
+#include <DotNet/System/String.h>
+#include <DotNet/UnityEngine/GameObject.h>
+
+using namespace Cesium3DTilesSelection;
+using namespace CesiumRasterOverlays;
+using namespace DotNet;
+
+namespace CesiumForUnityNative {
+
+CesiumUrlTemplateRasterOverlayImpl::CesiumUrlTemplateRasterOverlayImpl(
+    const DotNet::CesiumForUnity::CesiumUrlTemplateRasterOverlay& overlay)
+    : _pOverlay(nullptr) {}
+
+CesiumUrlTemplateRasterOverlayImpl::~CesiumUrlTemplateRasterOverlayImpl() {}
+
+void CesiumUrlTemplateRasterOverlayImpl::AddToTileset(
+    const ::DotNet::CesiumForUnity::CesiumUrlTemplateRasterOverlay& overlay,
+    const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset) {
+  if (this->_pOverlay != nullptr) {
+    // Overlay already added.
+    return;
+  }
+
+  DotNet::CesiumForUnity::CesiumGeoreference georeferenceComponent =
+      tileset.gameObject()
+          .GetComponentInParent<DotNet::CesiumForUnity::CesiumGeoreference>();
+  if (georeferenceComponent == nullptr) {
+    return;
+  }
+
+  const CesiumGeospatial::Ellipsoid& ellipsoid =
+      georeferenceComponent.ellipsoid().NativeImplementation().GetEllipsoid();
+
+  if (System::String::IsNullOrEmpty(overlay.templateUrl())) {
+    // Don't create an overlay with an empty URL.
+    return;
+  }
+
+  Cesium3DTilesetImpl& tilesetImpl = tileset.NativeImplementation();
+  Tileset* pTileset = tilesetImpl.getTileset();
+  if (!pTileset)
+    return;
+
+  UrlTemplateRasterOverlayOptions overlayOptions;
+  if (overlay.maximumLevel() > overlay.minimumLevel()) {
+    overlayOptions.minimumLevel = overlay.minimumLevel();
+    overlayOptions.maximumLevel = overlay.maximumLevel();
+  }
+
+  if (overlay.projection() ==
+      ::DotNet::CesiumForUnity::CesiumUrlTemplateRasterOverlayProjection::
+          WebMercator) {
+    overlayOptions.projection =
+        CesiumGeospatial::WebMercatorProjection(ellipsoid);
+  } else {
+    overlayOptions.projection =
+        CesiumGeospatial::GeographicProjection(ellipsoid);
+  }
+
+  overlayOptions.tileWidth = overlay.tileWidth();
+  overlayOptions.tileHeight = overlay.tileHeight();
+
+  if (overlay.specifyTilingScheme()) {
+    CesiumGeospatial::GlobeRectangle globeRectangle =
+        CesiumGeospatial::GlobeRectangle::fromDegrees(
+            overlay.rectangleWest(),
+            overlay.rectangleSouth(),
+            overlay.rectangleEast(),
+            overlay.rectangleNorth());
+    CesiumGeometry::Rectangle coverageRectangle =
+        CesiumGeospatial::projectRectangleSimple(
+            *overlayOptions.projection,
+            globeRectangle);
+    overlayOptions.coverageRectangle = coverageRectangle;
+    overlayOptions.tilingScheme = CesiumGeometry::QuadtreeTilingScheme(
+        coverageRectangle,
+        overlay.rootTilesX(),
+        overlay.rootTilesY());
+  }
+
+  CesiumForUnity::CesiumRasterOverlay genericOverlay = overlay;
+  RasterOverlayOptions options =
+      CesiumRasterOverlayUtility::GetOverlayOptions(genericOverlay);
+
+  std::vector<CesiumAsync::IAssetAccessor::THeader> headers;
+  if (overlay.requestHeaders() != nullptr) {
+    headers.reserve(overlay.requestHeaders().Count());
+    for (int i = 0; i < overlay.requestHeaders().Count(); i++) {
+      // Skip blank headers that might come up while editing in the inspector.
+      if (overlay.requestHeaders()[i].Name().Length() == 0 ||
+          overlay.requestHeaders()[i].Value().Length() == 0) {
+        continue;
+      }
+      headers.emplace_back(
+          overlay.requestHeaders()[i].Name().ToStlString(),
+          overlay.requestHeaders()[i].Value().ToStlString());
+    }
+  }
+
+  this->_pOverlay = new UrlTemplateRasterOverlay(
+      overlay.materialKey().ToStlString(),
+      overlay.templateUrl().ToStlString(),
+      headers,
+      overlayOptions,
+      options);
+
+  pTileset->getOverlays().add(this->_pOverlay);
+}
+
+void CesiumUrlTemplateRasterOverlayImpl::RemoveFromTileset(
+    const ::DotNet::CesiumForUnity::CesiumUrlTemplateRasterOverlay& overlay,
+    const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset) {
+  if (this->_pOverlay == nullptr)
+    return;
+
+  Cesium3DTilesetImpl& tilesetImpl = tileset.NativeImplementation();
+  Tileset* pTileset = tilesetImpl.getTileset();
+  if (!pTileset)
+    return;
+
+  pTileset->getOverlays().remove(this->_pOverlay);
+  this->_pOverlay = nullptr;
+}
+
+} // namespace CesiumForUnityNative

--- a/native~/Runtime/src/CesiumUrlTemplateRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumUrlTemplateRasterOverlayImpl.h
@@ -23,12 +23,10 @@ public:
   ~CesiumUrlTemplateRasterOverlayImpl();
 
   void AddToTileset(
-      const ::DotNet::CesiumForUnity::CesiumUrlTemplateRasterOverlay&
-          overlay,
+      const ::DotNet::CesiumForUnity::CesiumUrlTemplateRasterOverlay& overlay,
       const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset);
   void RemoveFromTileset(
-      const ::DotNet::CesiumForUnity::CesiumUrlTemplateRasterOverlay&
-          overlay,
+      const ::DotNet::CesiumForUnity::CesiumUrlTemplateRasterOverlay& overlay,
       const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset);
 
 private:

--- a/native~/Runtime/src/CesiumUrlTemplateRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumUrlTemplateRasterOverlayImpl.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "CesiumImpl.h"
+
+#include <CesiumUtility/IntrusivePointer.h>
+
+namespace DotNet::CesiumForUnity {
+class Cesium3DTileset;
+class CesiumUrlTemplateRasterOverlay;
+} // namespace DotNet::CesiumForUnity
+
+namespace CesiumRasterOverlays {
+class UrlTemplateRasterOverlay;
+}
+
+namespace CesiumForUnityNative {
+
+class CesiumUrlTemplateRasterOverlayImpl
+    : public CesiumImpl<CesiumUrlTemplateRasterOverlayImpl> {
+public:
+  CesiumUrlTemplateRasterOverlayImpl(
+      const DotNet::CesiumForUnity::CesiumUrlTemplateRasterOverlay& overlay);
+  ~CesiumUrlTemplateRasterOverlayImpl();
+
+  void AddToTileset(
+      const ::DotNet::CesiumForUnity::CesiumUrlTemplateRasterOverlay&
+          overlay,
+      const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset);
+  void RemoveFromTileset(
+      const ::DotNet::CesiumForUnity::CesiumUrlTemplateRasterOverlay&
+          overlay,
+      const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset);
+
+private:
+  CesiumUtility::IntrusivePointer<
+      CesiumRasterOverlays::UrlTemplateRasterOverlay>
+      _pOverlay;
+};
+
+} // namespace CesiumForUnityNative


### PR DESCRIPTION
This PR adds support for the UrlTemplateRasterOverlay already added to Cesium Native and Cesium for Unreal. It allows URL templates like `https://tile.openstreetmap.org/{z}/{x}/{reverseY}.png` to be used as raster overlays. 