### PR TITLE
Add Force Double Sided toggle to Cesium3DTileset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## ? - ?
 
+##### Additions :tada:
+
+- Added a `Force Double Sided` toggle to `Cesium3DTileset`. When enabled, all tile primitives are rendered with back-face culling disabled, regardless of the glTF material's `doubleSided` flag or the cull state of a user-supplied `Opaque Material`.
+
 ##### Fixes :wrench:
 
 - The native Android library (`libCesiumForUnityNative.so`) is now built with 16 KB ELF segment alignment, enabling compatibility with Android 15+ devices that use 16 KB memory pages.

--- a/Source/Editor/Cesium3DTilesetEditor.cs
+++ b/Source/Editor/Cesium3DTilesetEditor.cs
@@ -36,6 +36,7 @@ namespace CesiumForUnity
         //private SerializedProperty _useLodTransitions;
         //private SerializedProperty _lodTransitionLength;
         private SerializedProperty _generateSmoothNormals;
+        private SerializedProperty _forceDoubleSided;
 
         private SerializedProperty _pointCloudShading;
 
@@ -85,6 +86,8 @@ namespace CesiumForUnity
             //    this.serializedObject.FindProperty("_lodTransitionLength");
             this._generateSmoothNormals =
                 this.serializedObject.FindProperty("_generateSmoothNormals");
+            this._forceDoubleSided =
+                this.serializedObject.FindProperty("_forceDoubleSided");
             this._ignoreKhrMaterialsUnlit = this.serializedObject.FindProperty("_ignoreKhrMaterialsUnlit");
 
             this._pointCloudShading = this.serializedObject.FindProperty("_pointCloudShading");
@@ -428,6 +431,14 @@ namespace CesiumForUnity
                 "normals requires duplicating vertices. This option allows the glTFs to be " +
                 "rendered with smooth normals instead when the original glTF is missing normals.");
             EditorGUILayout.PropertyField(this._generateSmoothNormals, generateSmoothNormalsContent);
+
+            GUIContent forceDoubleSidedContent = new GUIContent(
+                "Force Double Sided",
+                "Disable back-face culling on every tile material, ignoring the " +
+                "glTF doubleSided flag. Use this when you assign a custom Opaque " +
+                "Material with double-sided rendering and don't want Cesium to " +
+                "overwrite that setting per tile.");
+            EditorGUILayout.PropertyField(this._forceDoubleSided, forceDoubleSidedContent);
 
             var ignoreKhrMaterialsUnlit = new GUIContent(
                 "Ignore KHR_materials_unlit",

--- a/Source/Runtime/Cesium3DTileset.cs
+++ b/Source/Runtime/Cesium3DTileset.cs
@@ -590,6 +590,29 @@ namespace CesiumForUnity
         }
 
         [SerializeField]
+        private bool _forceDoubleSided = false;
+
+        /// <summary>
+        /// When enabled, all tile primitives are rendered with back-face culling
+        /// disabled, regardless of the glTF material's doubleSided flag or the
+        /// settings on a user-supplied opaqueMaterial.
+        /// </summary>
+        /// <remarks>
+        /// Useful when assigning a custom Material whose Render Face is set to
+        /// Both - Cesium would otherwise overwrite the material's cull state from
+        /// the glTF on every tile load.
+        /// </remarks>
+        public bool forceDoubleSided
+        {
+            get => this._forceDoubleSided;
+            set
+            {
+                this._forceDoubleSided = value;
+                this.RecreateTileset();
+            }
+        }
+
+        [SerializeField]
         private bool _ignoreKhrMaterialsUnlit = false;
 
         /// <summary>

--- a/Source/Runtime/ConfigureReinterop.cs
+++ b/Source/Runtime/ConfigureReinterop.cs
@@ -295,6 +295,7 @@ namespace CesiumForUnity
             //tileset.useLodTransitions = tileset.useLodTransitions;
             //tileset.lodTransitionLength = tileset.lodTransitionLength;
             tileset.generateSmoothNormals = tileset.generateSmoothNormals;
