### PR TITLE
Editor: Skip CesiumIonSession.Tick() when Unity is offline

### DIFF
--- a/Editor/CesiumEditorUtility.cs
+++ b/Editor/CesiumEditorUtility.cs
@@ -21,6 +21,8 @@ namespace CesiumForUnity
 
         static void UpdateIonSession()
         {
+            if (Application.internetReachability == NetworkReachability.NotReachable)
+                return;
             try
             {
                 CesiumIonServerManager.instance.currentSession.Tick();


### PR DESCRIPTION
Problem
-------
If the Unity Editor launches without an Internet connection, CesiumIonServerManager.instance.currentSession.Tick() throws every frame because the DNS lookup for https://api.cesium.com fails.   The result is an endless stream of red-error messages:

    Exception: Request for `https://api.cesium.com/appData` failed:
    Cannot resolve destination host
    Exception: Failed to obtain _appData, can't resume connection

The spam clutters the Console and can even interrupt later domain reloads.

Change
------
Added a single guard clause at the top of
Editor/CesiumEditorUtility.UpdateIonSession():

    if (Application.internetReachability == NetworkReachability.NotReachable)
        return;

When Unity reports that the machine is offline the function now returns immediately, so the session is ticked again only after connectivity is restored.