### PR TITLE
Import tangents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,7 @@
 ## ? - ?
 
 ##### Fixes :wrench:
-
-- Corrected glTF import process to flip textures and UV coordinates from glTF's U-right, V-down convention to comply with Unity's U-right, V-up coordinate system. 
+- Textures and UV coordinates from glTFs are now flipped to properly comply with Unity's U-right, V-up convention.
 - Modified model importer to include tangents when they are present in the source glTF. 
 
 ## v1.18.1 - 2025-10-01

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 ##### Fixes :wrench:
 
 - Textures and UV coordinates from glTFs are now flipped to properly comply with Unity's U-right, V-up convention.
-- Vertex tangents from glTFs are properly imported. 
+- Vertex tangents are now properly imported when present in glTFs.
 
 ## v1.18.1 - 2025-10-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Corrected glTF import process to flip textures and UV coordinates from glTF's U-right, V-down convention to comply with Unity's U-right, V-up coordinate system. 
+- Modified model importer to include tangents when they are present in the source glTF. 
 
 ## v1.18.1 - 2025-10-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ##### Fixes :wrench:
 - Textures and UV coordinates from glTFs are now flipped to properly comply with Unity's U-right, V-up convention.
-- Tangents from glTFs are properly imported. 
+- Vertex tangents from glTFs are properly imported. 
 
 ## v1.18.1 - 2025-10-01
 

