### PR TITLE
Add support for KHR_materials_variants extension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## ? - ?
 
+##### Additions :tada:
+
+- Added support for the `KHR_materials_variants` glTF extension. Primitives with this extension will have a `CesiumMaterialVariants` component that allows switching between material variants at runtime using `SetVariant(int index)` or `SetVariant(string name)`.
+
+
 ##### Fixes :wrench:
 
 - Fixed a typo in the the name of the `CesiumGoogleMapTilesRasterOverlay.cs` file that prevented users from adding this component to a `GameObject` in more recent versions of Unity.

--- a/Source/Runtime/CesiumMaterialVariants.cs
+++ b/Source/Runtime/CesiumMaterialVariants.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CesiumForUnity
+{
+    /// <summary>
+    /// Represents KHR_materials_variants of a glTF primitive in a <see cref="Cesium3DTileset"/>.
+    /// Allows switching between different material variants at runtime.
+    /// </summary>
+    /// <remarks>
+    /// This component is automatically added to primitive game objects if they
+    /// contain the KHR_materials_variants extension.
+    /// </remarks>
+    [IconAttribute("Packages/com.cesium.unity/Editor/Resources/Cesium-24x24.png")]
+    [AddComponentMenu("")]
+    public partial class CesiumMaterialVariants : MonoBehaviour
+    {
+        /// <summary>
+        /// Names of all available variants for this model (from the root glTF extension).
+        /// </summary>
+        public string[] variantNames
+        {
+            get; internal set;
+        }
+
+        /// <summary>
+        /// The default material (the one specified in primitive.material).
+        /// </summary>
+        internal Material defaultMaterial
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Dictionary mapping variant indices to their corresponding materials.
+        /// Key = variant index, Value = Unity Material for that variant.
+        /// </summary>
+        internal Dictionary<int, Material> variantMaterials
+        {
+            get; set;
+        } = new Dictionary<int, Material>();
+
+        private MeshRenderer _meshRenderer;
+        private int _currentVariantIndex = -1; // -1 means default material is active
+
+        void Start()
+        {
+            _meshRenderer = GetComponent<MeshRenderer>();
+        }
+
+        /// <summary>
+        /// Gets the index of the currently active variant, or -1 if the default material is active.
+        /// </summary>
+        public int GetCurrentVariantIndex()
+        {
+            return _currentVariantIndex;
+        }
+
+        /// <summary>
+        /// Gets the name of the currently active variant, or "Default" if the default material is active.
+        /// </summary>
+        public string GetCurrentVariantName()
+        {
+            if (_currentVariantIndex < 0 || _currentVariantIndex >= variantNames.Length)
+            {
+                return "Default";
+            }
+            return variantNames[_currentVariantIndex];
+        }
+
+        /// <summary>
+        /// Sets the active material variant by index.
+        /// Use -1 to switch to the default material.
+        /// </summary>
+        /// <param name="variantIndex">The index of the variant to activate, or -1 for default.</param>
+        /// <returns>True if the variant was successfully set, false otherwise.</returns>
+        public bool SetVariant(int variantIndex)
+        {
+            if (_meshRenderer == null)
+            {
+                Debug.LogWarning("CesiumMaterialVariants: MeshRenderer not found.");
+                return false;
+            }
+
+            // Handle default material case
+            if (variantIndex < 0)
+            {
+                if (defaultMaterial != null)
+                {
+                    _meshRenderer.material = defaultMaterial;
+                    _currentVariantIndex = -1;
+                    return true;
+                }
+                Debug.LogWarning("CesiumMaterialVariants: Default material not available.");
+                return false;
+            }
+
+            // Validate variant index
+            if (variantIndex >= variantNames.Length)
+            {
+                Debug.LogWarning($"CesiumMaterialVariants: Variant index {variantIndex} is out of range. Available variants: {variantNames.Length}");
+                return false;
+            }
+
+            // Check if we have a material for this variant
+            if (variantMaterials.TryGetValue(variantIndex, out Material variantMaterial))
+            {
+                if (variantMaterial != null)
+                {
+                    _meshRenderer.material = variantMaterial;
+                    _currentVariantIndex = variantIndex;
+                    return true;
+                }
+                else
+                {
+                    Debug.LogWarning($"CesiumMaterialVariants: Material for variant '{variantNames[variantIndex]}' is null.");
+                    return false;
+                }
+            }
+
+            Debug.LogWarning($"CesiumMaterialVariants: No material found for variant '{variantNames[variantIndex]}' (index {variantIndex}).");
+            return false;
+        }
+
+        /// <summary>
+        /// Sets the active material variant by name.
+        /// Use "Default" or an empty string to switch to the default material.
+        /// </summary>
+        /// <param name="variantName">The name of the variant to activate.</param>
+        /// <returns>True if the variant was successfully set, false otherwise.</returns>
+        public bool SetVariant(string variantName)
+        {
+            if (string.IsNullOrEmpty(variantName) || variantName.Equals("Default", StringComparison.OrdinalIgnoreCase))
+            {
+                return SetVariant(-1);
+            }
+
+            for (int i = 0; i < variantNames.Length; i++)
+            {
+                if (variantNames[i].Equals(variantName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return SetVariant(i);
+                }
+            }
+
+            Debug.LogWarning($"CesiumMaterialVariants: Variant '{variantName}' not found. Available variants: {string.Join(", ", variantNames)}");
+            return false;
+        }
+
+        /// <summary>
+        /// Toggles between two specific variants. Useful for simple A/B switching.
+        /// </summary>
+        /// <param name="variantIndexA">First variant index.</param>
+        /// <param name="variantIndexB">Second variant index.</param>
+        public void ToggleBetween(int variantIndexA, int variantIndexB)
+        {
+            if (_currentVariantIndex == variantIndexA)
+            {
+                SetVariant(variantIndexB);
+            }
+            else
+            {
+                SetVariant(variantIndexA);
+            }
+        }
+
+        /// <summary>
+        /// Toggles between two specific variants by name.
+        /// </summary>
+        /// <param name="variantNameA">First variant name.</param>
+        /// <param name="variantNameB">Second variant name.</param>
+        public void ToggleBetween(string variantNameA, string variantNameB)
+        {
+            string currentName = GetCurrentVariantName();
+            if (currentName.Equals(variantNameA, StringComparison.OrdinalIgnoreCase))
+            {
+                SetVariant(variantNameB);
+            }
+            else
+            {
+                SetVariant(variantNameA);
+            }
+        }
+
+        /// <summary>
+        /// Gets a list of all available variant names.
+        /// </summary>
+        /// <returns>Array of variant names, or an empty array if none are available.</returns>
+        public string[] GetAvailableVariants()
+        {
+            return variantNames ?? Array.Empty<string>();
+        }
+    }
+}

--- a/Source/Runtime/CesiumMaterialVariants.cs
+++ b/Source/Runtime/CesiumMaterialVariants.cs
@@ -42,12 +42,8 @@ namespace CesiumForUnity
         } = new Dictionary<int, Material>();
 
         private MeshRenderer _meshRenderer;
