### PR TITLE
Add `CesiumGoogleMapTilesRasterOverlay` to stream Google Maps 2D Tiles

### DIFF
--- a/CONTRIBUTING.md.meta
+++ b/CONTRIBUTING.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3fd6df72dd74e4b4a9a1096d82b3e1b5
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/CesiumGoogleMapTilesRasterOverlayEditor.cs
+++ b/Editor/CesiumGoogleMapTilesRasterOverlayEditor.cs
@@ -1,0 +1,166 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace CesiumForUnity
+{
+    [CustomEditor(typeof(CesiumGoogleMapTilesRasterOverlay))]
+    public class CesiumGoogleMapTilesRasterOverlayEditor : Editor
+    {
+        private CesiumRasterOverlayEditor _rasterOverlayEditor;
+
+        private SerializedProperty _apiKey;
+        private SerializedProperty _mapType;
+        private SerializedProperty _language;
+        private SerializedProperty _region;
+        private SerializedProperty _scale;
+        private SerializedProperty _highDpi;
+        private SerializedProperty _layerTypes;
+        private SerializedProperty _styles;
+        private SerializedProperty _overlay;
+
+        private string[] _scaleOptions;
+        private int _selectedScaleIndex;
+
+        private void OnEnable()
+        {
+            this._rasterOverlayEditor =
+                (CesiumRasterOverlayEditor)Editor.CreateEditor(
+                                                     this.target,
+                                                     typeof(CesiumRasterOverlayEditor));
+
+            this._apiKey = this.serializedObject.FindProperty("_apiKey");
+            this._mapType = this.serializedObject.FindProperty("_mapType");
+            this._language = this.serializedObject.FindProperty("_language");
+            this._region = this.serializedObject.FindProperty("_region");
+            this._scale = this.serializedObject.FindProperty("_scale");
+            this._highDpi = this.serializedObject.FindProperty("_highDpi");
+            this._layerTypes = this.serializedObject.FindProperty("_layerTypes");
+            this._styles = this.serializedObject.FindProperty("_styles");
+            this._overlay = this.serializedObject.FindProperty("_overlay");
+
+            // Remove "ScaleFactor" prefix from the Scale enum options.
+            int nameOffset = ("ScaleFactor").Length;
+            this._scaleOptions = this._scale.enumNames;
+            for (int i = 0; i < this._scaleOptions.Length; i++)
+            {
+                this._scaleOptions[i] = this._scaleOptions[i].Substring(nameOffset);
+            }
+            this._selectedScaleIndex = this._scale.enumValueIndex;
+        }
+
+        private void OnDisable()
+        {
+            if (this._rasterOverlayEditor != null)
+            {
+                DestroyImmediate(this._rasterOverlayEditor);
+            }
+        }
+
+        public override void OnInspectorGUI()
+        {
+            this.serializedObject.Update();
+
+            EditorGUIUtility.labelWidth = CesiumEditorStyle.inspectorLabelWidth;
+            this.DrawGoogleMapTilesProperties();
+            EditorGUILayout.Space(5);
+            this.DrawRasterOverlayProperties();
+
+            this.serializedObject.ApplyModifiedProperties();
+        }
+
+        private void DrawGoogleMapTilesProperties()
+        {
+            GUIContent apiKeyContent = new GUIContent(
+                "API Key",
+                "The Google Map Tiles API key to use.");
+            EditorGUILayout.DelayedTextField(this._apiKey, apiKeyContent);
+
+            GUIContent mapTypeContent = new GUIContent(
+                "Map Type",
+                "The type of base map.");
+            EditorGUILayout.PropertyField(this._mapType, mapTypeContent);
+
+            GUIContent languageContent = new GUIContent(
+                "Language",
+                "An IETF language tag that specifies the language used to display " +
+                "information on the tiles. For example, `en-US` specifies the " +
+                "English language as spoken in the United States.");
+            EditorGUILayout.DelayedTextField(this._language, languageContent);
+
+            GUIContent regionContent = new GUIContent(
+                "Region",
+                "A Common Locale Data Repository region identifier (two uppercase " +
+                "letters) that represents the physical location of the user. For " +
+                "example, `US`.");
+            EditorGUILayout.DelayedTextField(this._region, regionContent);
+
+            GUIContent scaleContent = new GUIContent(
+                "Scale",
+                "Scales-up the size of map elements (such as road labels), while " +
+                "retaining the tile size and coverage area of the default tile." +
+                "\n\n" +
+                "Increasing the scale also reduces the number of labels on the map, " +
+                "which reduces clutter.");
+            this._selectedScaleIndex =
+                EditorGUILayout.Popup(scaleContent, this._selectedScaleIndex, this._scaleOptions);
+            this._scale.enumValueIndex = this._selectedScaleIndex;
+
+            GUIContent highDpiContent = new GUIContent(
+                "High DPI",
+                "Specifies whether to return high-resolution tiles." +
+                "\n\n" +
+                "If the scale-factor is increased, High DPI is used to increase the " +
+                "size of the tile. Normally, increasing the scale factor enlarges the " +
+                "resulting tile into an image of the same size, which lowers quality. " +
+                "With High DPI, the resulting size is also increased, preserving quality. " +
+                "DPI stands for Dots per Inch, and High DPI means the tile renders using " +
+                "more dots per inch than normal." +
+                "\n\n" +
+                "If enabled, the number of pixels in each of the x and y dimensions is " +
+                "multiplied by the scale factor (that is, 2x or 4x). The coverage area " +
+                "of the tile remains unchanged. This parameter works only with Scale " +
+                "values of 2x or 4x. It has no effect on 1x scale tiles.");
+            EditorGUILayout.PropertyField(this._highDpi, highDpiContent);
+
+            GUIContent layerTypesContent = new GUIContent(
+                "Layer Types",
+                "The layer types to be added to the map.");
+            EditorGUILayout.PropertyField(this._layerTypes, layerTypesContent);
+
+            GUIContent stylesContent = new GUIContent(
+                "Styles",
+                "A list of JSON style objects that specify the appearance and detail " +
+                "level of map features such as roads, parks, and built-up areas." +
+                "\n\n" +
+                "Styling is used to customize the standard Google base map. The Styles " +
+                "parameter is valid only if the Map Type is Roadmap.");
+            EditorGUILayout.PropertyField(this._styles, stylesContent);
+
+            GUIContent overlayContent = new GUIContent(
+                "Overlay",
+                "Specifies whether Layer Types are rendered as a separate overlay, or " +
+                "combined with the base imagery." +
+                "\n\n" +
+                "When enabled, the base map isn't displayed. If you haven't defined any " +
+                "Layer Types, then this value is ignored.");
+            EditorGUILayout.PropertyField(this._overlay, overlayContent);
+
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            if (EditorGUILayout.LinkButton("Maps Tile API Style reference"))
+            {
+                Application.OpenURL("https://developers.google.com/maps/documentation/tile/style-reference");
+            }
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+        }
+
+        private void DrawRasterOverlayProperties()
+        {
+            if (this._rasterOverlayEditor != null)
+            {
+                this._rasterOverlayEditor.OnInspectorGUI();
+            }
+        }
+    }
+}

