### PR TITLE
Updated Developer Setup guide

### DIFF
--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -53,7 +53,8 @@ This should be repeated if you modify Reinterop, or if you pull new changes that
 
 For more details, see the [Reinterop README](../Reinterop~/README.md).
 
-A common mistake is to open Unity before doing this step, which will cause Unity to delete `Reinterop.dll.meta` file because the `Reinterop.dll` file does not yet exist. Then, even after you publish `Reinterop.dll`, the `Reinterop.dll.meta` that Unity creates will be missing important information, and you'll get errors when Unity attemps to compile Cesium for Unity. If this happens to you, executing `git restore Reinterop.dll.meta` should fix it.
+> [!IMPORTANT] 
+> A common mistake is to open Unity before doing this step, which will cause Unity to delete `Reinterop.dll.meta` file because the `Reinterop.dll` file does not yet exist. Then, even after you publish `Reinterop.dll`, the `Reinterop.dll.meta` that Unity creates will be missing important information, and you'll get errors when Unity attemps to compile Cesium for Unity. If this happens to you, executing `git restore Reinterop.dll.meta` should fix it.
 
 ## Build for the Editor
 

--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -100,7 +100,7 @@ and `./Editor/ConfigureReinterop.cs` .
 > echo "" >> ./Runtime/ConfigureReinterop.cs
 > echo "" >> ./Editor/ConfigureReinterop.cs
 > ```
-> (Alternatively, one may add a blank line or other minor change to both `ConfigureReinterop.cs` files in any text editor.)
+> (Alternatively, one may open both `ConfigureReinterop.cs` files from within Unity any text editor, make a whitespace or other minor change, and save the files.)
 > Once those changes have been saved, go back to the Unity editor. It should detect the file changes and cause Reinterop to generate the required native source files. 
 
 ## Building and Running Games

--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -89,9 +89,7 @@ cmake --build build -j14 --target install --config RelWithDebInfo
 
 > [!NOTE]
 > If you receive compilation errors such as, 
-> ```
-> IonTokenTroubleshootingWindowImpl.h:3:10: fatal error: 'DotNet/System/String.h' file not found
-> ```
+> `IonTokenTroubleshootingWindowImpl.h:3:10: fatal error: 'DotNet/System/String.h' file not found`
 > Verify that Reinterop has generated the required `.cpp` and `.h` source files. These should be located in `com.cesium.unity/native~/Runtime/generated-Editor/` and `com.cesium.unity/native~/Editor/generated-Editor`. 
 > If those directories are not present, you may force Reinterop to run by adding a comment or other minor change to `./Runtime/ConfigureReinterop.cs`
 and `./Editor/ConfigureReinterop.cs` . 

--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -69,7 +69,7 @@ NotImplementedException: The native implementation is missing so OnValidate cann
 
 This is because the C++ code has not yet been compiled. 
 
-To compile the C++ code for use in the Editor, run:
+To compile the C++ code for use by the Editor, run:
 
 ```
 cd cesium-unity-samples/Packages/com.cesium.unity/native~
@@ -88,7 +88,11 @@ cmake --build build -j14 --target install --config RelWithDebInfo
 ```
 
 > [!NOTE]
-> If you receive compilation errors, verify that Reinterop has generated the `.cpp` and `.h` source files. These should be located in `com.cesium.unity/native~/Runtime/generated-Editor/` and `com.cesium.unity/native~/Editor/>generated-Editor/`. 
+> If you receive compilation errors such as, 
+> ```
+> IonTokenTroubleshootingWindowImpl.h:3:10: fatal error: 'DotNet/System/String.h' file not found
+> ```
+> Verify that Reinterop has generated the required `.cpp` and `.h` source files. These should be located in `com.cesium.unity/native~/Runtime/generated-Editor/` and `com.cesium.unity/native~/Editor/generated-Editor`. 
 > If those directories are not present, you may force Reinterop to run by adding a comment or other minor change to `./Runtime/ConfigureReinterop.cs`
 and `./Editor/ConfigureReinterop.cs` . 
 > ```
