### PR TITLE
Remove unnecessary `#pragma once` from .cpp file

### DIFF
--- a/native~/Runtime/src/CesiumPropertyTablePropertyImpl.cpp
+++ b/native~/Runtime/src/CesiumPropertyTablePropertyImpl.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "CesiumPropertyTablePropertyImpl.h"
 
 #include "CesiumFeaturesMetadataUtility.h"


### PR DESCRIPTION
Trivial change because I'm tired of seeing this warning. 😆 