### PR TITLE
StencilShadowVolume.Shader from CesiumJS to Unity

### DIFF
--- a/Runtime/Resources/CesiumForUnityStencilShadowVolume.shader
+++ b/Runtime/Resources/CesiumForUnityStencilShadowVolume.shader
@@ -1,0 +1,84 @@
+Shader "Custom/CesiumForUnityStencilShadowVolume"
+{
+    Properties
+    {        
+        _Color ("Color",Color) = (1,1,1,1)
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" "RenderPipeline"="UniversalPipeline" }
+        
+        //Using double-sided stencil, configured with 2 passes
+        Pass
+        {
+            Name "StencilDepthRenderState"
+            Tags{"LightMode" = "Step1"}
+            Cull Off
+            Stencil
+            {
+                Ref 0 
+                //Comp always//equal
+
+                CompFront Always
+                FailFront Keep
+                ZFailFront DecrWrap
+                PassFront Keep
+
+                CompBack Always
+                FailBack Keep
+                ZFailBack IncrWrap
+                PassBack Keep
+            }
+            ZTest On
+            ZWrite Off
+            ColorMask 0
+        }
+        Pass
+        {
+            Name "StencilColorRenderState"
+            Tags{"LightMode" = "Step2"}
+            Cull Off
+            Stencil
+            {
+                Ref 0
+
+                CompFront NotEqual
+                FailFront Zero
+                ZFailFront Zero
+                PassFront Zero
+
+                CompBack NotEqual
+                FailBack Zero
+                ZFailBack Zero
+                PassBack Zero
+            }
+            ZTest Off
+            ZWrite Off
+            Blend SrcAlpha OneMinusSrcAlpha
+            
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            # include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            //Using To UnityProperty
+            half4 _Color;
+
+            float4 vert(float4 positionOS:POSITION): SV_POSITION
+            {
+                //ObjectSpace To ClipSpace
+                float4 OUT;
+                OUT = TransformObjectToHClip(positionOS.xyz);
+                return OUT;
+            }
+            half4 frag(): SV_Target
+            {
+                //Set to Color
+                //half4 color = half4(0,1,0,1);
+                half4 color = _Color;
+                return color;
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/Runtime/Resources/CesiumForUnityStencilShadowVolume.shader.meta
+++ b/Runtime/Resources/CesiumForUnityStencilShadowVolume.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b89edf0f547ce004ca69ca33d00656bd
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Resources/CesiumForUnityStencilShadowVolume_Mat.mat
+++ b/Runtime/Resources/CesiumForUnityStencilShadowVolume_Mat.mat
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: CesiumForUnityStencilShadowVolume_Mat
+  m_Shader: {fileID: 4800000, guid: b89edf0f547ce004ca69ca33d00656bd, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs: []
+    m_Ints: []
+    m_Floats: []
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []

--- a/Runtime/Resources/CesiumForUnityStencilShadowVolume_Mat.mat.meta
+++ b/Runtime/Resources/CesiumForUnityStencilShadowVolume_Mat.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b9e291af1c5ae4148a2cc5760b804025
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Ported the stencil shadow volume shader from CesiumJS to Unity (For URP).
support for stencil shadow volume rendering technique in order to render vector shapes visualize on terrain. 

(My colleague @TomLeeLive is planning to do PR for VCTR polygon mesh processing, and it would work well together with this functionality.)

Instruction.
**Follow this Step**

//Project Setting
1. In ProjectSetting >> Graphics >> ScriptableRenderPipelineSetting
2. Select SRPSetting >> Rendering >> index0 (UniversalRendererData)
3. AddRendererFeature >> Add 2 more "RenderObjects (Experimental)"  A, B
4. Set A B RenderObjects >> Layer Mask >> "Everything"
5. A RenderObjects >> Filters >> LightMode Tags >> Add "Step1"
6. B RenderObjects >> Filters >> LightMode Tags >> Add "Step2" 
7. Sort this role  A(Step1), B(Step2)

//Create Material
1. In Shader "CesiumToUnityStencilShadowVolume"
2. Select And RightMouseClick >> Create >> Material
3. Choose Color

// Use case example
1. Return the Scene. And Create cube. 
2. Apply the Material(CesiumToUnityStencilShadowVolume) To the cube >> Set Scale (1, 20, 1)
3. Create Other Cube >> Set Scale (100, 1, 100)
5. Select Apply the Material cube >> Overlap the two cube