@@ -96,7 +100,7 @@ and `./Editor/ConfigureReinterop.cs` .
 > echo "" >> ./Runtime/ConfigureReinterop.cs
 > echo "" >> ./Editor/ConfigureReinterop.cs
 > ```
-> Alternatively, one may add a blank line or other minor change to both `ConfigureReinterop.cs` files in any text editor. 
+> (Alternatively, one may add a blank line or other minor change to both `ConfigureReinterop.cs` files in any text editor.)
 > Once those changes have been saved, go back to the Unity editor. It should detect the file changes and cause Reinterop to generate the required native source files. 
 
 Once this build/install completes, Cesium for Unity should work the next time Unity loads Cesium for Unity. You can get it to do so by either restarting the Editor, or by making a small change to any Cesium for Unity script (.cs) file in `Packages/com.cesium.unity/Runtime`.

--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -92,7 +92,7 @@ Once this build/install completes, Cesium for Unity should work the next time Un
 > ```
 > IonTokenTroubleshootingWindowImpl.h:3:10: fatal error: 'DotNet/System/String.h' file not found
 > ```
-> Verify that Reinterop has generated the required `.cpp` and `.h` source files. These should be located in `com.cesium.unity/native~/Runtime/generated-Editor/` and `com.cesium.unity/native~/Editor/generated-Editor`. 
+> Verify that Reinterop has generated the required `.cpp` and `.h` source files. These should be located in `com.cesium.unity/native~/Runtime/generated-Editor/` and `com.cesium.unity/native~/Editor/generated-Editor/`. 
 > If those directories are not present, you may force Reinterop to run by adding a comment or other minor change to `./Runtime/ConfigureReinterop.cs`
 and `./Editor/ConfigureReinterop.cs` . 
 > ```

--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -66,7 +66,20 @@ DllNotFoundException: CesiumForUnityNative assembly:<unknown assembly> type:<unk
 NotImplementedException: The native implementation is missing so OnValidate cannot be invoked.
 ```
 
-This is because the C++ code has not yet been compiled. To compile the C++ code for use in the Editor, run:
+This is because the C++ code has not yet been compiled. 
+
+> [!NOTE]
+> Once this step is complete, verify that Reinterop has generated the `.cpp` and `.h` source files. These should be located in `/native~/Runtime/generated-Editor/` and `/native~/Editor/>generated-Editor/`. If those directories are not present, it may be necessary to force Reinterop to run. This can be done by adding a comment or other minor change to `./Runtime/ConfigureReinterop.cs`
+and `./Editor/ConfigureReinterop.cs` . 
+> ```
+> cd cesium-unity-samples/Packages/com.cesium.unity
+> echo "" >> ./Runtime/ConfigureReinterop.cs
+> echo "" >> ./Editor/ConfigureReinterop.cs
+> ```
+> Alternatively, one may simple add a blank line or other minor change to both `ConfigureReinterop.cs` files in any text editor. 
+> Once those changes have been saved, go back to the Unity editor to force it to re-run Reinterop. 
+
+To compile the C++ code for use in the Editor, run:
 
 ```
 cd cesium-unity-samples/Packages/com.cesium.unity/native~
@@ -83,6 +96,8 @@ cd cesium-unity-samples/Packages/com.cesium.unity/native~
 cmake -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build build -j14 --target install --config RelWithDebInfo
 ```
+
+
 
 Once this build/install completes, Cesium for Unity should work the next time Unity loads Cesium for Unity. You can get it to do so by either restarting the Editor, or by making a small change to any Cesium for Unity script (.cs) file in `Packages/com.cesium.unity/Runtime`.
 

--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -100,7 +100,7 @@ and `./Editor/ConfigureReinterop.cs` .
 > echo "" >> ./Runtime/ConfigureReinterop.cs
 > echo "" >> ./Editor/ConfigureReinterop.cs
 > ```
