### PR TITLE
Prevent access on `null` `CesiumPointCloudShading`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 - Added option to ignore the `KHR_material_unlit` extension to force default lighting on tilesets. 
 
+##### Fixes :wrench:
+
+- Fixed a bug where `CesiumPointCloudRenderer` could dereference a null `CesiumPointCloudShading` on `Cesium3DTileset`.
+
 ## v1.17.0 - 2025-08-01
 
 ##### Additions :tada:

--- a/Runtime/Cesium3DTileset.cs
+++ b/Runtime/Cesium3DTileset.cs
@@ -617,7 +617,7 @@ namespace CesiumForUnity
         }
 
         [SerializeField]
-        private CesiumPointCloudShading _pointCloudShading;
+        private CesiumPointCloudShading _pointCloudShading = new CesiumPointCloudShading();
 
         /// <summary>
         /// The CesiumPointCloudShading attached to this tileset. If the tileset

--- a/Runtime/CesiumPointCloudRenderer.cs
+++ b/Runtime/CesiumPointCloudRenderer.cs
@@ -131,7 +131,9 @@ namespace CesiumForUnity
                 5.0f :
                 this._tileset.maximumScreenSpaceError;
 
-            if (this._tileset.pointCloudShading.maximumAttenuation > 0.0f)
+            CesiumPointCloudShading pointCloudShading = this._tileset.pointCloudShading;
+
+            if (pointCloudShading.maximumAttenuation > 0.0f)
             {
                 maximumPointSize = this._tileset.pointCloudShading.maximumAttenuation;
             }
@@ -141,8 +143,6 @@ namespace CesiumForUnity
                 // Approximation of device pixel ratio
                 maximumPointSize *= Screen.dpi / 150;
             }
-
-            CesiumPointCloudShading pointCloudShading = this._tileset.pointCloudShading;
 
             float geometricError = this.GetGeometricError(pointCloudShading);
             geometricError *= pointCloudShading.geometricErrorScale;
@@ -227,7 +227,8 @@ namespace CesiumForUnity
 
         void Update()
         {
-            if (this._tileset.pointCloudShading.attenuation)
+            CesiumPointCloudShading pointCloudShading = this._tileset.pointCloudShading;
+            if (pointCloudShading != null && pointCloudShading.attenuation)
             {
                 this.DrawPointsWithAttenuation();
                 this._meshRenderer.enabled = false;


### PR DESCRIPTION
## Description

This addresses a bug with point cloud tilesets that are created at runtime. Since `CesiumPointCloudShading` is a `class`, not a `struct`, it's possible for a `Cesium3DTileset` to be missing one, which is exactly what happens when it is created at runtime. This PR adds checks for a `null` reference, and also explicitly initializes `CesiumPointCloudShading` inline for good measure.

Ideally, `CesiumPointCloudShading` would just be a `struct` to avoid this, but C# 9.0 does not like `structs` with non-zero default values. :)

## Issue number or link

Fixes #604.

## Author checklist

- [X] I have done a full self-review of my code.
- [X] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- ~[ ] I have added or updated unit tests to ensure consistent code coverage as necessary.~
- ~[] I have updated the documentation as necessary.~

## Testing plan

1. Start from `02_CesiumMelbourne` in the Cesium samples.
2. Create a new script called `PointCloudLoader` with the contents below.
3. Add the component to any arbitrary `GameObject`. I just tacked it onto the `Getting Started` object.
4. Press Play. Ensure that the console is not spammed with errors as the points load in.

```
using System.Collections;
using System.Collections.Generic;
using UnityEngine;
using CesiumForUnity;

public class PointCloudLoader : MonoBehaviour
{
    // Start is called before the first frame update
    void Start()
    {
        var go = new GameObject("PointCloud");
        go.transform.SetParent(FindObjectOfType<CesiumGeoreference>().transform);
        Cesium3DTileset tileset = go.AddComponent<Cesium3DTileset>();
        tileset.ionAssetID = 43978;
    }
}
```