### PR TITLE
Implement the Cesium ion geocoder

### DIFF
--- a/Runtime/CesiumIonGeocoder.cs
+++ b/Runtime/CesiumIonGeocoder.cs
@@ -1,0 +1,112 @@
+using Reinterop;
+using System.Collections;
+using System.Threading.Tasks;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace CesiumForUnity
+{
+    /**
+     * @brief The supported types of requests to geocoding API.
+     */
+    public enum CesiumIonGeocoderRequestType
+    {
+        /**
+         * @brief Perform a full search from a complete query.
+         */
+        Search,
+
+        /**
+         * @brief Perform a quick search based on partial input, such as while a user
+         * is typing.
+         * The search results may be less accurate or exhaustive than using {@link GeocoderRequestType::Search}.
+         */
+        Autocomplete
+    }
+
+    /**
+     * @brief The supported providers that can be accessed through ion's geocoder
+     * API.
+     */
+    public enum CesiumIonGeocoderProviderType
+    {
+        /**
+         * @brief Google geocoder, for use with Google data.
+         */
+        Google,
+
+        /**
+         * @brief Bing geocoder, for use with Bing data.
+         */
+        Bing,
+
+        /**
+         * @brief Use the default geocoder as set on the server. Used when neither
+         * Bing or Google data is used.
+         */
+        Default
+    };
+
+    public class CesiumIonGeocoderFeature
+    {
+        /**
+         * @brief The user-friendly display name of this feature.
+         */
+        public string displayName;
+
+        /**
+         * @brief The Longitude-Latitude-Height coordinates representing this feature.
+         *
+         * If the geocoder service returned a bounding box for this result, this will
+         * return the bounding box. If the geocoder service returned a coordinate for
+         * this result, this will return a zero-width rectangle at that coordinate.
+         */
+        public double3 positionLlh;
+    }
+
+
+    /**
+     * @brief Attribution information for a query to a geocoder service.
+     */
+    public class CesiumIonGeocoderAttribution
+    {
+        /**
+         * @brief An HTML string containing the necessary attribution information.
+         */
+        public string html;
+
+        /**
+         * @brief If true, the credit should be visible in the main credit container.
+         * Otherwise, it can appear in a popover.
+         */
+        public bool showOnScreen;
+    };
+
+    /**
+     * @brief The result of making a request to a geocoder service.
+     */
+    public class CesiumIonGeocoderResult
+    {
+        /**
+         * @brief Any necessary attributions for this geocoder result.
+         */
+        public CesiumIonGeocoderAttribution[] attributions;
+
+        /**
+         * @brief The features obtained from this geocoder service, if any.
+         */
+        public CesiumIonGeocoderFeature[] features;
+    };
+
+    [ReinteropNativeImplementation("CesiumForUnityNative::CesiumIonGeocoderImpl", "CesiumIonGeocoderImpl.h")]
+    public partial class CesiumIonGeocoder
+    {
+        public partial Task<CesiumIonGeocoderResult> Geocode(
+            CesiumIonServer ionServer,
+            string ionToken,
+            CesiumIonGeocoderProviderType providerType,
+            CesiumIonGeocoderRequestType requestType,
+            string query
+       );
+    }
+}

--- a/Runtime/CesiumIonGeocoder.cs.meta
+++ b/Runtime/CesiumIonGeocoder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 237a3186b870725408ec532c08216bf4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -943,6 +943,23 @@ namespace CesiumForUnity
             TestReinterop.ThrowAnException();
             System.Exception exception = null;
             var message = exception.Message;
+
+            CesiumIonGeocoder geocoder = new CesiumIonGeocoder();
+            CesiumIonGeocoderProviderType providerType = CesiumIonGeocoderProviderType.Google;
+            CesiumIonGeocoderRequestType requestType = CesiumIonGeocoderRequestType.Autocomplete;
+            TaskCompletionSource<CesiumIonGeocoderResult> geocoderPromise = new TaskCompletionSource<CesiumIonGeocoderResult>();
+            geocoderPromise.SetException(new Exception("message"));
+            CesiumIonGeocoderResult geocoderResult = new CesiumIonGeocoderResult();
+            geocoderResult.features = new CesiumIonGeocoderFeature[1];
+            CesiumIonGeocoderFeature geocoderFeature = new CesiumIonGeocoderFeature();
+            geocoderResult.features[0].displayName = "";
+            geocoderResult.features[0].positionLlh = new double3(1, 2, 3);
+            geocoderResult.attributions = new CesiumIonGeocoderAttribution[1];
+            CesiumIonGeocoderAttribution attribution = new CesiumIonGeocoderAttribution();
+            attribution.html = "";
+            attribution.showOnScreen = true;
+            geocoderPromise.SetResult(geocoderResult);
+            Task<CesiumIonGeocoderResult> geocoderTask = geocoderPromise.Task;
         }
     }
 }