--- a/Editor/CesiumGoogleMapTilesRasterOverlayEditor.cs.meta
+++ b/Editor/CesiumGoogleMapTilesRasterOverlayEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 855b80a9fcf2d8b44a3845c463c5b8fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/CesiumIonRasterOverlayEditor.cs
+++ b/Editor/CesiumIonRasterOverlayEditor.cs
@@ -12,6 +12,7 @@ namespace CesiumForUnity
         private SerializedProperty _ionAssetID;
         private SerializedProperty _ionAccessToken;
         private SerializedProperty _ionServer;
+        private SerializedProperty _assetOptions;
 
         private void OnEnable()
         {
@@ -24,6 +25,7 @@ namespace CesiumForUnity
             this._ionAssetID = this.serializedObject.FindProperty("_ionAssetID");
             this._ionAccessToken = this.serializedObject.FindProperty("_ionAccessToken");
             this._ionServer = this.serializedObject.FindProperty("_ionServer");
+            this._assetOptions = this.serializedObject.FindProperty("_assetOptions");
         }
 
         private void OnDisable()
@@ -74,6 +76,12 @@ namespace CesiumForUnity
 
             GUIContent ionServerContent = new GUIContent("ion Server", "The Cesium ion server to use.");
             EditorGUILayout.PropertyField(this._ionServer, ionServerContent);
