### PR TITLE
Add option to ignore KHR_unlit_material extension in glTF tilesets. 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## ? - ?
+
+##### Additions :tada:
+
+- Added option to ignore the `KHR_material_unlit` extension to force default lighting on tilesets. 
+
 ## v1.17.0 - 2025-08-01
 
 ##### Additions :tada:

--- a/Editor/Cesium3DTilesetEditor.cs
+++ b/Editor/Cesium3DTilesetEditor.cs
@@ -31,6 +31,7 @@ namespace CesiumForUnity
         private SerializedProperty _culledScreenSpaceError;
 
         private SerializedProperty _opaqueMaterial;
+        private SerializedProperty _ignoreKhrMaterialsUnlit;
         //private SerializedProperty _useLodTransitions;
         //private SerializedProperty _lodTransitionLength;
         private SerializedProperty _generateSmoothNormals;
@@ -83,6 +84,7 @@ namespace CesiumForUnity
             //    this.serializedObject.FindProperty("_lodTransitionLength");
             this._generateSmoothNormals =
                 this.serializedObject.FindProperty("_generateSmoothNormals");
+            this._ignoreKhrMaterialsUnlit = this.serializedObject.FindProperty("_ignoreKhrMaterialsUnlit");
 
             this._pointCloudShading = this.serializedObject.FindProperty("_pointCloudShading");
 
@@ -425,6 +427,19 @@ namespace CesiumForUnity
                 "normals requires duplicating vertices. This option allows the glTFs to be " +
                 "rendered with smooth normals instead when the original glTF is missing normals.");
             EditorGUILayout.PropertyField(this._generateSmoothNormals, generateSmoothNormalsContent);
+
+            var ignoreKhrMaterialsUnlit = new GUIContent(
+                "Ignore KHR_materials_unlit",
+                "Whether to ignore the KHR_materials_unlit extension on the glTF tiles in "+
+                "this tileset, if it exists, and instead render with standard lighting and "+
+                "shadows. This property will have no effect if the tileset does not have any "+
+                "tiles that use this extension. "+
+                "\n\n"+
+               "The KHR_materials_unlit extension is often applied to photogrammetry "+
+                "tilesets because lighting and shadows are already baked into their "+
+                "textures. "
+            );
+            EditorGUILayout.PropertyField(this._ignoreKhrMaterialsUnlit, ignoreKhrMaterialsUnlit);
         }
 
         private void DrawPointCloudShadingProperties()

--- a/Runtime/Cesium3DTileset.cs
+++ b/Runtime/Cesium3DTileset.cs
@@ -590,6 +590,33 @@ namespace CesiumForUnity
         }
 
         [SerializeField]
+        private bool _ignoreKhrMaterialsUnlit = false;
+
+        /// <summary>
+        /// Whether to ignore the KHR_materials_unlit extension on the glTF tiles in
+        /// this tileset, if it exists
+        /// </summary>
+        /// <remarks>
+        /// Whether to ignore the KHR_materials_unlit extension on the glTF tiles in
+        /// this tileset, if it exists, and instead render with standard lighting and
+        /// shadows. This property will have no effect if the tileset does not have any
+        /// tiles that use this extension.
+        /// 
+        /// The KHR_materials_unlit extension is often applied to photogrammetry
+        /// tilesets because lighting and shadows are already baked into their
+        /// textures.
+        /// </remarks>
+        public bool ignoreKhrMaterialsUnlit
+        {
+            get => this._ignoreKhrMaterialsUnlit;
+            set
+            {
+                this._ignoreKhrMaterialsUnlit = value;
+                this.RecreateTileset();
+            }
+        }
+
+        [SerializeField]
         private CesiumPointCloudShading _pointCloudShading;
 
         /// <summary>

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -279,6 +279,7 @@ namespace CesiumForUnity
             //tileset.useLodTransitions = tileset.useLodTransitions;
             //tileset.lodTransitionLength = tileset.lodTransitionLength;
             tileset.generateSmoothNormals = tileset.generateSmoothNormals;
+            tileset.ignoreKhrMaterialsUnlit = tileset.ignoreKhrMaterialsUnlit;
             tileset.createPhysicsMeshes = tileset.createPhysicsMeshes;
             tileset.suspendUpdate = tileset.suspendUpdate;
             tileset.previousSuspendUpdate = tileset.previousSuspendUpdate;
@@ -948,3 +949,4 @@ namespace CesiumForUnity
         }
     }
 }
