### PR TITLE
Fix detection of credit image loading

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 - Added option to ignore the `KHR_material_unlit` extension to force default lighting on tilesets. 
 
+##### Fixes :wrench:
+
+- Fixed a bug where `CesiumCreditSystem` did not accurately track the loading progress of images, which could result in missing credits.
+
 ## v1.17.0 - 2025-08-01
 
 ##### Additions :tada:

--- a/Runtime/CesiumCreditSystem.cs
+++ b/Runtime/CesiumCreditSystem.cs
@@ -267,14 +267,15 @@ namespace CesiumForUnity
             return _defaultCreditSystem;
         }
 
-        internal bool HasLoadingImages()
+        internal int GetNumberOfLoadingImages()
         {
-            return this._numLoadingImages > 0;
+            return this._numLoadingImages;
         }
 
         internal IEnumerator LoadImage(string url)
         {
             int index = this._images.Count;
+            this._numLoadingImages++;
 
             // Initialize a texture of arbitrary size as a placeholder,
             // so that when other images are loaded, their IDs align properly
@@ -297,7 +298,6 @@ namespace CesiumForUnity
             {
                 // Load an image from a URL.
                 UnityWebRequest request = UnityWebRequestTexture.GetTexture(url);
-                this._numLoadingImages++;
                 yield return request.SendWebRequest();
 
                 if (request.result == UnityWebRequest.Result.ConnectionError ||
@@ -314,10 +314,10 @@ namespace CesiumForUnity
                     UnityLifetime.Destroy(placeholderTexture);
                 }
 
-                this._numLoadingImages--;
             }
 
             texture.wrapMode = TextureWrapMode.Clamp;
+            this._numLoadingImages--;
         }
     }
 }

--- a/Runtime/CesiumCreditSystem.cs
+++ b/Runtime/CesiumCreditSystem.cs
@@ -296,10 +296,17 @@ namespace CesiumForUnity
                 // Load an image from a string that contains the
                 // "data:image/png;base64," prefix
                 string byteString = url.Substring(base64Prefix.Length);
-                byte[] bytes = Convert.FromBase64String(byteString);
-                if (!texture.LoadImage(bytes))
+                try
                 {
-                    Debug.Log("Could not parse image from base64 string.");
+                    byte[] bytes = Convert.FromBase64String(byteString);
+                    if (!texture.LoadImage(bytes))
+                    {
+                        Debug.Log("Credit image could not be loaded into Texture2D.");
+                    }
+                }
+                catch (FormatException e)
+                {
+                    Debug.Log("Could not parse credit image from base64 string.");
                 }
             }
             else
@@ -311,7 +318,7 @@ namespace CesiumForUnity
                 if (request.result == UnityWebRequest.Result.ConnectionError ||
                     request.result == UnityWebRequest.Result.ProtocolError)
                 {
-                    Debug.Log(request.error);
+                    Debug.LogError(request.error);
                 }
                 else
                 {

--- a/Runtime/CesiumCreditSystem.cs
+++ b/Runtime/CesiumCreditSystem.cs
@@ -267,11 +267,19 @@ namespace CesiumForUnity
             return _defaultCreditSystem;
         }
 
+        /// <summary>
+        /// Gets the number of images on this credit system that are being loaded.
+        /// </summary>
+        /// <returns>The number of loading images.</returns>
         internal int GetNumberOfLoadingImages()
         {
             return this._numLoadingImages;
         }
 
+        /// <summary>
+        /// A function invoked with StartCoroutine() to asynchronously load images from an HTML credit.
+        /// </summary>
+        /// <param name="url">A string containing either the base64-encoded image data or the URL of the image.</param>
         internal IEnumerator LoadImage(string url)
         {
             int index = this._images.Count;

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -495,7 +495,7 @@ namespace CesiumForUnity
             credits.Add(credit);
             credits.Clear();
 
-            if (!creditSystem.HasLoadingImages())
+            if (creditSystem.GetNumberOfLoadingImages() == 0)
             {
                 creditSystem.BroadcastCreditsUpdate();
             }

--- a/native~/Runtime/src/CesiumCreditSystemImpl.h
+++ b/native~/Runtime/src/CesiumCreditSystemImpl.h
@@ -48,7 +48,8 @@ private:
       _htmlToUnityCredit;
 
   size_t _lastCreditsCount;
-  bool _creditsUpdated;
+  size_t _lastLoadingImagesCount;
+  bool _shouldBroadcastUpdate;
 };
 
 } // namespace CesiumForUnityNative


### PR DESCRIPTION
## Description

This fixes buggy behavior in `CesiumCreditSystem`. The implementation is fragmented between Unity and our native code, where `CesiumCreditSystemImpl` handles credit update logic and broadcasts events to the Unity side. If the native code detects HTML images, they're passed to a Coroutine on the Unity side to load the image.

Unfortunately, there were multiple bugs that led to image-loading being inaccurately tracked, thus leading to missing credits:

- `CesiumCreditSystem` only incremented the loading images number for external images (via `UnityWebRequest`). A base64 image in process of decoding could never show up.
- `StartCoroutine` may not start right away, so `CesiumCreditSystemImpl` incorrectly assumed zero loading images `==` finished loading all images, and would broadcast the update early.

The latter is solved by explicitly checking the number of loading images every frame. This ensures that image-loading coroutines are always tracked properly so it can update the credit system UI.

## Issue number or link

Fixes #585.

## Author checklist

- [X] I have done a full self-review of my code.
- [X] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- ~[ ] I have added or updated unit tests to ensure consistent code coverage as necessary.~
- [X] I have updated the documentation as necessary.

## Testing plan

See #585 for bug reproduction steps.