+        private MeshRenderer CurrentMeshRenderer => _meshRenderer ??= GetComponent<MeshRenderer>();
         private int _currentVariantIndex = -1; // -1 means default material is active
-
-        void Start()
-        {
-            _meshRenderer = GetComponent<MeshRenderer>();
-        }
 
         /// <summary>
         /// Gets the index of the currently active variant, or -1 if the default material is active.
@@ -77,7 +73,7 @@ namespace CesiumForUnity
         /// <returns>True if the variant was successfully set, false otherwise.</returns>
         public bool SetVariant(int variantIndex)
         {
-            if (_meshRenderer == null)
+            if (CurrentMeshRenderer == null)
             {
                 Debug.LogWarning("CesiumMaterialVariants: MeshRenderer not found.");
                 return false;
@@ -88,7 +84,7 @@ namespace CesiumForUnity
             {
                 if (defaultMaterial != null)
                 {
-                    _meshRenderer.material = defaultMaterial;
+                    CurrentMeshRenderer.material = defaultMaterial;
                     _currentVariantIndex = -1;
                     return true;
                 }
@@ -108,7 +104,7 @@ namespace CesiumForUnity
             {
                 if (variantMaterial != null)
                 {
-                    _meshRenderer.material = variantMaterial;
+                    CurrentMeshRenderer.material = variantMaterial;
                     _currentVariantIndex = variantIndex;
                     return true;
                 }

--- a/Source/Runtime/CesiumMaterialVariants.cs.meta
+++ b/Source/Runtime/CesiumMaterialVariants.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c67c838ac98494b438cce99c757ac571

--- a/Source/Runtime/ConfigureReinterop.cs
+++ b/Source/Runtime/ConfigureReinterop.cs
@@ -844,6 +844,14 @@ namespace CesiumForUnity
             sets[0].propertyTableIndex = 0;
             sets[0].Dispose();
 
+            // CesiumMaterialVariants - for KHR_materials_variants support
+            CesiumMaterialVariants materialVariants = go.AddComponent<CesiumMaterialVariants>();
+            materialVariants = go.GetComponent<CesiumMaterialVariants>();
+            materialVariants.variantNames = new string[] { "variant1", "variant2" };
+            materialVariants.defaultMaterial = meshRenderer.sharedMaterial;
+            materialVariants.variantMaterials = new Dictionary<int, Material>();
+            materialVariants.variantMaterials.Add(0, meshRenderer.sharedMaterial);
+
             CesiumFeatureIdAttribute featureIdAttribute = new CesiumFeatureIdAttribute();
             featureIdAttribute.status = featureIdAttribute.status;
             featureIdAttribute.featureCount = 1;
@@ -1009,4 +1017,3 @@ namespace CesiumForUnity
         }
     }
 }
-

--- a/native~/src/Runtime/CesiumMaterialVariantsUtility.cpp
+++ b/native~/src/Runtime/CesiumMaterialVariantsUtility.cpp
@@ -23,7 +23,6 @@
 #include <DotNet/UnityEngine/HideFlags.h>
 #include <DotNet/UnityEngine/Material.h>
 #include <DotNet/UnityEngine/Object.h>
-#include <DotNet/UnityEngine/Resources.h>
 #include <DotNet/UnityEngine/Texture.h>
 #include <DotNet/UnityEngine/Vector4.h>
 #include <DotNet/UnityEngine/Rendering/CullMode.h>
@@ -40,6 +39,7 @@ CesiumMaterialVariantsUtility::addMaterialVariants(
     const CesiumGltf::MeshPrimitive& primitive,
     const CesiumPrimitiveInfo& primitiveInfo,
     const DotNet::UnityEngine::Material& defaultMaterial,
+    const DotNet::UnityEngine::Material& opaqueMaterial,
     const TilesetMaterialProperties& materialProperties) noexcept {
 
   // Get the model-level extension (contains variant names)
@@ -89,16 +89,9 @@ CesiumMaterialVariantsUtility::addMaterialVariants(
 
   variantsComponent.defaultMaterial(defaultMaterial);
 
-  // Load the base material for creating variant materials
-  UnityEngine::Material baseMaterial =
-      UnityEngine::Resources::Load<UnityEngine::Material>(
-          primitiveInfo.isUnlit
-              ? System::String("CesiumUnlitTilesetMaterial")
-              : System::String("CesiumDefaultTilesetMaterial"));
-
-  if (baseMaterial == nullptr) {
+  if (opaqueMaterial == nullptr) {
     UnityEngine::Debug::LogWarning(static_cast<System::Object>(System::String(
-        "CesiumMaterialVariants: Failed to load base material. Material variants will not be available.")));
+        "CesiumMaterialVariants: No opaque material provided. Material variants will not be available.")));
     return variantsComponent;
   }
 
@@ -109,9 +102,9 @@ CesiumMaterialVariantsUtility::addMaterialVariants(
     const CesiumGltf::Material* pVariantMaterial =
         CesiumGltf::Model::getSafe(&model.materials, materialIndex);
 
-    if (pVariantMaterial && baseMaterial != nullptr) {
+    if (pVariantMaterial) {
       UnityEngine::Material variantMaterial =
-          UnityEngine::Object::Instantiate(baseMaterial);
+          UnityEngine::Object::Instantiate(opaqueMaterial);
 
       if (variantMaterial == nullptr) {
         continue;

--- a/native~/src/Runtime/CesiumMaterialVariantsUtility.cpp
+++ b/native~/src/Runtime/CesiumMaterialVariantsUtility.cpp
@@ -1,0 +1,138 @@
+#include "CesiumMaterialVariantsUtility.h"
+
+#include "TextureLoader.h"
+#include "TilesetMaterialProperties.h"
+#include "UnityPrepareRendererResources.h"
+
+#include <CesiumGltf/ExtensionMeshPrimitiveKhrMaterialsVariants.h>
+#include <CesiumGltf/ExtensionModelKhrMaterialsVariants.h>
+#include <CesiumGltf/Material.h>
+#include <CesiumGltf/Model.h>
+#include <CesiumGltf/MeshPrimitive.h>
+#include <CesiumUtility/Tracing.h>
+
+#include <unordered_map>
+
+#include <DotNet/CesiumForUnity/CesiumMaterialVariants.h>
+#include <DotNet/System/Array1.h>
+#include <DotNet/System/Collections/Generic/Dictionary2.h>
+#include <DotNet/System/String.h>
+#include <DotNet/System/Object.h>
+#include <DotNet/UnityEngine/Debug.h>
+#include <DotNet/UnityEngine/GameObject.h>
+#include <DotNet/UnityEngine/HideFlags.h>
+#include <DotNet/UnityEngine/Material.h>
+#include <DotNet/UnityEngine/Object.h>
+#include <DotNet/UnityEngine/Resources.h>
+#include <DotNet/UnityEngine/Texture.h>
+#include <DotNet/UnityEngine/Vector4.h>
+#include <DotNet/UnityEngine/Rendering/CullMode.h>
+
+using namespace DotNet;
+using namespace DotNet::System::Collections::Generic;
+
+namespace CesiumForUnityNative {
+
+DotNet::CesiumForUnity::CesiumMaterialVariants
+CesiumMaterialVariantsUtility::addMaterialVariants(
+    const DotNet::UnityEngine::GameObject& primitiveGameObject,
+    const CesiumGltf::Model& model,
+    const CesiumGltf::MeshPrimitive& primitive,
+    const CesiumPrimitiveInfo& primitiveInfo,
+    const DotNet::UnityEngine::Material& defaultMaterial,
+    const TilesetMaterialProperties& materialProperties) noexcept {
+
+  // Get the model-level extension (contains variant names)
+  const CesiumGltf::ExtensionModelKhrMaterialsVariants* pModelVariants =
+      model.getExtension<CesiumGltf::ExtensionModelKhrMaterialsVariants>();
+  if (!pModelVariants || pModelVariants->variants.empty()) {
+    return nullptr;
+  }
+
+  // Get the primitive-level extension (contains variant-to-material mappings)
+  const CesiumGltf::ExtensionMeshPrimitiveKhrMaterialsVariants* pPrimitiveVariants =
+      primitive.getExtension<CesiumGltf::ExtensionMeshPrimitiveKhrMaterialsVariants>();
+  if (!pPrimitiveVariants || pPrimitiveVariants->mappings.empty()) {
+    return nullptr;
+  }
+
+  // Build the variant-to-material map from the primitive extension
+  std::unordered_map<int32_t, int32_t> variantMaterialMap;
+  for (const auto& mapping : pPrimitiveVariants->mappings) {
+    int32_t materialIndex = mapping.material;
+    for (int64_t variantIndex : mapping.variants) {
+      if (variantIndex >= 0 && variantIndex <= INT32_MAX) {
+        variantMaterialMap[static_cast<int32_t>(variantIndex)] = materialIndex;
+      }
+    }
+  }
+
+  if (variantMaterialMap.empty()) {
+    return nullptr;
+  }
+
+  // Create the component
+  CesiumForUnity::CesiumMaterialVariants variantsComponent =
+      primitiveGameObject.AddComponent<CesiumForUnity::CesiumMaterialVariants>();
+
+  if (variantsComponent == nullptr) {
+    return nullptr;
+  }
+
+  // Set variant names from model extension
+  const auto& variants = pModelVariants->variants;
+  System::Array1<System::String> variantNames(static_cast<std::int32_t>(variants.size()));
+  for (size_t i = 0; i < variants.size(); i++) {
+    variantNames.Item(static_cast<std::int32_t>(i), System::String(variants[i].name));
+  }
+  variantsComponent.variantNames(variantNames);
+
+  variantsComponent.defaultMaterial(defaultMaterial);
+
+  // Load the base material for creating variant materials
+  UnityEngine::Material baseMaterial =
+      UnityEngine::Resources::Load<UnityEngine::Material>(
+          primitiveInfo.isUnlit
+              ? System::String("CesiumUnlitTilesetMaterial")
+              : System::String("CesiumDefaultTilesetMaterial"));
+
+  if (baseMaterial == nullptr) {
+    UnityEngine::Debug::LogWarning(static_cast<System::Object>(System::String(
+        "CesiumMaterialVariants: Failed to load base material. Material variants will not be available.")));
+    return variantsComponent;
+  }
+
+  // Create materials for each variant
+  auto variantMaterialsDict = Dictionary2<int32_t, UnityEngine::Material>();
+
+  for (const auto& [variantIndex, materialIndex] : variantMaterialMap) {
+    const CesiumGltf::Material* pVariantMaterial =
+        CesiumGltf::Model::getSafe(&model.materials, materialIndex);
+
+    if (pVariantMaterial && baseMaterial != nullptr) {
+      UnityEngine::Material variantMaterial =
+          UnityEngine::Object::Instantiate(baseMaterial);
+
+      if (variantMaterial == nullptr) {
+        continue;
+      }
+
+      variantMaterial.hideFlags(UnityEngine::HideFlags::HideAndDontSave);
+
+      setGltfMaterialParameterValues(
+          model,
+          primitiveInfo,
+          *pVariantMaterial,
+          variantMaterial,
+          materialProperties);
+
+      variantMaterialsDict.Add(variantIndex, variantMaterial);
+    }
+  }
+
+  variantsComponent.variantMaterials(variantMaterialsDict);
+
+  return variantsComponent;
+}
+
+} // namespace CesiumForUnityNative

--- a/native~/src/Runtime/CesiumMaterialVariantsUtility.h
+++ b/native~/src/Runtime/CesiumMaterialVariantsUtility.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "UnityPrepareRendererResources.h"
+
+namespace DotNet::CesiumForUnity {
+class CesiumMaterialVariants;
+} // namespace DotNet::CesiumForUnity
+
+namespace DotNet::UnityEngine {
+class GameObject;
+class Material;
+} // namespace DotNet::UnityEngine
+
+namespace CesiumGltf {
+struct Model;
+struct MeshPrimitive;
+} // namespace CesiumGltf
+
+namespace CesiumForUnityNative {
+
+class CesiumMaterialVariantsUtility {
+public:
+  /**
+   * @brief Adds a CesiumMaterialVariants component to a primitive GameObject
+   * if the primitive has the KHR_materials_variants extension.
+   *
+   * This function handles all extension parsing internally, following the same
+   * pattern as CesiumFeaturesMetadataUtility.
+   *
+   * @param primitiveGameObject The primitive GameObject to add the component to.
+   * @param model The glTF model containing the materials and variant definitions.
+   * @param primitive The glTF primitive (checked for KHR_materials_variants extension).
+   * @param primitiveInfo Information about the primitive, including UV mappings.
+   * @param defaultMaterial The default Unity material for this primitive.
+   * @param materialProperties Material properties for creating variant materials.
+   * @return The CesiumMaterialVariants component, or null if no variants exist.
+   */
+  static DotNet::CesiumForUnity::CesiumMaterialVariants addMaterialVariants(
+      const DotNet::UnityEngine::GameObject& primitiveGameObject,
+      const CesiumGltf::Model& model,
+      const CesiumGltf::MeshPrimitive& primitive,
+      const CesiumPrimitiveInfo& primitiveInfo,
+      const DotNet::UnityEngine::Material& defaultMaterial,
+      const TilesetMaterialProperties& materialProperties) noexcept;
+};
+
+} // namespace CesiumForUnityNative

--- a/native~/src/Runtime/CesiumMaterialVariantsUtility.h
+++ b/native~/src/Runtime/CesiumMaterialVariantsUtility.h
@@ -32,6 +32,7 @@ public:
    * @param primitive The glTF primitive (checked for KHR_materials_variants extension).
    * @param primitiveInfo Information about the primitive, including UV mappings.
    * @param defaultMaterial The default Unity material for this primitive.
+   * @param opaqueMaterial The tileset's base opaque material to use for variant materials.
    * @param materialProperties Material properties for creating variant materials.
    * @return The CesiumMaterialVariants component, or null if no variants exist.
    */
@@ -41,6 +42,7 @@ public:
       const CesiumGltf::MeshPrimitive& primitive,
       const CesiumPrimitiveInfo& primitiveInfo,
       const DotNet::UnityEngine::Material& defaultMaterial,
+      const DotNet::UnityEngine::Material& opaqueMaterial,
       const TilesetMaterialProperties& materialProperties) noexcept;
 };
 

--- a/native~/src/Runtime/UnityPrepareRendererResources.cpp
+++ b/native~/src/Runtime/UnityPrepareRendererResources.cpp
@@ -1,6 +1,7 @@
 #include "UnityPrepareRendererResources.h"
 
 #include "CesiumFeaturesMetadataUtility.h"
+#include "CesiumMaterialVariantsUtility.h"
 #include "TextureLoader.h"
 #include "TilesetMaterialProperties.h"
 #include "UnityLifetime.h"
@@ -30,6 +31,7 @@
 #include <DotNet/CesiumForUnity/CesiumModelMetadata.h>
 #include <DotNet/CesiumForUnity/CesiumObjectPool1.h>
 #include <DotNet/CesiumForUnity/CesiumObjectPools.h>
+#include <DotNet/CesiumForUnity/CesiumMaterialVariants.h>
 #include <DotNet/CesiumForUnity/CesiumPointCloudRenderer.h>
 #include <DotNet/CesiumForUnity/CesiumPrimitiveFeatures.h>
 #include <DotNet/CesiumForUnity/CesiumPropertyTable.h>
@@ -1081,6 +1083,10 @@ gltfVectorToUnityVector(const std::vector<double>& values, float defaultValue) {
   return result;
 }
 
+} // namespace
+
+namespace CesiumForUnityNative {
+
 void setGltfMaterialParameterValues(
     const CesiumGltf::Model& model,
     const CesiumPrimitiveInfo& primitiveInfo,
@@ -1387,7 +1393,8 @@ void setGltfMaterialParameterValues(
     }
   }
 }
-} // namespace
+
+} // namespace CesiumForUnityNative
 
 void* UnityPrepareRendererResources::prepareInMainThread(
     Cesium3DTilesSelection::Tile& tile,
@@ -1644,6 +1651,15 @@ void* UnityPrepareRendererResources::prepareInMainThread(
                 *pFeatures);
           }
         }
