### PR TITLE
Flip textures and UVs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ CesiumForUnityNativeBindings/native/
 *.user
 .DS_STORE
 .idea
+obj.meta
+bin.meta
 Reinterop.dll
 Reinterop.deps.json
 Reinterop.deps.json.meta

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ##### Fixes :wrench:
 
-- Corrected texture import process to flip textures and UV coordinates from glTF's U-right, V-down convention to comply with Unity's U-right, V-up coordinate system. 
+- Corrected glTF import process to flip textures and UV coordinates from glTF's U-right, V-down convention to comply with Unity's U-right, V-up coordinate system. 
 
 ## v1.18.1 - 2025-10-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## ? - ?
+
+##### Fixes :wrench:
+
+- Corrected texture import process to flip textures and UV coordinates from glTF's U-right, V-down convention to comply with Unity's U-right, V-up coordinate system. 
+
 ## v1.18.1 - 2025-10-01
 
 This release updates [cesium-native](https://github.com/CesiumGS/cesium-native) from v0.51.0 to v0.52.1. See the [changelog](https://github.com/CesiumGS/cesium-native/blob/main/CHANGES.md) for a complete list of changes in cesium-native.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## ? - ?
 
 ##### Fixes :wrench:
+
 - Textures and UV coordinates from glTFs are now flipped to properly comply with Unity's U-right, V-up convention.
 
 ## v1.18.1 - 2025-10-01

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,7 @@
 ## ? - ?
 
 ##### Fixes :wrench:
-
-- Corrected glTF import process to flip textures and UV coordinates from glTF's U-right, V-down convention to comply with Unity's U-right, V-up coordinate system. 
+- Textures and UV coordinates from glTFs are now flipped to properly comply with Unity's U-right, V-up convention.
 
 ## v1.18.1 - 2025-10-01
 

--- a/native~/Runtime/src/TextureLoader.cpp
+++ b/native~/Runtime/src/TextureLoader.cpp
@@ -71,15 +71,14 @@ getUncompressedPixelFormat(const CesiumGltf::ImageAsset& image) {
 
 /**
  * Copy image data while flipping the data vertically. According to the glTF 2.0
- * spec, glTF stores textures in x-right, y-down (right-handed) coordinates.
+ * spec, glTF stores textures in x-right, y-down coordinates.
  * However, Unity uses x-right, y-up coordinates, so we need to flip the
- *textures and UV coordinates. See loadPrimitive() in
- *UnityPrepareRenderResources.cpp for the corresponding UV flip.
+ * textures and UV coordinates. See loadPrimitive() in
+ * UnityPrepareRenderResources.cpp for the corresponding UV flip.
  **/
-template <typename TSrcByte, typename TDstByte>
-void copyAndFlipY(
-    TSrcByte* dst,
-    const TDstByte* src,
+void copyAndFlipTexture(
+    std::uint8_t* dst,
+    const std::byte* src,
     const size_t dataLength,
     const size_t height) {
   assert(
@@ -88,8 +87,8 @@ void copyAndFlipY(
 
   const size_t stride = dataLength / height;
 
-  for (size_t j = 0; j < height; ++j) {
-    memcpy(dst, src + (height - j) * stride, stride);
+  for (int32_t i = int32_t(height) - 1; i >= 0; --i) {
+    memcpy(dst, src + i * stride, stride);
     dst += stride;
   }
 }
@@ -125,7 +124,7 @@ TextureLoader::loadTexture(const CesiumGltf::ImageAsset& image, bool sRGB) {
   if (image.mipPositions.empty()) {
     // No mipmaps, copy the whole thing and then let Unity generate mipmaps on a
     // worker thread.
-    copyAndFlipY(
+    copyAndFlipTexture(
         pixels,
         image.pixelData.data(),
         image.pixelData.size(),
@@ -136,26 +135,27 @@ TextureLoader::loadTexture(const CesiumGltf::ImageAsset& image, bool sRGB) {
     std::uint8_t* pWritePosition = pixels;
     const std::byte* pReadBuffer = image.pixelData.data();
 
-    // track square image dimension for each mip level
-    int32_t mipHeight = image.height;
+    // Track image height for each mip level
+    size_t mipHeight = image.height;
 
     for (const ImageAssetMipPosition& mip : image.mipPositions) {
       assert(mipHeight > 0 && "Invalid image size.");
       const size_t start = mip.byteOffset;
       const size_t end = mip.byteOffset + mip.byteSize;
       if (start >= textureLength || end > textureLength) {
+        // Invalid mip, skip this level.
         mipHeight /= 2;
-        continue; // invalid mip spec, ignore it
+        continue;
       }
 
-      copyAndFlipY(
+      copyAndFlipTexture(
           pWritePosition,
           pReadBuffer + start,
           mip.byteSize,
           mipHeight);
       pWritePosition += mip.byteSize;
       // adjust height for next mip level.
-      mipHeight /= 2;
+      mipHeight >>= 1;
     }
 
     result.Apply(false, true);

--- a/native~/Runtime/src/TextureLoader.cpp
+++ b/native~/Runtime/src/TextureLoader.cpp
@@ -69,6 +69,25 @@ getUncompressedPixelFormat(const CesiumGltf::ImageAsset& image) {
   }
 }
 
+/**
+ * Copy image data while flipping the data vertically. According to the glTF 2.0
+ * spec, glTF stores textures in x-right, y-down (right-handed) coordinates.
+ * However, Unity uses x-right, y-up coordinates, so we need to flip the textures
+ * and UV coordinates. See loadPrimitive() in UnityPrepareRenderResources.cpp for
+ * the corresponding UV flip.
+ **/
+template<typename TSrcByte, typename TDstByte>
+void copyAndFlipY(TSrcByte* dst, const TDstByte* src, const size_t dataLength, const size_t height) {
+  assert((dataLength % height) == 0 && "Image data size is not an even multiple of image width.");
+
+  const size_t stride = dataLength / height;
+
+  for (size_t j=0; j < height; ++j) {
+    memcpy(dst, src + (height - j) * stride, stride);
+    dst += stride;
+  }
+}
+
 } // namespace
 
 UnityEngine::Texture
@@ -100,21 +119,29 @@ TextureLoader::loadTexture(const CesiumGltf::ImageAsset& image, bool sRGB) {
   if (image.mipPositions.empty()) {
     // No mipmaps, copy the whole thing and then let Unity generate mipmaps on a
     // worker thread.
-    std::memcpy(pixels, image.pixelData.data(), image.pixelData.size());
+    copyAndFlipY(pixels, image.pixelData.data(), image.pixelData.size(), image.height);
     result.Apply(false, true);
   } else {
     // Copy the mipmaps explicitly.
     std::uint8_t* pWritePosition = pixels;
     const std::byte* pReadBuffer = image.pixelData.data();
 
-    for (const ImageAssetMipPosition& mip : image.mipPositions) {
-      size_t start = mip.byteOffset;
-      size_t end = mip.byteOffset + mip.byteSize;
-      if (start >= textureLength || end > textureLength)
-        continue; // invalid mip spec, ignore it
+    // track square image dimension for each mip level
+    int32_t mipHeight = image.height;
 
-      std::memcpy(pWritePosition, pReadBuffer + start, mip.byteSize);
+    for (const ImageAssetMipPosition& mip : image.mipPositions) {
+      assert(mipHeight > 0 && "Invalid image size.");
+      const size_t start = mip.byteOffset;
+      const size_t end = mip.byteOffset + mip.byteSize;
+      if (start >= textureLength || end > textureLength) {
+        mipHeight /= 2;
+        continue; // invalid mip spec, ignore it
+      }
+
+      copyAndFlipY(pWritePosition, pReadBuffer + start, mip.byteSize, mipHeight);
       pWritePosition += mip.byteSize;
+      // adjust height for next mip level.
+      mipHeight /= 2;
     }
 
     result.Apply(false, true);

--- a/native~/Runtime/src/TextureLoader.cpp
+++ b/native~/Runtime/src/TextureLoader.cpp
@@ -86,7 +86,7 @@ void copyAndFlipTexture(
       "Image data size is not an even multiple of the given row pitch.");
 
   const int32_t height = static_cast<int32_t>(dataLength / stride);
-  for (int32_t i = height-1; i >= 0; --i) {
+  for (int32_t i = height - 1; i >= 0; --i) {
     memcpy(pDst, pSrc + i * stride, stride);
     pDst += stride;
   }

--- a/native~/Runtime/src/TextureLoader.cpp
+++ b/native~/Runtime/src/TextureLoader.cpp
@@ -72,17 +72,23 @@ getUncompressedPixelFormat(const CesiumGltf::ImageAsset& image) {
 /**
  * Copy image data while flipping the data vertically. According to the glTF 2.0
  * spec, glTF stores textures in x-right, y-down (right-handed) coordinates.
- * However, Unity uses x-right, y-up coordinates, so we need to flip the textures
- * and UV coordinates. See loadPrimitive() in UnityPrepareRenderResources.cpp for
- * the corresponding UV flip.
+ * However, Unity uses x-right, y-up coordinates, so we need to flip the
+ *textures and UV coordinates. See loadPrimitive() in
+ *UnityPrepareRenderResources.cpp for the corresponding UV flip.
  **/
-template<typename TSrcByte, typename TDstByte>
-void copyAndFlipY(TSrcByte* dst, const TDstByte* src, const size_t dataLength, const size_t height) {
-  assert((dataLength % height) == 0 && "Image data size is not an even multiple of image width.");
+template <typename TSrcByte, typename TDstByte>
+void copyAndFlipY(
+    TSrcByte* dst,
+    const TDstByte* src,
+    const size_t dataLength,
+    const size_t height) {
+  assert(
+      (dataLength % height) == 0 &&
+      "Image data size is not an even multiple of image width.");
 
   const size_t stride = dataLength / height;
 
-  for (size_t j=0; j < height; ++j) {
+  for (size_t j = 0; j < height; ++j) {
     memcpy(dst, src + (height - j) * stride, stride);
     dst += stride;
   }
@@ -119,7 +125,11 @@ TextureLoader::loadTexture(const CesiumGltf::ImageAsset& image, bool sRGB) {
   if (image.mipPositions.empty()) {
     // No mipmaps, copy the whole thing and then let Unity generate mipmaps on a
     // worker thread.
-    copyAndFlipY(pixels, image.pixelData.data(), image.pixelData.size(), image.height);
+    copyAndFlipY(
+        pixels,
+        image.pixelData.data(),
+        image.pixelData.size(),
+        image.height);
     result.Apply(false, true);
   } else {
     // Copy the mipmaps explicitly.
@@ -138,7 +148,11 @@ TextureLoader::loadTexture(const CesiumGltf::ImageAsset& image, bool sRGB) {
         continue; // invalid mip spec, ignore it
       }
 
-      copyAndFlipY(pWritePosition, pReadBuffer + start, mip.byteSize, mipHeight);
+      copyAndFlipY(
+          pWritePosition,
+          pReadBuffer + start,
+          mip.byteSize,
+          mipHeight);
       pWritePosition += mip.byteSize;
       // adjust height for next mip level.
       mipHeight /= 2;

--- a/native~/Runtime/src/TextureLoader.cpp
+++ b/native~/Runtime/src/TextureLoader.cpp
@@ -77,8 +77,8 @@ getUncompressedPixelFormat(const CesiumGltf::ImageAsset& image) {
  * UnityPrepareRenderResources.cpp for the corresponding UV flip.
  **/
 void copyAndFlipTexture(
-    std::uint8_t* dst,
-    const std::byte* src,
+    std::uint8_t* pDst,
+    const std::byte* pSrc,
     const size_t dataLength,
     const size_t height) {
   assert(
@@ -88,8 +88,8 @@ void copyAndFlipTexture(
   const size_t stride = dataLength / height;
 
   for (int32_t i = int32_t(height) - 1; i >= 0; --i) {
-    memcpy(dst, src + i * stride, stride);
-    dst += stride;
+    memcpy(pDst, pSrc + i * stride, stride);
+    pDst += stride;
   }
 }
 
@@ -144,7 +144,7 @@ TextureLoader::loadTexture(const CesiumGltf::ImageAsset& image, bool sRGB) {
       const size_t end = mip.byteOffset + mip.byteSize;
       if (start >= textureLength || end > textureLength) {
         // Invalid mip, skip this level.
-        mipHeight /= 2;
+        mipHeight >>= 1;
         continue;
       }
 

--- a/native~/Runtime/src/TextureLoader.cpp
+++ b/native~/Runtime/src/TextureLoader.cpp
@@ -84,7 +84,7 @@ void copyAndFlipY(
     const size_t height) {
   assert(
       (dataLength % height) == 0 &&
-      "Image data size is not an even multiple of image width.");
+      "Image data size is not an even multiple of image height.");
 
   const size_t stride = dataLength / height;
 

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -608,7 +608,7 @@ void loadPrimitive(
         Vector2 texCoord = texCoordViews[texCoordIndex][vertexIndex];
         // flip Y to comply with Unity's left-handed UV coordinates
         texCoord.y = 1 - texCoord.y;
-        *reinterpret_cast<Vector2*>(pWritePos) =texCoord;
+        *reinterpret_cast<Vector2*>(pWritePos) = texCoord;
         pWritePos += sizeof(Vector2);
       }
     }

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -628,8 +628,10 @@ void loadPrimitive(
 
       for (uint32_t texCoordIndex = 0; texCoordIndex < numTexCoords;
            ++texCoordIndex) {
-        *reinterpret_cast<Vector2*>(pWritePos) =
-            texCoordViews[texCoordIndex][i];
+        Vector2 texCoord = texCoordViews[texCoordIndex][i];
+        // flip Y to comply with Unity's left-handed UV coordinates
+        texCoord.y = 1 - texCoord.y;
+        *reinterpret_cast<Vector2*>(pWritePos) = texCoord;
         pWritePos += sizeof(Vector2);
       }
     }

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -606,6 +606,7 @@ void loadPrimitive(
       for (uint32_t texCoordIndex = 0; texCoordIndex < numTexCoords;
            ++texCoordIndex) {
         Vector2 texCoord = texCoordViews[texCoordIndex][vertexIndex];
+        // flip Y to comply with Unity's left-handed UV coordinates
         texCoord.y = 1 - texCoord.y;
         *reinterpret_cast<Vector2*>(pWritePos) =texCoord;
         pWritePos += sizeof(Vector2);
@@ -615,18 +616,15 @@ void loadPrimitive(
     for (int64_t i = 0; i < vertexCount; ++i) {
       *reinterpret_cast<Vector3*>(pWritePos) = positionView[i];
       pWritePos += sizeof(Vector3);
-
       if (hasNormals) {
         *reinterpret_cast<Vector3*>(pWritePos) = normalView[i];
         pWritePos += sizeof(Vector3);
       }
-
       // Skip the slot allocated for vertex colors, we will fill them in
       // bulk later.
       if (hasVertexColors) {
         pWritePos += sizeof(uint32_t);
       }
-
       for (uint32_t texCoordIndex = 0; texCoordIndex < numTexCoords;
            ++texCoordIndex) {
         Vector2 texCoord = texCoordViews[texCoordIndex][i];

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -606,7 +606,7 @@ void loadPrimitive(
       for (uint32_t texCoordIndex = 0; texCoordIndex < numTexCoords;
            ++texCoordIndex) {
         Vector2 texCoord = texCoordViews[texCoordIndex][vertexIndex];
-        // Flip Y to comply with Unity's Y-up coordinate convention
+        // Flip Y to comply with Unity's V-up coordinate convention
         texCoord.y = 1 - texCoord.y;
         *reinterpret_cast<Vector2*>(pWritePos) = texCoord;
         pWritePos += sizeof(Vector2);
@@ -628,7 +628,7 @@ void loadPrimitive(
       for (uint32_t texCoordIndex = 0; texCoordIndex < numTexCoords;
            ++texCoordIndex) {
         Vector2 texCoord = texCoordViews[texCoordIndex][i];
-        // Flip Y to comply with Unity's Y-up coordinate convention
+        // Flip Y to comply with Unity's V-up coordinate convention
         texCoord.y = 1 - texCoord.y;
         *reinterpret_cast<Vector2*>(pWritePos) = texCoord;
         pWritePos += sizeof(Vector2);

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -605,8 +605,9 @@ void loadPrimitive(
       }
       for (uint32_t texCoordIndex = 0; texCoordIndex < numTexCoords;
            ++texCoordIndex) {
-        *reinterpret_cast<Vector2*>(pWritePos) =
-            texCoordViews[texCoordIndex][vertexIndex];
+        Vector2 texCoord = texCoordViews[texCoordIndex][vertexIndex];
+        texCoord.y = 1 - texCoord.y;
+        *reinterpret_cast<Vector2*>(pWritePos) =texCoord;
         pWritePos += sizeof(Vector2);
       }
     }

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -606,7 +606,7 @@ void loadPrimitive(
       for (uint32_t texCoordIndex = 0; texCoordIndex < numTexCoords;
            ++texCoordIndex) {
         Vector2 texCoord = texCoordViews[texCoordIndex][vertexIndex];
-        // flip Y to comply with Unity's left-handed UV coordinates
+        // Flip Y to comply with Unity's Y-up coordinate convention
         texCoord.y = 1 - texCoord.y;
         *reinterpret_cast<Vector2*>(pWritePos) = texCoord;
         pWritePos += sizeof(Vector2);
@@ -628,7 +628,7 @@ void loadPrimitive(
       for (uint32_t texCoordIndex = 0; texCoordIndex < numTexCoords;
            ++texCoordIndex) {
         Vector2 texCoord = texCoordViews[texCoordIndex][i];
-        // flip Y to comply with Unity's left-handed UV coordinates
+        // Flip Y to comply with Unity's Y-up coordinate convention
         texCoord.y = 1 - texCoord.y;
         *reinterpret_cast<Vector2*>(pWritePos) = texCoord;
         pWritePos += sizeof(Vector2);


### PR DESCRIPTION
## Description

This PR modifies the texture and model import process to comply with Unity's U-right, V-up convention. 
The glTF 2.0 spec mandates that textures are anchored at UV (0,0) and the upper-left corner of the texture, with UVs increasing to the right and down. (See https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#images .) 
Unity, however, assumes that UV (0,0) corresponds to the bottom-left corner of the image. Previously, the system did not flip either the textures OR the UVs, so it mostly worked, but has caused issues with tangent generation. 

In the UV overlay debug images below, the six columns on the left were loaded by Cesium, while the six on the right were loaded by [Unity glTFast](https://docs.unity3d.com/Packages/com.unity.cloud.gltfast@6.1/manual/installation.html). These were generated using [the same glTF model](https://github.com/KhronosGroup/glTF-Sample-Models/tree/main/2.0/NormalTangentTest):

This requires changes to `cesium-native` in https://github.com/CesiumGS/cesium-native/pull/1259 . 

Before this change:
<img width="1328" height="677" alt="image" src="https://github.com/user-attachments/assets/1a231a09-43d9-4185-aa88-48942ea81f3a" />

After this change:
<img width="1148" height="597" alt="image" src="https://github.com/user-attachments/assets/cafd7034-699e-45ca-a927-ad58ff53c558" />

With textures flipped: 
<img width="1177" height="576" alt="image" src="https://github.com/user-attachments/assets/11df1780-5952-44e7-aedd-3b30153bf701" />


## Author checklist

- [ ] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [x] I have done a full self-review of my code.
- [x] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- [ ] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [ ] I have updated the documentation as necessary.


## Testing plan

Load a tileset. Use Unity's Render Debugger to visualize the `Texcoord0` vertex attribute. Observe that UV coordinates increase in the right- and up-direction, and that textures are correctly flipped to match. 
<img width="715" height="297" alt="image" src="https://github.com/user-attachments/assets/97d125a8-79ce-4825-8668-eaa4ff8d4a27" />


