### PR TITLE
Add issue and PR templates, CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,55 @@
+name: Report a bug
+description: Let us know so we can fix it!
+labels: ["needs triage", "bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us improve Cesium for Unity!
+        
+        First, check if the issue already exists in the [issues](https://github.com/CesiumGS/cesium-unity/issues) page. If it does, please leave a **comment** on the existing issue instead.
+        
+        Otherwise, if you can't find a similar issue, describe what is happening using the text fields below.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: What environment are you experiencing this issue in?
+      value: |
+        Cesium for Unity version:
+        Unity Editor Version:
+        Operating System:
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: "How do you trigger this bug? Please walk us through it step by step, starting from either a blank project or the Cesium for Unity Samples. (We can triage bugs much faster when we have these steps.)"
+      value: |
+        1.
+        2.
+        3.
+        ...
+    validations:
+      required: false
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Supporting evidence
+      description: Providing screenshots, videos, or GIFs of the issue helps us a lot, especially for visual bugs. If there were any error messages or logs in the console, please include those too.
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        If you can also contribute a fix, we'd absolutely appreciate it! Fixing a bug in Cesium for Unity often means fixing a bug for numerous applications and end users. Check out the contributor guide to get started: [CONTRIBUTING.md](https://github.com/CesiumGS/cesium-unity/tree/main/CONTRIBUTING.md)
+
+        Let us know you're working on it, and we'd be happy to provide advice and feedback.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+- name: Ask a question
+  url: https://community.cesium.com/c/cesium-for-unity/13
+  about: Please use the community forum for general questions. The Cesium team and community actively monitor it and love to see what people are working on! We reserve GitHub for confirmed bug reports and feature requests. 

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,20 @@
+name: Request a feature
+description: New ideas & improvements to Cesium for Unity are always welcome.
+labels: ["needs triage", "enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us improve Cesium for Unity!
+
+        When suggesting an idea, give examples of the intended use case. Features that benefit the wider community are more likely to be prioritized.
+  - type: textarea
+    id: new-feature
+    attributes:
+      label: Feature
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        The best way to get your ideas into Cesium for Unity is to help us! We love contributions and are always happy to be provide feedback and advice. Check out the contributor guide to get started: [CONTRIBUTING.md](https://github.com/CesiumGS/cesium-unity/tree/main/CONTRIBUTING.md)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+<!--
+Thanks for the Pull Request!
+
+Please review the [Contributor Guide](https://cesium.com/learn/cesium-unity/ref-doc/contributing-unity.html) before opening your first Pull Request.
+
+To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://cesium.com/learn/cesium-unity/ref-doc/contributing-unity.html#opening-a-pull-request).
+
+-->
+
+## Description
+
+<!-- Summarize the pull request. -- >
+
+< !-- Provide context for the reviewer to understand the pull request. Include what changes were made and why. -->
+
+<!-- Include screenshots if appropriate. -->
+
+## Issue number or link
+
+<!-- If it fixes an open issue, link to the issue here -->
+
+<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->
+
+## Author checklist
+
+- [ ] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
+- [ ] I have done a full self-review of my code.
+- [ ] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
+- [ ] I have added or updated unit tests to ensure consistent code coverage as necessary.
+- [ ] I have updated the documentation as necessary.
+
+## Remaining Tasks
+
+<!-- Are there any remaining tasks to do or blocking questions to answer before we can merge this? -->
+
+<!-- If so, please convert this to a draft PR and let us know how we can help. Otherwise, you may remove this section. -->
+
+## Testing plan
+
+<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->
+
+<!-- Include links to any required data or screenshots. Mention any edge cases such as user error, invalid data, etc. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing {#contributing-unity}
+
+Thanks for contributing to Cesium for Unity!
+
+<!--!
+[TOC]
+-->
+
+Here are the guidelines that we use for all contributions to this project:
+
+- [Submitting an issue](#submitting-an-issue)
+- [Getting started contributing](#getting-started-contributing)
+- [Opening a pull request](#opening-a-pull-request)
+
+To ensure an inclusive community, contributors and users in the Cesium community should follow the [code of conduct](https://github.com/CesiumGS/community/tree/main/CODE_OF_CONDUCT.md).
+
+# Submitting an Issue {#submitting-an-issue}
+
+If you have a question, **do not submit an issue**. Instead, search the [Cesium community forum](https://community.cesium.com/) for your question. The forum is very active and there are years of informative archives for the Cesium platform, often with answers from the core Cesium team. If you do not find an answer to your question, start a new thread and you'll likely get a quick response.
+
+If you think you've found a bug in Cesium for Unity, first search the existing [issues](https://github.com/CesiumGS/cesium-unity/issues). If an issue already exists, please add a **comment** expressing your interest and any additional information. This helps us stay organized and prioritize issues.
+
+If a related issue does not exist, then you can submit a new one. Please include as much of the following information as is relevant:
+
+- What version of Cesium for Unity were you using? Do other versions have the same issue?
+- What version of Unity Editor were you using?
+- What is your operating system and version, and your video card? Are they up-to-date? Is the issue specific to one of them?
+- Can the issue be reproduced in the [Cesium for Unity Samples](https://github.com/CesiumGS/cesium-unity-samples)?
+- Does the issue occur in Edit mode? In Play Mode? Both?
+- What [render pipeline](https://docs.unity3d.com/6000.1/Documentation/Manual/render-pipelines-overview.html) is your Unity project using? Built-in, URP, or HDRP?
+- Are there any error messages in the console? Any stack traces or logs? Please include them if so.
+- Share a screenshot, video or animated `.gif` if appropriate. Screenshots are particularly useful for exceptions and rendering artifacts.
+- Link to threads on the [Cesium community forum](https://community.cesium.com/) if this was discussed on there.
+- Include step-by-step instructions for us to reproduce the issue from scratch.
+- Any ideas for how to fix or workaround the issue. Also mention if you are willing to help fix it. If so, the Cesium team can often provide guidance and the issue may get fixed more quickly with your help.
+
+**Note**: It is difficult for us to debug everyone's individual projects. We can triage issues faster when we receive steps to reproduce the issue from scratch—either from [Cesium for Unity Samples](https://github.com/CesiumGS/cesium-unity-samples) or from a blank project. We will only request your Unity project and/or data as a last resort.
+
+# Getting Started Contributing {#getting-started-contributing}
+
+Everyone is welcome to contribute to Cesium for Unity!
+
+In addition to contributing code, we appreciate many types of contributions:
+
+- Being active on the [Cesium community forum](https://community.cesium.com/) by answering questions and providing input on Cesium's direction.
+- Showcasing your Cesium for Unity apps on [Cesium blog](https://cesium.com/blog/categories/userstories/). Contact us at hello@cesium.com.
+- Writing tutorials, creating examples, and improving the reference documentation. See the issues labeled [documentation](https://github.com/CesiumGS/cesium-unity/labels/documentation).
+- Submitting issues as [described above](#submitting-an-issue).
+- Triaging issues. Browse the [issues](https://github.com/CesiumGS/cesium-unity/issues) and comment on issues that are no longer reproducible or on issues for which you have additional information.
+
+For ideas for Cesium for Unity code contributions, see:
+
+- issues labeled [`good first issue`](https://github.com/CesiumGS/cesium-unity/labels/good%20first%20issue),
+- issues labeled [`low hanging fruit`](https://github.com/CesiumGS/cesium-unity/labels/low%20hanging%20fruit), and
+- issues labeled [`enhancement`](https://github.com/CesiumGS/cesium-unity/labels/enhancement).
+
+See [Developer Setup](https://cesium.com/learn/cesium-unity/ref-doc/developer-setup.html) for how to build and run Cesium for Unity.
+
+Always feel free to introduce yourself on the [Cesium community forum](https://community.cesium.com/) to brainstorm ideas and ask for guidance.
+
+# Opening a Pull Request {#opening-a-pull-request}
+
+We love pull requests. We strive to promptly review them, provide feedback, and merge. Interest in Cesium is at an all-time high so the core team is busy. Following the tips in this guide will help your pull request get merged quickly.
+
+> If you plan to make a major change, please start a new thread on the [Cesium community forum](https://community.cesium.com/) first. Pull requests for small features and bug fixes can generally just be opened without discussion on the forum.
+
+## Contributor License Agreement (CLA)
+
+Before we can review a pull request, we require a signed Contributor License Agreement. The CLA forms can be found in our `community` repo [here](https://github.com/CesiumGS/community/tree/main/CLAs).
+
+## Pull Request Guidelines
+
+Our code is our lifeblood so maintaining Cesium's high code quality is important to us.
+
+- For an overview of our workflow see [github pull request workflows](https://cesium.com/blog/2013/10/08/github-pull-request-workflows/).
+- Pull request tips
+  - After you open a pull request, one or more Cesium teammates will review your pull request.
+  - If your pull request fixes an existing issue, include a link to the issue in the description (like this: [#1](https://github.com/CesiumGS/cesium-unity/issues/1)). Likewise, if your pull request fixes an issue reported on the Cesium forum, include a link to the thread.
+  - If your pull request needs additional work, include a [task list](https://github.com/blog/1375%0A-task-lists-in-gfm-issues-pulls-comments).
+  - Once you are done making new commits to address feedback, add a comment to the pull request such as `"this is ready"` so we know to take another look.
+  - Verify that your code conforms to our [Style Guide](https://cesium.com/learn/cesium-native/ref-doc/style-guide.html).
+
+## Code of Conduct
+
+To ensure an inclusive community, contributors and users in the Cesium community should follow the [code of conduct](https://github.com/CesiumGS/community/tree/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
This PR copies the Github templates from [Cesium for Unreal](https://github.com/CesiumGS/cesium-unreal), as well as `CONTRIBUTING.md`, to improve Github logistics like bug reports and new contributor PRs.