--- a/CONTRIBUTING.md.meta
+++ b/CONTRIBUTING.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3fd6df72dd74e4b4a9a1096d82b3e1b5
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/native~/Runtime/src/TextureLoader.cpp
+++ b/native~/Runtime/src/TextureLoader.cpp
@@ -71,15 +71,14 @@ getUncompressedPixelFormat(const CesiumGltf::ImageAsset& image) {
 
 /**
  * Copy image data while flipping the data vertically. According to the glTF 2.0
- * spec, glTF stores textures in x-right, y-down (right-handed) coordinates.
+ * spec, glTF stores textures in x-right, y-down coordinates.
  * However, Unity uses x-right, y-up coordinates, so we need to flip the
- *textures and UV coordinates. See loadPrimitive() in
- *UnityPrepareRenderResources.cpp for the corresponding UV flip.
+ * textures and UV coordinates. See loadPrimitive() in
+ * UnityPrepareRenderResources.cpp for the corresponding UV flip.
  **/
-template <typename TSrcByte, typename TDstByte>
-void copyAndFlipY(
-    TSrcByte* dst,
-    const TDstByte* src,
+void copyAndFlipTexture(
+    std::uint8_t* dst,
+    const std::byte* src,
     const size_t dataLength,
     const size_t height) {
   assert(
@@ -88,8 +87,8 @@ void copyAndFlipY(
 
   const size_t stride = dataLength / height;
 
-  for (size_t j = 0; j < height; ++j) {
-    memcpy(dst, src + (height - j) * stride, stride);
+  for (int32_t i = int32_t(height) - 1; i >= 0; --i) {
+    memcpy(dst, src + i * stride, stride);
     dst += stride;
   }
 }
@@ -125,7 +124,7 @@ TextureLoader::loadTexture(const CesiumGltf::ImageAsset& image, bool sRGB) {
   if (image.mipPositions.empty()) {
     // No mipmaps, copy the whole thing and then let Unity generate mipmaps on a
     // worker thread.
-    copyAndFlipY(
+    copyAndFlipTexture(
         pixels,
         image.pixelData.data(),
         image.pixelData.size(),
@@ -136,26 +135,27 @@ TextureLoader::loadTexture(const CesiumGltf::ImageAsset& image, bool sRGB) {
     std::uint8_t* pWritePosition = pixels;
     const std::byte* pReadBuffer = image.pixelData.data();
 
-    // track square image dimension for each mip level
-    int32_t mipHeight = image.height;
+    // Track image height for each mip level
+    size_t mipHeight = image.height;
 
     for (const ImageAssetMipPosition& mip : image.mipPositions) {
       assert(mipHeight > 0 && "Invalid image size.");
       const size_t start = mip.byteOffset;
       const size_t end = mip.byteOffset + mip.byteSize;
       if (start >= textureLength || end > textureLength) {
+        // Invalid mip, skip this level.
         mipHeight /= 2;
-        continue; // invalid mip spec, ignore it
+        continue;
       }
 
-      copyAndFlipY(
+      copyAndFlipTexture(
           pWritePosition,
           pReadBuffer + start,
           mip.byteSize,
           mipHeight);
       pWritePosition += mip.byteSize;
       // adjust height for next mip level.
-      mipHeight /= 2;
+      mipHeight >>= 1;
     }
 
     result.Apply(false, true);

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -373,7 +373,8 @@ void loadPrimitive(
   auto tangentAcccessorIt = primitive.attributes.find("TANGENT");
   AccessorView<UnityEngine::Vector4> tangentView;
   if (tangentAcccessorIt != primitive.attributes.end()) {
-    tangentView = AccessorView<UnityEngine::Vector4>(gltf, tangentAcccessorIt->second);
+    tangentView =
+        AccessorView<UnityEngine::Vector4>(gltf, tangentAcccessorIt->second);
     hasTangents = tangentView.status() == AccessorViewStatus::Valid;
   }
 
@@ -638,7 +639,7 @@ void loadPrimitive(
         Vector2 texCoord = texCoordViews[texCoordIndex][vertexIndex];
         // flip Y to comply with Unity's left-handed UV coordinates
         texCoord.y = 1 - texCoord.y;
-        *reinterpret_cast<Vector2*>(pWritePos) =texCoord;
+        *reinterpret_cast<Vector2*>(pWritePos) = texCoord;
         pWritePos += sizeof(Vector2);
       }
     }

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -623,7 +623,7 @@ void loadPrimitive(
   }
 
   for (int64_t i = 0; i < vertexCount; ++i) {
-    TIndex vertexIndex = duplicateVertices ? indices[i] : i;
+    const TIndex vertexIndex = duplicateVertices ? indices[i] : i;
     *reinterpret_cast<Vector3*>(pWritePos) = positionView[vertexIndex];
     pWritePos += sizeof(Vector3);
 
@@ -658,7 +658,7 @@ void loadPrimitive(
 
   // Fill in vertex colors separately, if they exist.
   if (hasVertexColors) {
-    // Color comes after position and normal.
+    // Color comes after position, normal and tangent
     createAccessorView(
         gltf,
         colorAccessorIt->second,

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -637,7 +637,7 @@ void loadPrimitive(
       for (uint32_t texCoordIndex = 0; texCoordIndex < numTexCoords;
            ++texCoordIndex) {
         Vector2 texCoord = texCoordViews[texCoordIndex][vertexIndex];
-        // flip Y to comply with Unity's left-handed UV coordinates
+        // Flip Y to comply with Unity's V-up coordinate convention
         texCoord.y = 1 - texCoord.y;
         *reinterpret_cast<Vector2*>(pWritePos) = texCoord;
         pWritePos += sizeof(Vector2);
@@ -647,6 +647,7 @@ void loadPrimitive(
     for (int64_t i = 0; i < vertexCount; ++i) {
       *reinterpret_cast<Vector3*>(pWritePos) = positionView[i];
       pWritePos += sizeof(Vector3);
+
       if (hasNormals) {
         *reinterpret_cast<Vector3*>(pWritePos) = normalView[i];
         pWritePos += sizeof(Vector3);
@@ -663,7 +664,7 @@ void loadPrimitive(
       for (uint32_t texCoordIndex = 0; texCoordIndex < numTexCoords;
            ++texCoordIndex) {
         Vector2 texCoord = texCoordViews[texCoordIndex][i];
-        // flip Y to comply with Unity's left-handed UV coordinates
+        // Flip Y to comply with Unity's V-up coordinate convention
         texCoord.y = 1 - texCoord.y;
         *reinterpret_cast<Vector2*>(pWritePos) = texCoord;
         pWritePos += sizeof(Vector2);

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -670,7 +670,7 @@ void loadPrimitive(
             indices});
   }
 
-  if (computeFlatNormals) {
+  if (duplicateVertices) {
     // rewrite indices
     for (TIndex i = 0; i < indexCount; i++) {
       indices[i] = i;

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -635,8 +635,9 @@ void loadPrimitive(
       }
       for (uint32_t texCoordIndex = 0; texCoordIndex < numTexCoords;
            ++texCoordIndex) {
-        *reinterpret_cast<Vector2*>(pWritePos) =
-            texCoordViews[texCoordIndex][vertexIndex];
+        Vector2 texCoord = texCoordViews[texCoordIndex][vertexIndex];
+        texCoord.y = 1 - texCoord.y;
+        *reinterpret_cast<Vector2*>(pWritePos) =texCoord;
         pWritePos += sizeof(Vector2);
       }
     }

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -636,6 +636,7 @@ void loadPrimitive(
       for (uint32_t texCoordIndex = 0; texCoordIndex < numTexCoords;
            ++texCoordIndex) {
         Vector2 texCoord = texCoordViews[texCoordIndex][vertexIndex];
+        // flip Y to comply with Unity's left-handed UV coordinates
         texCoord.y = 1 - texCoord.y;
         *reinterpret_cast<Vector2*>(pWritePos) =texCoord;
         pWritePos += sizeof(Vector2);
@@ -650,18 +651,15 @@ void loadPrimitive(
         *reinterpret_cast<Vector3*>(pWritePos) = normalView[i];
         pWritePos += sizeof(Vector3);
       }
-
       if (hasTangents) {
         *reinterpret_cast<Vector4*>(pWritePos) = tangentView[i];
         pWritePos += sizeof(Vector4);
       }
-
       // Skip the slot allocated for vertex colors, we will fill them in
       // bulk later.
       if (hasVertexColors) {
         pWritePos += sizeof(uint32_t);
       }
-
       for (uint32_t texCoordIndex = 0; texCoordIndex < numTexCoords;
            ++texCoordIndex) {
         Vector2 texCoord = texCoordViews[texCoordIndex][i];

--- a/native~/Runtime/src/UnityPrepareRendererResources.cpp
+++ b/native~/Runtime/src/UnityPrepareRendererResources.cpp
@@ -370,7 +370,7 @@ void loadPrimitive(
   }
 
   bool hasTangents = false;
-  auto tangentAcccessorIt = primitive.attributes.find("TANGENT");
+  auto tangentAccessorIt = primitive.attributes.find("TANGENT");
   AccessorView<UnityEngine::Vector4> tangentView;
   if (tangentAcccessorIt != primitive.attributes.end()) {
     tangentView =


### PR DESCRIPTION
## Description

Previously, the glTF importer would ignore tangents in the model. This PR ensure that tangents in the vertex stream are properly imported and transferred to the relevant vertex buffer. 

(This depends on #611 so merge that first.)

## Author checklist

- [ ] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [x] I have done a full self-review of my code.
- [x] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- [ ] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [ ] I have updated the documentation as necessary.

## Testing plan

Load a glTF that includes tangents, such as the [glTF Normal Tangent Mirror Test](https://github.com/KhronosGroup/glTF-Sample-Models/blob/main/2.0/NormalTangentMirrorTest/README.md).
In Unity's Render Debugger, activate the Tangent material override and verify that tangents are included. 
By default, Unity provides `(1,0,0)` for tangents if they are missing. The tangent vertex attribute override should show something other than `(1,0,0)` . 