+
+            GUIContent assetOptionsContent = new GUIContent(
+                "Asset Options",
+                "Extra options to pass to Cesium ion when accessing the asset. " +
+                "This should be a JSON string.");
+            EditorGUILayout.DelayedTextField(this._assetOptions, assetOptionsContent);
         }
 
         private void DrawRasterOverlayProperties()

--- a/Runtime/CesiumCreditSystem.cs
+++ b/Runtime/CesiumCreditSystem.cs
@@ -304,7 +304,7 @@ namespace CesiumForUnity
                         Debug.Log("Credit image could not be loaded into Texture2D.");
                     }
                 }
-                catch (FormatException e)
+                catch (FormatException)
                 {
                     Debug.Log("Could not parse credit image from base64 string.");
                 }

--- a/Runtime/CesiumGoogleMapsTilesRasterOverlay.cs
+++ b/Runtime/CesiumGoogleMapsTilesRasterOverlay.cs
@@ -227,7 +227,7 @@ namespace CesiumForUnity
         private List<string> _styles;
 
         /// <summary>
-        /// An array of JSON style objects that specify the appearance and
+        /// A list of JSON style objects that specify the appearance and
         /// detail level of map features such as roads, parks, and built-up areas.
         /// </summary>
         /// <remarks>

--- a/Runtime/CesiumGoogleMapsTilesRasterOverlay.cs
+++ b/Runtime/CesiumGoogleMapsTilesRasterOverlay.cs
@@ -1,0 +1,282 @@
+using Reinterop;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CesiumForUnity
+{
+    /// <summary>
+    /// The possible values of <see cref="CesiumGoogleMapTilesRasterOverlay.mapType"/>.
+    /// </summary>
+    public enum GoogleMapTilesMapType
+    {
+        /// <summary>
+        /// Satellite imagery.
+        /// </summary>
+        Satellite,
+
+        /// <summary>
+        /// The standard Google Maps painted map tiles.
+        /// </summary>
+        Roadmap,
+
+        /// <summary>
+        /// Terrain imagery.
+        /// </summary>
+        /// <remarks>
+        /// When selecting terrain as the map type, you must also add
+        /// <see cref="GoogleMapTilesLayerType.Roadmap"/> to
+        /// <see cref="CesiumGoogleMapTilesRasterOverlay.layerTypes"/>.
+        /// </remarks>
+        Terrain
+    };
+
+    /// <summary>
+    /// The possible values of <see cref="CesiumGoogleMapTilesRasterOverlay.scale"/>.
+    /// </summary>
+    public enum GoogleMapTilesScale
+    {
+        /// <summary>
+        /// The default.
+        /// </summary>
+        ScaleFactor1x,
+
+        /// <summary>
+        /// Doubles label size and removes minor feature labels.
+        /// </summary>
+        ScaleFactor2x,
+
+        /// <summary>
+        /// Quadruples label size and removes minor feature labels.
+        /// </summary>
+        ScaleFactor4x,
+    }
+
+    ///<summary>
+    ///The possible values of <see cref="CesiumGoogleMapTilesRasterOverlay.layerTypes"/>.
+    ///</summary>
+    public enum GoogleMapTilesLayerType
+    {
+        /// <summary>
+        /// Required if you specify <see cref="GoogleMapTilesMapType.Terrain"/>
+        /// as the map type. Can also be optionally overlaid on the satellite map type.
+        /// Has no effect on roadmap tiles.
+        /// </summary>
+        Roadmap,
+
+        /// <summary>
+        /// Shows Street View-enabled streets and locations using blue outlines
+        /// on the map.
+        /// </summary>
+        Streetview,
+
+        /// <summary>
+        /// Displays current traffic conditions.
+        /// </summary>
+        Traffic
+    };
+
+    /// <summary>
+    /// A raster overlay that directly accesses Google Map Tiles (2D).
+    /// If you're using Google Map Tiles via Cesium ion, use <see cref="CesiumIonRasterOverlay"/> instead.
+    /// </summary>
+    [ReinteropNativeImplementation(
+        "CesiumForUnityNative::CesiumGoogleMapTilesRasterOverlayImpl",
+        "CesiumGoogleMapTilesRasterOverlayImpl.h")]
+    [AddComponentMenu("Cesium/Cesium Google Map Tiles Raster Overlay")]
+    [IconAttribute("Packages/com.cesium.unity/Editor/Resources/Cesium-24x24.png")]
+    public partial class CesiumGoogleMapTilesRasterOverlay : CesiumRasterOverlay
+    {
+
+        [SerializeField]
+        private string _apiKey = "";
+
+        /// <summary>
+        /// The Google Map Tiles API key to use.
+        /// </summary>
+        public string apiKey
+        {
+            get => this._apiKey;
+            set
+            {
+                this._apiKey = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private GoogleMapTilesMapType _mapType = GoogleMapTilesMapType.Satellite;
+
+        /// <summary>
+        /// The type of base map.
+        /// </summary>
+        public GoogleMapTilesMapType mapType
+        {
+            get => this._mapType;
+            set
+            {
+                this._mapType = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private string _language = "en-US";
+
+        /// <summary>
+        /// An IETF language tag that specifies the language used to display
+        /// information on the tiles. For example, <c>en-US</c> specifies the English
+        /// language as spoken in the United States.
+        /// </summary>
+        public string language
+        {
+            get => this._language;
+            set
+            {
+                this._language = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private string _region = "US";
+
+        /// <summary>
+        /// A Common Locale Data Repository region identifier (two uppercase letters)
+        /// that represents the physical location of the user. For example, <c>US</c>.
+        /// </summary>
+        public string region
+        {
+            get => this._region;
+            set
+            {
+                this._region = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private GoogleMapTilesScale _scale = GoogleMapTilesScale.ScaleFactor1x;
+
+        /// <summary>
+        /// Scales-up the size of map elements (such as road labels), while
+        /// retaining the tile size and coverage area of the default tile.
+        /// </summary>
+        /// <remarks>
+        /// Increasing the scale also reduces the number of labels on the map, which
+        /// reduces clutter.
+        /// </remarks>
+        public GoogleMapTilesScale scale
+        {
+            get => this._scale;
+            set
+            {
+                this._scale = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private bool _highDpi;
+
+        /// <summary>
+        /// Specifies whether to return high-resolution tiles.
+        /// </summary>
+        /// <remarks>
+        /// <para>If the scale-factor is increased, <c>highDpi</c> is used to increase
+        /// the size of the tile. Normally, increasing the scale factor enlarges the
+        /// resulting tile into an image of the same size, which lowers quality. With
+        /// <c>highDpi</c>, the resulting size is also increased, preserving quality.
+        /// DPI stands for Dots per Inch, and High DPI means the tile renders using
+        /// more dots per inch than normal.
+        /// </para>
+        /// <para>
+        /// If <c>true</c>, then the number of pixels in each of the x and y
+        /// dimensions is multiplied by the scale factor (that is, 2x or 4x). The
+        /// coverage area of the tile remains unchanged. This parameter works only
+        /// with <see cref="scale"/> values of <c>2x</c> or <c>4x</c>. It has no 
+        /// effect on <c>1x</c> scale tiles.
+        /// </para>
+        /// </remarks>
+        public bool highDpi
+        {
+            get => this._highDpi; set
+            {
+                this._highDpi = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private List<GoogleMapTilesLayerType> _layerTypes;
+
+        /// <summary>
+        /// The layer types to be added to the map.
+        /// </summary>
+        public List<GoogleMapTilesLayerType> layerTypes
+        {
+            get => this._layerTypes;
+            set
+            {
+                this._layerTypes = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private List<string> _styles;
+
+        /// <summary>
+        /// An array of JSON style objects that specify the appearance and
+        /// detail level of map features such as roads, parks, and built-up areas.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Styling is used to customize the standard Google base map. The <c>styles</c>
+        /// parameter is valid only if the <see cref="mapType"/> is
+        /// <see cref="GoogleMapTilesMapType.Roadmap"/>.
+        /// </para>
+        /// <para>
+        /// For the complete style syntax, see the
+        /// <see href="https://developers.google.com/maps/documentation/tile/style-reference">
+        /// Style Reference.</see>
+        /// </para>
+        /// </remarks>
+        public List<string> styles
+        {
+            get => this._styles;
+            set
+            {
+                this._styles = value;
+                this.Refresh();
+            }
+        }
+
+        [SerializeField]
+        private bool _overlay = false;
+
+        /// <summary>
+        /// Specifies whether <see cref="layerTypes"/> are rendered as a separate overlay,
+        /// or combined with the base imagery.
+        /// </summary>
+        /// <remarks>
+        /// When <c>true</c>, the base map isn't displayed. If you haven't defined any
+        /// <c>layerTypes</c>, then this value is ignored.
+        /// </remarks>
+        public bool overlay
+        {
+            get => this._overlay;
+            set
+            {
+                this._overlay = value;
+                this.Refresh();
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override partial void AddToTileset(Cesium3DTileset tileset);
+
+        /// <inheritdoc/>
+        protected override partial void RemoveFromTileset(Cesium3DTileset tileset);
+    };
+}

--- a/Runtime/CesiumGoogleMapsTilesRasterOverlay.cs.meta
+++ b/Runtime/CesiumGoogleMapsTilesRasterOverlay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7cae66d51653994b8eed3a36ff03914
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/CesiumIonRasterOverlay.cs
+++ b/Runtime/CesiumIonRasterOverlay.cs
@@ -78,6 +78,23 @@ namespace CesiumForUnity
             }
         }
 
+        [SerializeField]
+        private string _assetOptions = "";
+
+        /// <summary>
+        /// Extra options to pass to Cesium ion when accessing the asset.
+        /// This should be a JSON string.
+        /// </summary>
+        public string assetOptions
+        {
+            get => this._assetOptions;
+            set
+            {
+                this._assetOptions = value;
+                this.Refresh();
+            }
+        }
+
         /// <inheritdoc/>
         protected override partial void AddToTileset(Cesium3DTileset tileset);
         /// <inheritdoc/>

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -77,7 +77,7 @@ namespace CesiumForUnity
             int pixelWidth = c.pixelWidth;
             float aspect = c.aspect;
             bool isOrtho = c.orthographic;
-            float orthoSize = c.orthographicSize;            
+            float orthoSize = c.orthographicSize;
             //IFormattable f = new Vector3();
             //IEquatable<Vector3> f2 = new Vector3();
 
@@ -319,6 +319,23 @@ namespace CesiumForUnity
             bingMapsRasterOverlay.bingMapsKey = bingMapsRasterOverlay.bingMapsKey;
             bingMapsRasterOverlay.mapStyle = bingMapsRasterOverlay.mapStyle;
             baseOverlay = bingMapsRasterOverlay;
+
+            CesiumGoogleMapTilesRasterOverlay googleMapTilesRasterOverlay =
+                go.GetComponent<CesiumGoogleMapTilesRasterOverlay>();
+            googleMapTilesRasterOverlay.apiKey = googleMapTilesRasterOverlay.apiKey;
+            googleMapTilesRasterOverlay.mapType = googleMapTilesRasterOverlay.mapType;
+            googleMapTilesRasterOverlay.language = googleMapTilesRasterOverlay.language;
+            googleMapTilesRasterOverlay.region = googleMapTilesRasterOverlay.region;
+            googleMapTilesRasterOverlay.scale = googleMapTilesRasterOverlay.scale;
+            googleMapTilesRasterOverlay.highDpi = googleMapTilesRasterOverlay.highDpi;
+            googleMapTilesRasterOverlay.layerTypes = googleMapTilesRasterOverlay.layerTypes;
+            googleMapTilesRasterOverlay.styles = googleMapTilesRasterOverlay.styles;
+            googleMapTilesRasterOverlay.overlay = googleMapTilesRasterOverlay.overlay;
+            baseOverlay = googleMapTilesRasterOverlay;
+
+            List<GoogleMapTilesLayerType> layers = new List<GoogleMapTilesLayerType>();
+            if (layers.Count > 0)
+                layers[0] = layers[0];
 
             CesiumTileMapServiceRasterOverlay tileMapServiceRasterOverlay =
                 go.GetComponent<CesiumTileMapServiceRasterOverlay>();

--- a/Runtime/ConfigureReinterop.cs
+++ b/Runtime/ConfigureReinterop.cs
@@ -300,6 +300,7 @@ namespace CesiumForUnity
             ionOverlay.ionAssetID = ionOverlay.ionAssetID;
             ionOverlay.ionAccessToken = ionOverlay.ionAccessToken;
             ionOverlay.ionServer = ionOverlay.ionServer;
+            ionOverlay.assetOptions = ionOverlay.assetOptions;
             ionOverlay.AddToTilesetLater(null);
 
             CesiumRasterOverlay overlay = go.GetComponent<CesiumRasterOverlay>();

--- a/native~/Runtime/src/CesiumGoogleMapTilesRasterOverlayImpl.cpp
+++ b/native~/Runtime/src/CesiumGoogleMapTilesRasterOverlayImpl.cpp
@@ -63,7 +63,7 @@ std::optional<std::vector<std::string>> getLayerTypes(
 
   int32_t count = layerTypes.Count();
   if (count > 0) {
-    result.reserve(layerTypes.Count());
+    result.reserve(count);
 
     for (int32_t i = 0; i < count; i++) {
       CesiumForUnity::GoogleMapTilesLayerType layerType = layerTypes[i];

--- a/native~/Runtime/src/CesiumGoogleMapTilesRasterOverlayImpl.cpp
+++ b/native~/Runtime/src/CesiumGoogleMapTilesRasterOverlayImpl.cpp
@@ -1,0 +1,194 @@
+#include "CesiumGoogleMapTilesRasterOverlayImpl.h"
+
+#include "Cesium3DTilesetImpl.h"
+#include "CesiumRasterOverlayUtility.h"
+
+#include <Cesium3DTilesSelection/Tileset.h>
+#include <CesiumGeospatial/Ellipsoid.h>
+#include <CesiumJsonReader/JsonObjectJsonHandler.h>
+#include <CesiumJsonReader/JsonReader.h>
+#include <CesiumRasterOverlays/GoogleMapTilesRasterOverlay.h>
+#include <CesiumUtility/JsonValue.h>
+
+#include <DotNet/CesiumForUnity/Cesium3DTileset.h>
+#include <DotNet/CesiumForUnity/CesiumGoogleMapTilesRasterOverlay.h>
+#include <DotNet/CesiumForUnity/CesiumRasterOverlay.h>
+#include <DotNet/CesiumForUnity/GoogleMapTilesLayerType.h>
+#include <DotNet/CesiumForUnity/GoogleMapTilesMapType.h>
+#include <DotNet/CesiumForUnity/GoogleMapTilesScale.h>
+#include <DotNet/System/Object.h>
+#include <DotNet/System/String.h>
+#include <DotNet/UnityEngine/Debug.h>
+
+using namespace Cesium3DTilesSelection;
+using namespace CesiumJsonReader;
+using namespace CesiumRasterOverlays;
+using namespace CesiumUtility;
+using namespace DotNet;
+
+namespace CesiumForUnityNative {
+
+namespace {
+std::string getMapType(CesiumForUnity::GoogleMapTilesMapType mapType) {
+  switch (mapType) {
+  case CesiumForUnity::GoogleMapTilesMapType::Roadmap:
+    return CesiumRasterOverlays::GoogleMapTilesMapType::roadmap;
+  case CesiumForUnity::GoogleMapTilesMapType::Terrain:
+    return CesiumRasterOverlays::GoogleMapTilesMapType::terrain;
+  case CesiumForUnity::GoogleMapTilesMapType::Satellite:
+  default:
+    return CesiumRasterOverlays::GoogleMapTilesMapType::satellite;
+  }
+}
+
+std::string getScale(CesiumForUnity::GoogleMapTilesScale scale) {
+  switch (scale) {
+  case CesiumForUnity::GoogleMapTilesScale::ScaleFactor4x:
+    return CesiumRasterOverlays::GoogleMapTilesScale::scaleFactor4x;
+  case CesiumForUnity::GoogleMapTilesScale::ScaleFactor2x:
+    return CesiumRasterOverlays::GoogleMapTilesScale::scaleFactor2x;
+  case CesiumForUnity::GoogleMapTilesScale::ScaleFactor1x:
+  default:
+    return CesiumRasterOverlays::GoogleMapTilesScale::scaleFactor1x;
+  }
+}
+
+std::optional<std::vector<std::string>> getLayerTypes(
+    const DotNet::System::Collections::Generic::List1<
+        CesiumForUnity::GoogleMapTilesLayerType>& layerTypes,
+    CesiumForUnity::GoogleMapTilesMapType mapType) {
+  std::vector<std::string> result;
+
+  bool hasRoadmap = false;
+
+  int32_t count = layerTypes.Count();
+  if (count > 0) {
+    result.reserve(layerTypes.Count());
+
+    for (int32_t i = 0; i < count; i++) {
+      CesiumForUnity::GoogleMapTilesLayerType layerType = layerTypes[i];
+      switch (layerType) {
+      case CesiumForUnity::GoogleMapTilesLayerType::Roadmap:
+        hasRoadmap = true;
+        result.emplace_back(GoogleMapTilesLayerType::layerRoadmap);
+        break;
+      case CesiumForUnity::GoogleMapTilesLayerType::Streetview:
+        result.emplace_back(GoogleMapTilesLayerType::layerStreetview);
+        break;
+      case CesiumForUnity::GoogleMapTilesLayerType::Traffic:
+        result.emplace_back(GoogleMapTilesLayerType::layerTraffic);
+        break;
+      }
+    }
+  }
+
+  if (mapType == CesiumForUnity::GoogleMapTilesMapType::Terrain &&
+      !hasRoadmap) {
+    UnityEngine::Debug::LogWarning(System::String(
+        "When the mapType is set to Terrain on "
+        "CesiumGoogleMapTilesRasterOverlay, layerTypes must contain "
+        "Roadmap."));
+  }
+
+  return result;
+}
+
+JsonValue::Array getStyles(
+    const DotNet::System::Collections::Generic::List1<DotNet::System::String>&
+        styles) {
+  int32_t count = styles.Count();
+
+  JsonValue::Array result;
+  result.reserve(count);
+
+  JsonObjectJsonHandler handler{};
+
+  for (int32_t i = 0; i < count; ++i) {
+    const System::String& style = styles[i];
+    std::string styleUtf8 = style.ToStlString();
+    ReadJsonResult<JsonValue> response = JsonReader::readJson(
+        std::span<const std::byte>(
+            reinterpret_cast<const std::byte*>(styleUtf8.data()),
+            styleUtf8.size()),
+        handler);
+
+    ErrorList errorList;
+    errorList.errors = std::move(response.errors);
+    errorList.warnings = std::move(response.warnings);
+    errorList.log(
+        spdlog::default_logger(),
+        fmt::format("Problems parsing JSON in element {} of Styles:", i));
+
+    if (response.value) {
+      result.emplace_back(std::move(*response.value));
+    }
+  }
+
+  return result;
+}
+
+} // namespace
+
+CesiumGoogleMapTilesRasterOverlayImpl::CesiumGoogleMapTilesRasterOverlayImpl(
+    const DotNet::CesiumForUnity::CesiumGoogleMapTilesRasterOverlay& overlay)
+    : _pOverlay(nullptr) {}
+
+CesiumGoogleMapTilesRasterOverlayImpl::
+    ~CesiumGoogleMapTilesRasterOverlayImpl() {}
+
+void CesiumGoogleMapTilesRasterOverlayImpl::AddToTileset(
+    const ::DotNet::CesiumForUnity::CesiumGoogleMapTilesRasterOverlay& overlay,
+    const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset) {
+  if (this->_pOverlay != nullptr) {
+    // Overlay already added.
+    return;
+  }
+
+  if (System::String::IsNullOrEmpty(overlay.apiKey())) {
+    // Don't create an overlay with an empty API key.
+    return;
+  }
+
+  Cesium3DTilesetImpl& tilesetImpl = tileset.NativeImplementation();
+  Tileset* pTileset = tilesetImpl.getTileset();
+  if (!pTileset)
+    return;
+
+  CesiumForUnity::CesiumRasterOverlay genericOverlay = overlay;
+  RasterOverlayOptions options =
+      CesiumRasterOverlayUtility::GetOverlayOptions(genericOverlay);
+
+  this->_pOverlay = new GoogleMapTilesRasterOverlay(
+      overlay.materialKey().ToStlString(),
+      CesiumRasterOverlays::GoogleMapTilesNewSessionParameters{
+          .key = overlay.apiKey().ToStlString(),
+          .mapType = getMapType(overlay.mapType()),
+          .language = overlay.language().ToStlString(),
+          .region = overlay.region().ToStlString(),
+          .scale = getScale(overlay.scale()),
+          .highDpi = overlay.highDpi(),
+          .layerTypes = getLayerTypes(overlay.layerTypes(), overlay.mapType()),
+          .styles = getStyles(overlay.styles()),
+          .overlay = overlay.overlay()},
+      options);
+
+  pTileset->getOverlays().add(this->_pOverlay);
+}
+void CesiumGoogleMapTilesRasterOverlayImpl::RemoveFromTileset(
+    const ::DotNet::CesiumForUnity::CesiumGoogleMapTilesRasterOverlay& overlay,
+    const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset) {
+  if (this->_pOverlay == nullptr)
+    return;
+
+  Cesium3DTilesetImpl& tilesetImpl = tileset.NativeImplementation();
+  Tileset* pTileset = tilesetImpl.getTileset();
+  if (!pTileset)
+    return;
+
+  CesiumUtility::IntrusivePointer<CesiumRasterOverlays::RasterOverlay>
+      pOverlay = this->_pOverlay.get();
+  pTileset->getOverlays().remove(pOverlay);
+  this->_pOverlay = nullptr;
+}
+
+} // namespace CesiumForUnityNative

--- a/native~/Runtime/src/CesiumGoogleMapTilesRasterOverlayImpl.h
+++ b/native~/Runtime/src/CesiumGoogleMapTilesRasterOverlayImpl.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "CesiumImpl.h"
+
+#include <CesiumUtility/IntrusivePointer.h>
+
+namespace DotNet::CesiumForUnity {
+class Cesium3DTileset;
+class CesiumGoogleMapTilesRasterOverlay;
+} // namespace DotNet::CesiumForUnity
+
+namespace CesiumRasterOverlays {
+class GoogleMapTilesRasterOverlay;
+}
+
+namespace CesiumForUnityNative {
+
+class CesiumGoogleMapTilesRasterOverlayImpl
+    : public CesiumImpl<CesiumGoogleMapTilesRasterOverlayImpl> {
+public:
+  CesiumGoogleMapTilesRasterOverlayImpl(
+      const DotNet::CesiumForUnity::CesiumGoogleMapTilesRasterOverlay& overlay);
+  ~CesiumGoogleMapTilesRasterOverlayImpl();
+
+  void AddToTileset(
+      const ::DotNet::CesiumForUnity::CesiumGoogleMapTilesRasterOverlay&
+          overlay,
+      const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset);
+  void RemoveFromTileset(
+      const ::DotNet::CesiumForUnity::CesiumGoogleMapTilesRasterOverlay&
+          overlay,
+      const ::DotNet::CesiumForUnity::Cesium3DTileset& tileset);
+
+private:
+  CesiumUtility::IntrusivePointer<
+      CesiumRasterOverlays::GoogleMapTilesRasterOverlay>
+      _pOverlay;
+};
+
+} // namespace CesiumForUnityNative

--- a/native~/Runtime/src/CesiumIonRasterOverlayImpl.cpp
+++ b/native~/Runtime/src/CesiumIonRasterOverlayImpl.cpp
@@ -67,6 +67,10 @@ void CesiumIonRasterOverlayImpl::AddToTileset(
         options,
         apiUrl);
 
+    if (!System::String::IsNullOrEmpty(overlay.assetOptions())) {
+      this->_pOverlay->setAssetOptions(overlay.assetOptions().ToStlString());
+    }
+
     pTileset->getOverlays().add(this->_pOverlay);
   } else {
     // Resolve the API URL if it's not already in progress.


### PR DESCRIPTION
## Description

Unity equivalent of https://github.com/CesiumGS/cesium-unreal/pull/1741.

This PR adds a new raster overlay type so users can stream 2D imagery directly from Google Maps with their own API key.

<img width="1885" height="1299" alt="image" src="https://github.com/user-attachments/assets/83685a51-7c3d-4613-9f2c-b00c88a31609" />

It also adds the `assetOptions` parameter to `CesiumIonRasterOverlay` so that users who stream the imagery from ion can still apply options like layer types / styles.

## Author checklist

- [ ] I have done a full self-review of my code.
- [ ] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- [ ] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [ ] I have updated the documentation as necessary.

## Testing plan

Reach out for a test API key. You can get a lot of mileage from just playing around with the options on the component. Example styles can be found in the API style reference, which is conveniently hyperlinked in the component inspector:

<img width="500"alt="image" src="https://github.com/user-attachments/assets/f3c5ec0b-5fa3-4af2-9424-9f0f47068095" />