--- a/Runtime/Resources/CesiumDefaultTilesetMaterial.mat
+++ b/Runtime/Resources/CesiumDefaultTilesetMaterial.mat
@@ -23,13 +23,15 @@ Material:
   m_Name: CesiumDefaultTilesetMaterial
   m_Shader: {fileID: -6465566751694194690, guid: 407c0cff68611ac46a65eec87a5203f5,
     type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - _ALPHATEST_ON
   - _BUILTIN_ALPHATEST_ON
   - _BUILTIN_AlphaClip
+  m_InvalidKeywords:
   - _DISABLE_SSR_TRANSPARENT
   - _DOUBLESIDED_ON
-  m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 1
@@ -43,6 +45,7 @@ Material:
   - TransparentBackface
   - RayTracingPrepass
   - MOTIONVECTORS
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -101,7 +104,7 @@ Material:
     - _AlphaCutoffEnable: 1
     - _AlphaDstBlend: 0
     - _AlphaSrcBlend: 1
-    - _AlphaToMask: 0
+    - _AlphaToMask: 1
     - _AlphaToMaskInspectorValue: 0
     - _BUILTIN_AlphaClip: 1
     - _BUILTIN_Blend: 0
@@ -116,6 +119,7 @@ Material:
     - _BUILTIN_ZWriteControl: 0
     - _Blend: 0
     - _BlendMode: 0
+    - _BlendModePreserveSpecular: 0
     - _CastShadows: 1
     - _ConservativeDepthOffsetEnable: 0
     - _Cull: 0
@@ -222,4 +226,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  version: 5
+  version: 7

--- a/Runtime/Resources/CesiumDefaultTilesetMaterial.mat
+++ b/Runtime/Resources/CesiumDefaultTilesetMaterial.mat
@@ -23,15 +23,13 @@ Material:
   m_Name: CesiumDefaultTilesetMaterial
   m_Shader: {fileID: -6465566751694194690, guid: 407c0cff68611ac46a65eec87a5203f5,
     type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - _ALPHATEST_ON
   - _BUILTIN_ALPHATEST_ON
   - _BUILTIN_AlphaClip
-  m_InvalidKeywords:
   - _DISABLE_SSR_TRANSPARENT
   - _DOUBLESIDED_ON
+  m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 1
@@ -45,7 +43,6 @@ Material:
   - TransparentBackface
   - RayTracingPrepass
   - MOTIONVECTORS
-  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -104,7 +101,7 @@ Material:
     - _AlphaCutoffEnable: 1
     - _AlphaDstBlend: 0
     - _AlphaSrcBlend: 1
-    - _AlphaToMask: 1
+    - _AlphaToMask: 0
     - _AlphaToMaskInspectorValue: 0
     - _BUILTIN_AlphaClip: 1
     - _BUILTIN_Blend: 0
@@ -119,7 +116,6 @@ Material:
     - _BUILTIN_ZWriteControl: 0
     - _Blend: 0
     - _BlendMode: 0
-    - _BlendModePreserveSpecular: 0
     - _CastShadows: 1
     - _ConservativeDepthOffsetEnable: 0
     - _Cull: 0
@@ -226,4 +222,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  version: 7
+  version: 5

--- a/native~/Runtime/src/CesiumIonGeocoderImpl.cpp
+++ b/native~/Runtime/src/CesiumIonGeocoderImpl.cpp
@@ -1,0 +1,153 @@
+#include "CesiumIonGeocoderImpl.h"
+
+#include "UnityTilesetExternals.h"
+
+#include <CesiumIonClient/Connection.h>
+#include <CesiumIonClient/Geocoder.h>
+
+#include <DotNet/CesiumForUnity/CesiumIonGeocoder.h>
+#include <DotNet/CesiumForUnity/CesiumIonGeocoderAttribution.h>
+#include <DotNet/CesiumForUnity/CesiumIonGeocoderFeature.h>
+#include <DotNet/CesiumForUnity/CesiumIonGeocoderProviderType.h>
+#include <DotNet/CesiumForUnity/CesiumIonGeocoderRequestType.h>
+#include <DotNet/CesiumForUnity/CesiumIonGeocoderResult.h>
+#include <DotNet/CesiumForUnity/CesiumIonServer.h>
+#include <DotNet/System/Array1.h>
+#include <DotNet/System/Exception.h>
+#include <DotNet/System/Threading/Tasks/Task1.h>
+#include <DotNet/System/Threading/Tasks/TaskCompletionSource1.h>
+#include <DotNet/Unity/Mathematics/double3.h>
+
+namespace {
+CesiumIonClient::GeocoderProviderType geocoderProviderTypeEnumToNative(
+    DotNet::CesiumForUnity::CesiumIonGeocoderProviderType providerType) {
+  switch (providerType) {
+  case DotNet::CesiumForUnity::CesiumIonGeocoderProviderType::Bing:
+    return CesiumIonClient::GeocoderProviderType::Bing;
+  case DotNet::CesiumForUnity::CesiumIonGeocoderProviderType::Google:
+    return CesiumIonClient::GeocoderProviderType::Google;
+  case DotNet::CesiumForUnity::CesiumIonGeocoderProviderType::Default:
+    return CesiumIonClient::GeocoderProviderType::Default;
+  }
+}
+
+CesiumIonClient::GeocoderRequestType geocoderRequestTypeEnumToNative(
+    DotNet::CesiumForUnity::CesiumIonGeocoderRequestType requestType) {
+  switch (requestType) {
+  case DotNet::CesiumForUnity::CesiumIonGeocoderRequestType::Autocomplete:
+    return CesiumIonClient::GeocoderRequestType::Autocomplete;
+  case DotNet::CesiumForUnity::CesiumIonGeocoderRequestType::Search:
+    return CesiumIonClient::GeocoderRequestType::Search;
+  }
+}
+} // namespace
+
+namespace CesiumForUnityNative {
+CesiumIonGeocoderImpl::CesiumIonGeocoderImpl(
+    const DotNet::CesiumForUnity::CesiumIonGeocoder& geocoder)
+    : _pConnection(nullptr) {}
+
+DotNet::System::Threading::Tasks::Task1<
+    DotNet::CesiumForUnity::CesiumIonGeocoderResult>
+CesiumIonGeocoderImpl::Geocode(
+    const DotNet::CesiumForUnity::CesiumIonGeocoder& /*geocoder*/,
+    const DotNet::CesiumForUnity::CesiumIonServer& server,
+    DotNet::System::String ionToken,
+    DotNet::CesiumForUnity::CesiumIonGeocoderProviderType providerType,
+    DotNet::CesiumForUnity::CesiumIonGeocoderRequestType requestType,
+    DotNet::System::String query) {
+  DotNet::System::Threading::Tasks::TaskCompletionSource1<
+      DotNet::CesiumForUnity::CesiumIonGeocoderResult>
+      promise{};
+
+  getConnection(server, ionToken)
+      .thenImmediately(
+          [providerType, requestType, query](
+              std::shared_ptr<CesiumIonClient::Connection>&& pConnection) {
+            return pConnection->geocode(
+                geocoderProviderTypeEnumToNative(providerType),
+                geocoderRequestTypeEnumToNative(requestType),
+                query.ToStlString());
+          })
+      .thenImmediately([&promise](CesiumIonClient::Response<
+                                  CesiumIonClient::GeocoderResult>&& response) {
+        if (!response.errorCode.empty()) {
+          promise.SetException(DotNet::System::Exception(DotNet::System::String(
+              "Ion error code received: " + response.errorCode +
+              ", message: " + response.errorMessage)));
+        } else {
+          DotNet::System::Array1<
+              DotNet::CesiumForUnity::CesiumIonGeocoderAttribution>
+              attributions(response.value->attributions.size());
+          for (size_t i = 0; i < response.value->attributions.size(); i++) {
+            DotNet::CesiumForUnity::CesiumIonGeocoderAttribution attribution;
+            attribution.html(
+                DotNet::System::String(response.value->attributions[i].html));
+            attribution.showOnScreen(
+                response.value->attributions[i].showOnScreen);
+            attributions.Item((int32_t)i, attribution);
+          }
+
+          DotNet::System::Array1<
+              DotNet::CesiumForUnity::CesiumIonGeocoderFeature>
+              features(response.value->features.size());
+          for (size_t i = 0; i < response.value->features.size(); i++) {
+            DotNet::CesiumForUnity::CesiumIonGeocoderFeature feature;
+            feature.displayName(DotNet::System::String(
+                response.value->features[i].displayName));
+            CesiumGeospatial::Cartographic point =
+                response.value->features[i].getCartographic();
+            feature.positionLlh(DotNet::Unity::Mathematics::double3(
+                point.longitude,
+                point.latitude,
+                point.height));
+            features.Item((int32_t)i, feature);
+          }
+
+          DotNet::CesiumForUnity::CesiumIonGeocoderResult geocoderResult;
+          geocoderResult.attributions(attributions);
+          geocoderResult.features(features);
+          promise.SetResult(geocoderResult);
+        }
+      });
+
+  return promise.Task();
+}
+
+CesiumAsync::Future<std::shared_ptr<CesiumIonClient::Connection>>
+CesiumIonGeocoderImpl::getConnection(
+    const DotNet::CesiumForUnity::CesiumIonServer& server,
+    DotNet::System::String ionToken) {
+  if (this->_pConnection != nullptr) {
+    return getAsyncSystem().createResolvedFuture(
+        std::shared_ptr(this->_pConnection));
+  }
+
+  return CesiumIonClient::Connection::appData(
+             getAsyncSystem(),
+             getAssetAccessor(),
+             server.apiUrl().ToStlString())
+      .thenInMainThread(
+          [ionToken, server, this](
+              CesiumIonClient::Response<CesiumIonClient::ApplicationData>&&
+                  response) {
+            if (!response.value) {
+              return std::shared_ptr<CesiumIonClient::Connection>(nullptr);
+            }
+
+            if (this->_pConnection != nullptr) {
+              // Another query has already created a connection before this one
+              // returned.
+              return this->_pConnection;
+            }
+
+            this->_pConnection = std::make_shared<CesiumIonClient::Connection>(
+                getAsyncSystem(),
+                getAssetAccessor(),
+                ionToken.ToStlString(),
+                *response.value,
+                server.apiUrl().ToStlString());
+            return this->_pConnection;
+          });
+}
+} // namespace CesiumForUnityNative

--- a/native~/Runtime/src/CesiumIonGeocoderImpl.h
+++ b/native~/Runtime/src/CesiumIonGeocoderImpl.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "CesiumImpl.h"
+
+#include <CesiumAsync/Future.h>
+
+#include <DotNet/System/String.h>
+#include <DotNet/System/Threading/Tasks/Task1.h>
+
+#include <memory>
+
+namespace DotNet::CesiumForUnity {
+class CesiumIonGeocoder;
+class CesiumIonGeocoderResult;
+enum class CesiumIonGeocoderRequestType;
+enum class CesiumIonGeocoderProviderType;
+class CesiumIonServer;
+
+} // namespace DotNet::CesiumForUnity
+
+namespace CesiumIonClient {
+class Connection;
+}
+
+namespace CesiumForUnityNative {
+
+class CesiumIonGeocoderImpl : public CesiumImpl<CesiumIonGeocoderImpl> {
+public:
+  CesiumIonGeocoderImpl(
+      const DotNet::CesiumForUnity::CesiumIonGeocoder& geocoder);
+
+  DotNet::System::Threading::Tasks::Task1<
+      DotNet::CesiumForUnity::CesiumIonGeocoderResult>
+  Geocode(
+      const DotNet::CesiumForUnity::CesiumIonGeocoder& geocoder,
+      const DotNet::CesiumForUnity::CesiumIonServer& server,
+      DotNet::System::String ionToken,
+      DotNet::CesiumForUnity::CesiumIonGeocoderProviderType providerType,
+      DotNet::CesiumForUnity::CesiumIonGeocoderRequestType requestType,
+      DotNet::System::String query);
+
+private:
+  CesiumAsync::Future<std::shared_ptr<CesiumIonClient::Connection>>
+  getConnection(
+      const DotNet::CesiumForUnity::CesiumIonServer& server,
+      DotNet::System::String ionToken);
+
+  std::shared_ptr<CesiumIonClient::Connection> _pConnection;
+};
+
+} // namespace CesiumForUnityNative

--- a/native~/Runtime/src/CesiumIonGeocoderImpl.h
+++ b/native~/Runtime/src/CesiumIonGeocoderImpl.h
@@ -7,6 +7,7 @@
 #include <DotNet/System/String.h>
 #include <DotNet/System/Threading/Tasks/Task1.h>
 
+#include <mutex>
 #include <memory>
 
 namespace DotNet::CesiumForUnity {
@@ -42,10 +43,12 @@ public:
 private:
   CesiumAsync::Future<std::shared_ptr<CesiumIonClient::Connection>>
   getConnection(
+      const CesiumAsync::AsyncSystem& asyncSystem,
       const DotNet::CesiumForUnity::CesiumIonServer& server,
       DotNet::System::String ionToken);
 
   std::shared_ptr<CesiumIonClient::Connection> _pConnection;
+  std::mutex _connectionMutex;
 };
 
 } // namespace CesiumForUnityNative


### PR DESCRIPTION
This PR implements the Cesium ion geocoder in Unity. The geocoder can be used like so:
```csharp
 void Start()
 {
     var geocoder = new CesiumIonGeocoder();
     StartCoroutine(GeocodeCoroutine(geocoder));
 }

 IEnumerator GeocodeCoroutine(CesiumIonGeocoder geocoder)
 {
     var task = geocoder.Geocode(
          CesiumIonServer.defaultServer, 
          "<token here>", 
          CesiumIonGeocoderProviderType.Google, 
          CesiumIonGeocoderRequestType.Search, 
          "<search query here>");
     yield return new WaitForTask(task);
     Debug.Log(task.Result.features);
 }
```

This is in a draft PR for the moment as it is not fully working yet. Some things also left to work out:
- error handling when creating a connection
- returning bounding boxes
- using default token when no token is provided to the method