-> (Alternatively, one may open both `ConfigureReinterop.cs` files from within Unity any text editor, make a whitespace or other minor change, and save the files.)
+> (Alternatively, one may open both `ConfigureReinterop.cs` files from within Unity or any text editor, make a whitespace or other minor change, and save the files.)
 > Once those changes have been saved, go back to the Unity editor. It should detect the file changes and cause Reinterop to generate the required native source files. 
 
 ## Building and Running Games

--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -91,7 +91,9 @@ Once this build/install completes, Cesium for Unity should work the next time Un
 
 > [!NOTE]
 > If you receive compilation errors such as, 
-> ```IonTokenTroubleshootingWindowImpl.h:3:10: fatal error: 'DotNet/System/String.h' file not found```
+> ```
+> IonTokenTroubleshootingWindowImpl.h:3:10: fatal error: 'DotNet/System/String.h' file not found
+> ```
 > Verify that Reinterop has generated the required `.cpp` and `.h` source files. These should be located in `com.cesium.unity/native~/Runtime/generated-Editor/` and `com.cesium.unity/native~/Editor/generated-Editor`. 
 > If those directories are not present, you may force Reinterop to run by adding a comment or other minor change to `./Runtime/ConfigureReinterop.cs`
 and `./Editor/ConfigureReinterop.cs` . 

--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -67,9 +67,7 @@ DllNotFoundException: CesiumForUnityNative assembly:<unknown assembly> type:<unk
 NotImplementedException: The native implementation is missing so OnValidate cannot be invoked.
 ```
 
-This is because the C++ code has not yet been compiled. 
-
-To compile the C++ code for use by the Editor, run:
+This is because the C++ code has not yet been compiled. To compile the C++ code for use by the Editor, run:
 
 ```
 cd cesium-unity-samples/Packages/com.cesium.unity/native~

--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -87,6 +87,8 @@ cmake -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build build -j14 --target install --config RelWithDebInfo
 ```
 
+Once this build/install completes, Cesium for Unity should work the next time Unity loads Cesium for Unity. You can get it to do so by either restarting the Editor, or by making a small change to any Cesium for Unity script (.cs) file in `Packages/com.cesium.unity/Runtime`.
+
 > [!NOTE]
 > If you receive compilation errors such as, 
 > `IonTokenTroubleshootingWindowImpl.h:3:10: fatal error: 'DotNet/System/String.h' file not found`
@@ -100,8 +102,6 @@ and `./Editor/ConfigureReinterop.cs` .
 > ```
 > (Alternatively, one may add a blank line or other minor change to both `ConfigureReinterop.cs` files in any text editor.)
 > Once those changes have been saved, go back to the Unity editor. It should detect the file changes and cause Reinterop to generate the required native source files. 
-
-Once this build/install completes, Cesium for Unity should work the next time Unity loads Cesium for Unity. You can get it to do so by either restarting the Editor, or by making a small change to any Cesium for Unity script (.cs) file in `Packages/com.cesium.unity/Runtime`.
 
 ## Building and Running Games
 

--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -77,7 +77,7 @@ and `./Editor/ConfigureReinterop.cs` .
 > echo "" >> ./Editor/ConfigureReinterop.cs
 > ```
 > Alternatively, one may simple add a blank line or other minor change to both `ConfigureReinterop.cs` files in any text editor. 
-> Once those changes have been saved, go back to the Unity editor to force it to re-run Reinterop. 
+> Once those changes have been saved, go back to the Unity editor. It should automatically run Reinterop to generate the required native source files. 
 
 To compile the C++ code for use in the Editor, run:
 

--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -101,7 +101,7 @@ and `./Editor/ConfigureReinterop.cs` .
 > echo "" >> ./Editor/ConfigureReinterop.cs
 > ```
 > (Alternatively, one may open both `ConfigureReinterop.cs` files from within Unity or any text editor, make a whitespace or other minor change, and save the files.)
