### PR TITLE
Fix reference to GeoJsonDocumentRasterOverlay

### DIFF
--- a/native~/CMakeLists.txt
+++ b/native~/CMakeLists.txt
@@ -189,6 +189,7 @@ target_link_libraries(
       Cesium3DTilesSelection
       CesiumAsync
       CesiumIonClient
+      CesiumVectorOverlays
     PRIVATE
       tidy-static
       enum-flags

--- a/native~/src/Runtime/CesiumGeoJsonDocumentRasterOverlayImpl.cpp
+++ b/native~/src/Runtime/CesiumGeoJsonDocumentRasterOverlayImpl.cpp
@@ -7,10 +7,10 @@
 #include "UnityExternals.h"
 
 #include <Cesium3DTilesSelection/Tileset.h>
-#include <CesiumRasterOverlays/GeoJsonDocumentRasterOverlay.h>
 #include <CesiumUtility/Color.h>
 #include <CesiumVectorData/GeoJsonDocument.h>
 #include <CesiumVectorData/VectorStyle.h>
+#include <CesiumVectorOverlays/GeoJsonDocumentRasterOverlay.h>
 
 #include <DotNet/CesiumForUnity/Cesium3DTileset.h>
 #include <DotNet/CesiumForUnity/CesiumGeoJsonDocument.h>
@@ -22,7 +22,7 @@
 #include <spdlog/spdlog.h>
 
 using namespace Cesium3DTilesSelection;
-using namespace CesiumRasterOverlays;
+using namespace CesiumVectorOverlays;
 using namespace CesiumVectorData;
 using namespace DotNet;
 

--- a/native~/src/Runtime/CesiumGeoJsonDocumentRasterOverlayImpl.cpp
+++ b/native~/src/Runtime/CesiumGeoJsonDocumentRasterOverlayImpl.cpp
@@ -23,6 +23,7 @@
 
 using namespace Cesium3DTilesSelection;
 using namespace CesiumVectorOverlays;
+using namespace CesiumRasterOverlays;
 using namespace CesiumVectorData;
 using namespace DotNet;
 

--- a/native~/src/Runtime/CesiumGeoJsonDocumentRasterOverlayImpl.h
+++ b/native~/src/Runtime/CesiumGeoJsonDocumentRasterOverlayImpl.h
@@ -9,7 +9,7 @@ class Cesium3DTileset;
 class CesiumGeoJsonDocumentRasterOverlay;
 } // namespace DotNet::CesiumForUnity
 
-namespace CesiumRasterOverlays {
+namespace CesiumVectorOverlays {
 class GeoJsonDocumentRasterOverlay;
 }
 
@@ -34,7 +34,7 @@ public:
 
 private:
   CesiumUtility::IntrusivePointer<
-      CesiumRasterOverlays::GeoJsonDocumentRasterOverlay>
+      CesiumVectorOverlays::GeoJsonDocumentRasterOverlay>
       _pOverlay;
 };
 


### PR DESCRIPTION
Quick fix to let Cesium for Unity build with the vector tiles branch.

This should only be merged in after CesiumGS/cesium-native#1365 is.