### PR TITLE
576 triangle fan indexing is wrong

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## ? - ?
+
+##### Additions :tada:
+
+- Added support for `TRIANGLE_FAN` primitives in tile meshes.
+
 ## v1.16.1 - 2025-06-02
 
 This release updates [cesium-native](https://github.com/CesiumGS/cesium-native) from v0.47.0 to v0.48.0. See the [changelog](https://github.com/CesiumGS/cesium-native/blob/main/CHANGES.md) for a complete list of changes in cesium-native.

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -392,12 +392,6 @@ void loadPrimitive(
           GetUnsafeBufferPointerWithoutChecks(dest));
 
   switch (primitive.mode) {
-  case MeshPrimitive::Mode::TRIANGLES:
-  case MeshPrimitive::Mode::POINTS:
-    for (int64_t i = 0; i < indicesView.size(); ++i) {
-      indices[i] = indicesView[i];
-    }
-    break;
   case MeshPrimitive::Mode::TRIANGLE_STRIP:
     for (int64_t i = 0; i < indicesView.size() - 2; ++i) {
       if (i % 2) {
@@ -412,11 +406,17 @@ void loadPrimitive(
     }
     break;
   case MeshPrimitive::Mode::TRIANGLE_FAN:
-  default:
-    for (int64_t i = 2; i < indicesView.size(); ++i) {
+    for (int64_t i = 0; i < indicesView.size()-2; ++i) {
       indices[3 * i] = indicesView[0];
-      indices[3 * i + 1] = indicesView[i - 1];
-      indices[3 * i + 2] = indicesView[i];
+      indices[3 * i + 1] = indicesView[i + 1];
+      indices[3 * i + 2] = indicesView[i + 2];
+    }
+    break;
+  case MeshPrimitive::Mode::TRIANGLES:
+  case MeshPrimitive::Mode::POINTS:
+  default:
+    for (int64_t i = 0; i < indicesView.size(); ++i) {
+      indices[i] = indicesView[i];
     }
     break;
   }


### PR DESCRIPTION
## Description

[Port of fix for Unreal](https://github.com/CesiumGS/cesium-unreal/pull/1675) . 
This PR adds support for `TRIANGLE_FAN` primitives.

## Author checklist

- [X] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [x] I have done a full self-review of my code.
- [X] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- ~[ ] I have added or updated unit tests to ensure consistent code coverage as necessary.~
- ~[ ] I have updated the documentation as necessary.~

## Testing plan

Test that this tileset loads (best viewed under a "True Origin" georeference): [MeshPrimitiveModes.zip](https://github.com/user-attachments/files/20353260/MeshPrimitiveModes.zip).

There should be a row of three hexagons.
![image](https://github.com/user-attachments/assets/0bfe6594-b2c8-4bcf-8a43-360b49ee98da)