+
+        // Add material variants component if the primitive has variants
+        CesiumMaterialVariantsUtility::addMaterialVariants(
+            primitiveGameObject,
+            gltf,
+            primitive,
+            primitiveInfo,
+            material,
+            materialProperties);
       });
 
   tilesetComponent.BroadcastNewGameObjectCreated(*pModelGameObject);

--- a/native~/src/Runtime/UnityPrepareRendererResources.cpp
+++ b/native~/src/Runtime/UnityPrepareRendererResources.cpp
@@ -1659,6 +1659,7 @@ void* UnityPrepareRendererResources::prepareInMainThread(
             primitive,
             primitiveInfo,
             material,
+            opaqueMaterial,
             materialProperties);
       });
 

--- a/native~/src/Runtime/UnityPrepareRendererResources.h
+++ b/native~/src/Runtime/UnityPrepareRendererResources.h
@@ -136,4 +136,17 @@ private:
   TilesetMaterialProperties _materialProperties;
 };
 
+/**
+ * @brief Sets glTF material parameter values on a Unity material.
+ *
+ * This function is used internally to apply glTF material properties
+ * (base color, metallic, roughness, textures, etc.) to a Unity Material.
+ */
+void setGltfMaterialParameterValues(
+    const CesiumGltf::Model& model,
+    const CesiumPrimitiveInfo& primitiveInfo,
+    const CesiumGltf::Material& gltfMaterial,
+    const DotNet::UnityEngine::Material& unityMaterial,
+    const TilesetMaterialProperties& materialProperties);
+
 } // namespace CesiumForUnityNative


### PR DESCRIPTION
## Description

This PR exposes the KHR_materials_variants extension at the Unity level for runtime-switching of textures. Primitives with the extension enabled will automatically add a `CesiumMaterialVariants` component which can be toggled between variants with `SetVariant(int index)` or `SetVariant(string name)`.

## Author checklist

- [x] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [x] I have done a full self-review of my code.
- [x] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- [x] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [x] I have updated the documentation as necessary.


## Testing plan

- In Unity, create a CesiumTileset pointed at a tileset with the KHR_materials_variants extension.
- Create a script that does something like:
```
[SerializeField]
private Cesium3DTileset tileset;

void Update()
{
    if (Keyboard.current.aKey.wasPressedThisFrame)
    {
        if (tileset != null)
        {
            var childVariants = tileset.GetComponentsInChildren<CesiumMaterialVariants>(true);

            foreach (var v in childVariants)
            {

                bool success = v.SetVariant(v.GetCurrentVariantIndex() == 0 ? -1 : 0);
                Debug.Log($"SetVariant result: {success}, now at: {v.GetCurrentVariantName()}");
            }

        }
    }
}
```
- Expect to see tiles toggle between available variants.