### PR TITLE
279 setting the scale of a cesium3dtileset to zero causes editor crash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed broken support for `TRIANGLE_FAN` primitives in tile meshes.
+- Fixed editor crash when any 3D Tile scale component was set to zero. 
 
 ## v1.16.1 - 2025-06-02
 

--- a/native~/Runtime/src/CameraManager.cpp
+++ b/native~/Runtime/src/CameraManager.cpp
@@ -150,7 +150,6 @@ CameraManager::getAllCameras(
       0.0 == unityWorldToTileset[2].z)
     return {};
 
-
   CesiumGeoreference georeferenceComponent =
       tileset.gameObject().GetComponentInParent<CesiumGeoreference>();
   if (georeferenceComponent != nullptr) {

--- a/native~/Runtime/src/CameraManager.cpp
+++ b/native~/Runtime/src/CameraManager.cpp
@@ -121,12 +121,6 @@ void addActiveSceneCameraInEditor(
     SceneView lastActiveEditorView = SceneView::lastActiveSceneView();
     if (lastActiveEditorView != nullptr) {
       Camera editorCamera = lastActiveEditorView.camera();
-      // check for invalid scale
-      if (0.0 == unityWorldToTileset[0].x ||
-          0.0 == unityWorldToTileset[1].y ||
-          0.0 == unityWorldToTileset[2].z)
-        return;
-
       if (editorCamera != nullptr) {
         result.emplace_back(unityCameraToViewState(
           georeferenceComponent,

--- a/native~/Runtime/src/CameraManager.cpp
+++ b/native~/Runtime/src/CameraManager.cpp
@@ -121,12 +121,18 @@ void addActiveSceneCameraInEditor(
     SceneView lastActiveEditorView = SceneView::lastActiveSceneView();
     if (lastActiveEditorView != nullptr) {
       Camera editorCamera = lastActiveEditorView.camera();
+      // check for invalid scale
+      if (0.0 == unityWorldToTileset[0].x ||
+          0.0 == unityWorldToTileset[1].y ||
+          0.0 == unityWorldToTileset[2].z)
+        return;
+
       if (editorCamera != nullptr) {
         result.emplace_back(unityCameraToViewState(
-            georeferenceComponent,
-            pCoordinateSystem,
-            unityWorldToTileset,
-            editorCamera));
+          georeferenceComponent,
+          pCoordinateSystem,
+          unityWorldToTileset,
+          editorCamera));
       }
     }
   }
@@ -143,6 +149,13 @@ CameraManager::getAllCameras(
 
   glm::dmat4 unityWorldToTileset =
       UnityTransforms::fromUnity(tileset.transform().worldToLocalMatrix());
+
+  // check for invalid scale
+  if (0.0 == unityWorldToTileset[0].x ||
+      0.0 == unityWorldToTileset[1].y ||
+      0.0 == unityWorldToTileset[2].z)
+    return {};
+
 
   CesiumGeoreference georeferenceComponent =
       tileset.gameObject().GetComponentInParent<CesiumGeoreference>();


### PR DESCRIPTION
## Description

Fix for editor crash when setting any component of a 3d TileSet's transform.scale property to zero. 

## Author checklist

- [x] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [x] I have done a full self-review of my code.
- [X] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- ~[ ] I have added or updated unit tests to ensure consistent code coverage as necessary.~
- ~[ ] I have updated the documentation as necessary.~

## Testing plan

Open any of the Cesium for Unity Samples scenes. Select any Cesium GameObject (CesiumGeoreference or any 3D Tileset), and set any component of the Transform.Scale Vector3 to zero. Observe that the editor does not crash. 