+

--- a/native~/Runtime/src/Cesium3DTilesetImpl.cpp
+++ b/native~/Runtime/src/Cesium3DTilesetImpl.cpp
@@ -566,6 +566,7 @@ void Cesium3DTilesetImpl::DestroyTileset(
 void Cesium3DTilesetImpl::LoadTileset(
     const DotNet::CesiumForUnity::Cesium3DTileset& tileset) {
   TilesetOptions options{};
+  options.rendererOptions = std::make_any<CreateModelOptions>(tileset);
   options.maximumScreenSpaceError = tileset.maximumScreenSpaceError();
   options.preloadAncestors = tileset.preloadAncestors();
   options.preloadSiblings = tileset.preloadSiblings();

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -314,6 +314,7 @@ template <typename TIndex, class TIndexAccessor>
 void loadPrimitive(
     UnityEngine::MeshData meshData,
     CesiumPrimitiveInfo& primitiveInfo,
+    const CreateModelOptions& options,
     const Model& gltf,
     const Node& node,
     const Mesh& mesh,
@@ -351,7 +352,9 @@ void loadPrimitive(
       Model::getSafe(&gltf.materials, primitive.material);
 
   primitiveInfo.isUnlit =
-      pMaterial && pMaterial->hasExtension<ExtensionKhrMaterialsUnlit>();
+      options.ignoreKhrMaterialUnlit
+          ? false
+          : pMaterial && pMaterial->hasExtension<ExtensionKhrMaterialsUnlit>();
 
   bool hasNormals = false;
   bool computeFlatNormals = false;
@@ -373,6 +376,7 @@ void loadPrimitive(
     loadPrimitive<uint32_t>(
         meshData,
         primitiveInfo,
+        options,
         gltf,
         node,
         mesh,
@@ -692,7 +696,8 @@ int32_t countPrimitives(const CesiumGltf::Model& model) {
 
 void populateMeshDataArray(
     MeshDataResult& meshDataResult,
-    TileLoadResult& tileLoadResult) {
+    TileLoadResult& tileLoadResult,
+    const CreateModelOptions& options) {
   CesiumGltf::Model* pModel =
       std::get_if<CesiumGltf::Model>(&tileLoadResult.contentKind);
   if (!pModel)
@@ -704,7 +709,7 @@ void populateMeshDataArray(
 
   pModel->forEachPrimitiveInScene(
       -1,
-      [&meshDataResult, &meshDataInstance, pModel](
+      [&meshDataResult, &meshDataInstance, pModel, &options](
           const Model& gltf,
           const Node& node,
           const Mesh& mesh,
@@ -739,6 +744,7 @@ void populateMeshDataArray(
             loadPrimitive<std::uint32_t>(
                 meshData,
                 primitiveInfo,
+                options,
                 gltf,
                 node,
                 mesh,
@@ -751,6 +757,7 @@ void populateMeshDataArray(
             loadPrimitive<std::uint16_t>(
                 meshData,
                 primitiveInfo,
+                options,
                 gltf,
                 node,
                 mesh,
@@ -768,6 +775,7 @@ void populateMeshDataArray(
             loadPrimitive<std::uint16_t>(
                 meshData,
                 primitiveInfo,
+                options,
                 gltf,
                 node,
                 mesh,
@@ -783,6 +791,7 @@ void populateMeshDataArray(
             loadPrimitive<std::uint16_t>(
                 meshData,
                 primitiveInfo,
+                options,
                 gltf,
                 node,
                 mesh,
@@ -798,6 +807,7 @@ void populateMeshDataArray(
             loadPrimitive<std::uint16_t>(
                 meshData,
                 primitiveInfo,
+                options,
                 gltf,
                 node,
                 mesh,
@@ -813,6 +823,7 @@ void populateMeshDataArray(
             loadPrimitive<std::uint16_t>(
                 meshData,
                 primitiveInfo,
+                options,
                 gltf,
                 node,
                 mesh,
@@ -828,6 +839,7 @@ void populateMeshDataArray(
             loadPrimitive<std::uint32_t>(
                 meshData,
                 primitiveInfo,
+                options,
                 gltf,
                 node,
                 mesh,
@@ -881,6 +893,7 @@ UnityPrepareRendererResources::prepareInLoadThread(
     TileLoadResult&& tileLoadResult,
     const glm::dmat4& transform,
     const std::any& rendererOptions) {
+
   CesiumGltf::Model* pModel =
       std::get_if<CesiumGltf::Model>(&tileLoadResult.contentKind);
   if (!pModel)
@@ -901,7 +914,7 @@ UnityPrepareRendererResources::prepareInLoadThread(
         return UnityEngine::Mesh::AllocateWritableMeshData(numberOfPrimitives);
       })
       .thenInWorkerThread(
-          [tileLoadResult = std::move(tileLoadResult)](
+          [tileLoadResult = std::move(tileLoadResult), rendererOptions](
               UnityEngine::MeshDataArray&& meshDataArray) mutable {
             MeshDataResult meshDataResult{std::move(meshDataArray), {}};
             // Free the MeshDataArray if something goes wrong.
@@ -909,7 +922,12 @@ UnityPrepareRendererResources::prepareInLoadThread(
               meshDataResult.meshDataArray.Dispose();
             });
 
-            populateMeshDataArray(meshDataResult, tileLoadResult);
+            const auto* pOptions =
+                std::any_cast<CreateModelOptions>(&rendererOptions);
+            if (pOptions)
+              populateMeshDataArray(meshDataResult, tileLoadResult, *pOptions);
+            else
+              populateMeshDataArray(meshDataResult, tileLoadResult, {});
 
             // We're returning the MeshDataArray, so don't free it.
             sg.release();
@@ -928,11 +946,10 @@ UnityPrepareRendererResources::prepareInLoadThread(
                       std::move(workerResult.tileLoadResult),
                       nullptr});
             }
-
             bool shouldCreatePhysicsMeshes = false;
             bool shouldShowTilesInHierarchy = false;
 
-            DotNet::CesiumForUnity::Cesium3DTileset tilesetComponent =
+            auto tilesetComponent =
                 tileset.GetComponent<DotNet::CesiumForUnity::Cesium3DTileset>();
             if (tilesetComponent != nullptr) {
               shouldCreatePhysicsMeshes =
@@ -1550,7 +1567,6 @@ void* UnityPrepareRendererResources::prepareInMainThread(
             UnityEngine::Object::Instantiate(opaqueMaterial);
         material.hideFlags(UnityEngine::HideFlags::HideAndDontSave);
         meshRenderer.material(material);
-
         if (pMaterial) {
           setGltfMaterialParameterValues(
               gltf,

--- a/native~/Runtime/src/UnityPrepareRendererResources.h
+++ b/native~/Runtime/src/UnityPrepareRendererResources.h
@@ -4,10 +4,24 @@
 
 #include <Cesium3DTilesSelection/IPrepareRendererResources.h>
 
+#include <DotNet/CesiumForUnity/Cesium3DTileset.h>
 #include <DotNet/UnityEngine/GameObject.h>
 
 namespace CesiumForUnityNative {
 
+struct CreateModelOptions {
+  /**
+   * Whether to ignore the KHR_materials_unlit extension in the model. If this
+   * is true and the extension is present, then flat normals will be generated
+   * for the model as it loads.
+   */
+  bool ignoreKhrMaterialUnlit = false;
+
+  CreateModelOptions() = default;
+  explicit CreateModelOptions(
+      const DotNet::CesiumForUnity::Cesium3DTileset& tilesetComponent)
+      : ignoreKhrMaterialUnlit(tilesetComponent.ignoreKhrMaterialsUnlit()) {}
+};
 /**
  * @brief Information about how a given glTF primitive was converted into
  * Unity MeshData.
@@ -28,6 +42,9 @@ struct CesiumPrimitiveInfo {
   /**
    * @brief Whether or not the primitive material has the KHR_materials_unlit
    * extension.
+   * @remarks This may be overridden if
+   * DotNet::CesiumForUnity::Cesium3DTileset::ignoreignoreKHRMaterialsUnlit() is
+   * set.
    */
   bool isUnlit = false;
 


### PR DESCRIPTION
## Description

This PR adds the option to override the `KHR_unlit_material` flag in a glTF 3DTileset. 

## Author checklist

- ~[ ] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).~
- [x] I have done a full self-review of my code.
- [X] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- ~[ ] I have added or updated unit tests to ensure consistent code coverage as necessary.~
- ~[ ] I have updated the documentation as necessary.~

## Testing plan

Load a 3DTileset that uses `KHR_material_unlit` flag. Observe that it is rendered using the unlit material. Toggle the checkbox and observe that it is rendered with default lighting. 