### PR TITLE
Fix documentation input path

### DIFF
--- a/Documentation~/Doxyfile
+++ b/Documentation~/Doxyfile
@@ -949,6 +949,16 @@ INPUT                  = ./Source/Runtime \
                          ./CHANGES.md \
                          ./Reinterop~/README.md
 
+# If the IMPLICIT_DIR_DOCS tag is set to YES, any README.md file found in 
+# sub-directories of the project's root, is used as the documentation for 
+# that sub-directory, except when the README.md starts with a \dir, \page 
+# or \mainpage command. If set to NO, the README.md file needs to start 
+# with an explicit \dir command in order to be used as directory documentation.
+#
+# The default value is: YES.
+
+IMPLICIT_DIR_DOCS = NO
+
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
 # libiconv (or the iconv built into libc) for the transcoding. See the libiconv


### PR DESCRIPTION
## Description

Our Unity docs were broken after #642 because the documentation path for it had not been updated for the new folder structure. This fixes that path.

## Issue number or link

N/A

## Author checklist

- [X] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [X] I have done a full self-review of my code.
- ~[ ] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).~
- ~[ ] I have added or updated unit tests to ensure consistent code coverage as necessary.~
- [X] I have updated the documentation as necessary.

## Testing plan

The docs should work locally using `npm run doxygen`.