### PR TITLE
Attempt to work around warning spam from Unity physics engine

### DIFF
--- a/native~/Runtime/src/UnityPrepareRendererResources.h
+++ b/native~/Runtime/src/UnityPrepareRendererResources.h
@@ -59,6 +59,19 @@ struct CesiumPrimitiveInfo {
    * the corresponding Unity texture coordinate index.
    */
   std::unordered_map<uint32_t, uint32_t> rasterOverlayUvIndexMap{};
+
+  /**
+   * @brief The scale factor that was used to divide each vertex position in
+   * this primitive when creating the Unity mesh. The primitive's transformation
+   * matrix must scale up (multiply) by this same factor in order to return the
+   * mesh to its original size.
+   *
+   * We do this silly dance because Unity (or perhaps PhysX) complains
+   * incessantly about meshes with triangles that are more than 500 units.
+   *
+   * For best precision, this factor should be a power of two.
+   */
+  double vertexScaleFactor = 1.0f;
 };
 
 /**


### PR DESCRIPTION
> Detected one or more triangles where the distance between any 2 vertices is greater than 500 units. The resulting Triangle Mesh can impact simulation and query stability. It is recommended to tessellate meshes that have large triangles.

This commit tries to avoid this warning by scaling down the vertex positions of every tile mesh to fit inside a cube with a diagonal <= 1 unit. And then scale it back up to its proper size via the transformation matrix.

It reduces the number of occurrences of this warning, but for some reason it doesn't eliminate them entirely.

Draft because I'd like to eliminate these warnings entirely, and I don't know why it isn't working.

This PR also gives each mesh a name derived from the tile's content URL, so that the warning tells us which tile is the problem. This should probably be removed before this is merged because the URLs can get quite long.