### PR TITLE
Fixed Cesium build for projects without 'com.unity.xr.management' installed

### DIFF
--- a/Runtime/CesiumPointCloudRenderer.cs
+++ b/Runtime/CesiumPointCloudRenderer.cs
@@ -1,6 +1,9 @@
 using UnityEngine;
 using UnityEngine.Rendering;
+
+#if ENABLE_XR_MODULE
 using UnityEngine.XR;
+#endif
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -98,11 +101,13 @@ namespace CesiumForUnity
                 this._pointMaterial.EnableKeyword("HAS_POINT_NORMALS");
             }
 
+#if ENABLE_XR_MODULE
             if (XRSettings.stereoRenderingMode == XRSettings.StereoRenderingMode.SinglePassInstanced ||
                 XRSettings.stereoRenderingMode == XRSettings.StereoRenderingMode.SinglePassMultiview)
             {
                 this._pointMaterial.EnableKeyword("INSTANCING_ON");
             }
+#endif
         }
 
         private float GetGeometricError(CesiumPointCloudShading pointCloudShading)


### PR DESCRIPTION
For most (if not all) Unity project templates the package com.unity.xr.management comes preinstalled. However, it is possible to remove that package afterwards.

Cesium gives a compilation error when that package is not installed:

```
Library/PackageCache/com.cesium.unity@03780efe4504/Runtime/CesiumPointCloudRenderer.cs(101,17): error CS0103: The name 'XRSettings' does not exist in the current context
```
That error can be fixed by adding `#if ENABLE_XR_MODULE` checks around the according code.

## Author checklist

- [x] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [x] I have done a full self-review of my code.
- [ ] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- [ ] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [ ] I have updated the documentation as necessary.
