### PR TITLE
Use new Unity licenses on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           mkdir -p $ENV:PROGRAMDATA/Unity/config
           $filename="$ENV:PROGRAMDATA/Unity/config/services-config.json"
-          $text='{"licensingServiceBaseUrl":"http://localhost:12331","enableEntitlementLicensing":true,"clientConnectTimeoutSec":120,"clientHandshakeTimeoutSec":60,"toolset":"UnityLicenseServer_16768262570522_2"}'
+          $text='{"licensingServiceBaseUrl":"http://localhost:12331","enableEntitlementLicensing":true,"clientConnectTimeoutSec":120,"clientHandshakeTimeoutSec":60,"toolset":"UnityLicenseServer_16768262570522_9"}'
           [IO.File]::WriteAllLines($filename,$text)
       - name: Update the version in Cesium.cpp
         run: |
@@ -248,7 +248,7 @@ jobs:
           sudo mkdir -p "/Library/Application Support/Unity/config"
           sudo chmod g+w "/Library/Application Support/Unity"
           sudo chmod g+w "/Library/Application Support/Unity/config"
-          sudo echo '{"licensingServiceBaseUrl": "http://localhost:12331","enableEntitlementLicensing": true,"clientConnectTimeoutSec": 60,"clientHandshakeTimeoutSec": 120,"toolset":"UnityLicenseServer_16768262570522_2"}' > "/Library/Application Support/Unity/config/services-config.json"
+          sudo echo '{"licensingServiceBaseUrl": "http://localhost:12331","enableEntitlementLicensing": true,"clientConnectTimeoutSec": 60,"clientHandshakeTimeoutSec": 120,"toolset":"UnityLicenseServer_16768262570522_9"}' > "/Library/Application Support/Unity/config/services-config.json"
       - name: Create SSH tunnel to Unity License Server
         env:
           UNITY_LICENSE_SERVER_SSH_KEY: ${{ secrets.UNITY_LICENSE_SERVER_SSH_KEY }}
@@ -403,7 +403,7 @@ jobs:
         run: |
           mkdir -p $ENV:PROGRAMDATA/Unity/config
           $filename="$ENV:PROGRAMDATA/Unity/config/services-config.json"
-          $text='{"licensingServiceBaseUrl":"http://localhost:12331","enableEntitlementLicensing":true,"clientConnectTimeoutSec":120,"clientHandshakeTimeoutSec":60,"toolset":"UnityLicenseServer_16768262643415_1"}'
+          $text='{"licensingServiceBaseUrl":"http://localhost:12331","enableEntitlementLicensing":true,"clientConnectTimeoutSec":120,"clientHandshakeTimeoutSec":60,"toolset":"UnityLicenseServer_16768335856821_1"}'
           [IO.File]::WriteAllLines($filename,$text)
       - name: Update the version in Cesium.cpp
         run: |


### PR DESCRIPTION
Every year we get new Unity licenses, which annoyingly have new entitlement IDs. So this PR updates CI to use them.