-> Once those changes have been saved, go back to the Unity editor. It should detect the file changes and cause Reinterop to generate the required native source files. 
+> Once those changes have been saved, go back to the Unity editor. It should detect the file changes and cause Reinterop to generate the required C++ source files. 
 
 ## Building and Running Games
 

--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -69,17 +69,6 @@ NotImplementedException: The native implementation is missing so OnValidate cann
 
 This is because the C++ code has not yet been compiled. 
 
-> [!NOTE]
-> Once this step is complete, verify that Reinterop has generated the `.cpp` and `.h` source files. These should be located in `/native~/Runtime/generated-Editor/` and `/native~/Editor/>generated-Editor/`. If those directories are not present, it may be necessary to force Reinterop to run. This can be done by adding a comment or other minor change to `./Runtime/ConfigureReinterop.cs`
-and `./Editor/ConfigureReinterop.cs` . 
-> ```
-> cd cesium-unity-samples/Packages/com.cesium.unity
-> echo "" >> ./Runtime/ConfigureReinterop.cs
-> echo "" >> ./Editor/ConfigureReinterop.cs
-> ```
-> Alternatively, one may simple add a blank line or other minor change to both `ConfigureReinterop.cs` files in any text editor. 
-> Once those changes have been saved, go back to the Unity editor. It should automatically run Reinterop to generate the required native source files. 
-
 To compile the C++ code for use in the Editor, run:
 
 ```
@@ -98,7 +87,17 @@ cmake -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build build -j14 --target install --config RelWithDebInfo
 ```
 
-
+> [!NOTE]
+> If you receive compilation errors, verify that Reinterop has generated the `.cpp` and `.h` source files. These should be located in `com.cesium.unity/native~/Runtime/generated-Editor/` and `com.cesium.unity/native~/Editor/>generated-Editor/`. 
+> If those directories are not present, you may force Reinterop to run by adding a comment or other minor change to `./Runtime/ConfigureReinterop.cs`
+and `./Editor/ConfigureReinterop.cs` . 
+> ```
+> cd cesium-unity-samples/Packages/com.cesium.unity
+> echo "" >> ./Runtime/ConfigureReinterop.cs
+> echo "" >> ./Editor/ConfigureReinterop.cs
+> ```
+> Alternatively, one may add a blank line or other minor change to both `ConfigureReinterop.cs` files in any text editor. 
+> Once those changes have been saved, go back to the Unity editor. It should detect the file changes and cause Reinterop to generate the required native source files. 
 
 Once this build/install completes, Cesium for Unity should work the next time Unity loads Cesium for Unity. You can get it to do so by either restarting the Editor, or by making a small change to any Cesium for Unity script (.cs) file in `Packages/com.cesium.unity/Runtime`.
 

--- a/Documentation~/developer-setup.md
+++ b/Documentation~/developer-setup.md
@@ -91,7 +91,7 @@ Once this build/install completes, Cesium for Unity should work the next time Un
 
 > [!NOTE]
 > If you receive compilation errors such as, 
-> `IonTokenTroubleshootingWindowImpl.h:3:10: fatal error: 'DotNet/System/String.h' file not found`
+> ```IonTokenTroubleshootingWindowImpl.h:3:10: fatal error: 'DotNet/System/String.h' file not found```
 > Verify that Reinterop has generated the required `.cpp` and `.h` source files. These should be located in `com.cesium.unity/native~/Runtime/generated-Editor/` and `com.cesium.unity/native~/Editor/generated-Editor`. 
 > If those directories are not present, you may force Reinterop to run by adding a comment or other minor change to `./Runtime/ConfigureReinterop.cs`
 and `./Editor/ConfigureReinterop.cs` . 


### PR DESCRIPTION
This adds a note about modifying the `ConfigureReinterop.cs` files to force Unity to run Reinterop. 

On fresh clones of the package, Unity doesn't always run Reinterop. When that happens, it's necessary to modify `Editor/ConfigureReinterop.cs` and `Runtime/ConfigureReinterop.cs` so that Unity will detect a file change and then rebuild and run Reinterop. 