+            tileset.forceDoubleSided = tileset.forceDoubleSided;
             tileset.ignoreKhrMaterialsUnlit = tileset.ignoreKhrMaterialsUnlit;
             tileset.createPhysicsMeshes = tileset.createPhysicsMeshes;
             tileset.suspendUpdate = tileset.suspendUpdate;

--- a/native~/src/Runtime/UnityPrepareRendererResources.cpp
+++ b/native~/src/Runtime/UnityPrepareRendererResources.cpp
@@ -1586,6 +1586,21 @@ void* UnityPrepareRendererResources::prepareInMainThread(
               materialProperties);
         }
 
+        if (tilesetComponent.forceDoubleSided()) {
+          material.SetFloat(
+              materialProperties.getDoubleSidedEnableID(),
+              1.0f);
+          material.SetFloat(
+              materialProperties.getCullID(),
+              float(UnityEngine::Rendering::CullMode::Off));
+          material.SetFloat(
+              materialProperties.getCullModeID(),
+              float(UnityEngine::Rendering::CullMode::Off));
+          material.SetFloat(
+              materialProperties.getBuiltInCullModeID(),
+              float(UnityEngine::Rendering::CullMode::Off));
+        }
+
         if (primitiveInfo.containsPoints) {
           CesiumForUnity::CesiumPointCloudRenderer pointCloudRenderer =
               primitiveGameObject


### PR DESCRIPTION
## Description

Adds an opt-in `Force Double Sided` boolean to `Cesium3DTileset`. When enabled, every per-primitive material has `_DoubleSidedEnable = 1` and `_Cull / _CullMode / _BUILTIN_CullMode = Off`, applied **after** the per-primitive glTF material values are written.

This makes it possible to assign a custom `Opaque Material` with `Render Face = Both` (URP) or its built-in / HDRP equivalent and have that setting actually stick. Currently, the cull state on every cloned material is overwritten on each tile load from `gltfMaterial.doubleSided` (see #491 for why that override exists), so user-supplied materials with double-sided rendering silently revert to back-face culling.

Default is `false`, so the existing glTF-spec-driven behavior introduced in #491 is unchanged for anyone who doesn't opt in.

**Where the override is applied (native):** outside the existing `if (pMaterial) { setGltfMaterialParameterValues(...); }` block in `UnityPrepareRendererResources.cpp`, so it runs after the glTF write and also covers primitives that have no glTF material attached.

**How the C# property reaches native code:** standard Reinterop wiring — `_forceDoubleSided` field + `forceDoubleSided` property on `Cesium3DTileset`, an exposure line in `ConfigureReinterop.cs`, and `tilesetComponent.forceDoubleSided()` at the native call site. No header changes — Reinterop generates the binding.

## Issue number or link

No tracking issue — small additive feature. Happy to open one if preferred.

## Author checklist

- [x] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [x] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- [x] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [x] I have done a full self-review of my code.
- [x] I have updated the documentation as necessary.

## Testing plan

Manual, in both URP and Built-in (have not yet verified HDRP, where the original #491 had quirks).

1. Fresh scene, `Cesium3DTileset` with `Opaque Material = None`, `Force Double Sided = false` — default behavior preserved:
   - Tiles whose glTF has `doubleSided = false` are back-face culled.
   - Tiles whose glTF has `doubleSided = true` render from both sides.
2. Same scene, flip `Force Double Sided = true` — every tile renders both sides. Runtime per-primitive material has `_Cull == 0`, `_CullMode == 0`, `_DoubleSidedEnable == 1`.
3. Duplicate `CesiumDefaultTilesetMaterial`, set `Render Face = Back` so `_Cull = 2`, assign to `Opaque Material`, toggle `Force Double Sided = true` — Cesium still renders double-sided (verifies the toggle wins over the source material as well).
4. Same custom material, `Force Double Sided = false` — cull state matches the glTF (original behavior).
5. Inspector: the new "Force Double Sided" entry appears in the Render section between "Generate Smooth Normals" and "Ignore KHR_materials_unlit", with the tooltip on hover.
