### PR TITLE
Catch exceptions in `UnityPrepareRendererResources::free`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug where credits would not display in the Game tab after entering Play Mode.
+- Improved stability during AppDomain reloads by catching exceptions thrown while freeing tiles.
 
 ## v1.15.5 - 2025-04-01
 


### PR DESCRIPTION
I noticed while testing #567 that Unity is a bit crashy when reloading AppDomains, which happens every time we enter or exit Play mode. This has always been an issue (see #561) but I think it has gotten worse with the multiple viewports changes. I don't think there is anything wrong with the multiple viewports feature itself, it just changes the timing of object destruction slightly.

As always, a "good" solution is elusive. But this PR improves the situation by adding a pokemon exception handler to `UnityPrepareRendererResources::free`. This function is on the critical path of AppDomain reloads, and oftens triggers exceptions when the managed world, now in a new AppDomain, is different from the one that the native objects from the previous AppDomain expect. By catching and ignoring these exceptions locally, rather than allowing them to propagate, we grealy reduce the chances of cascading failures.

I saw much improved stability when entering and exiting Play mode after making these changes.
