### PR TITLE
Make Reinterop skip attributes with 'Ignore' attribute

### DIFF
--- a/Reinterop~/Fields.cs
+++ b/Reinterop~/Fields.cs
@@ -42,6 +42,10 @@ namespace Reinterop
             // TODO: Implement these as functions that call into the C#?
             if (field.IsStatic)
                 return;
+                
+            // Skip any fields with an "Ignore" attribute.
+            if (field.GetAttributes().Where(attrib => attrib.AttributeClass != null && (attrib.AttributeClass.Name == "IgnoreAttribute")).Any())
+                return;
 
             string fieldName = CSharpTypeUtility.GetFieldName(field);
             bool isPrivate = CSharpTypeUtility.GetFieldIsPrivate(field);


### PR DESCRIPTION
## Description

This PR supports #656 and enables the use of Unity's `Color32` struct with Reinterop.

As @kring discovered, `Color32` has an `int` field that doesn't actually contribute to the struct's size. Reinterop was turning this into an actual `int` field, preventing the actual `r`,`g` etc. bytes from storing value.

```c#
[StructLayout(LayoutKind.Explicit)]
[UsedByNativeCode]
public struct Color32 : IEquatable<Color32>, IFormattable
{
    [FieldOffset(0)]
    [Ignore(DoesNotContributeToSize = true)]
    private int rgba;

    //
    // Summary:
    //     Red component of the color.
    [FieldOffset(0)]
    public byte r;

    //
    // Summary:
    //     Green component of the color.
    [FieldOffset(1)]
    public byte g;

    //
    // Summary:
    //     Blue component of the color.
    [FieldOffset(2)]
    public byte b;

    //
    // Summary:
    //     Alpha component of the color.
    [FieldOffset(3)]
    public byte a;
 
```

The easiest way to avoid this is to tell Reinterop to ignore anything with that `Ignore` attribute. It hasn't resulted in any surprises in any other generated classes; I checked with diff tools.

## Testing plan

1. Rebuild Reinterop using `dotnet publish Reinterop~ -o . ` before opening Unity.
2. Open Unity, then add a line like `Color32 color = new Color32(0, 0, 0, 1)` to Reinterop
3. Wait for Reinterop to complete, then navigate to `native~/generated-Editor/include/DotNet/UnityEngine/Color32.h`.
4. Confirm that the uint8 `r`, `g`, `b,` and `a` fields show up, but not an int32 `rgba` field.