### PR TITLE
Use image-library branch of cesium-native

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,8 +64,6 @@ jobs:
             vcpkg-windows-${{ hashFiles('native~/vcpkg/ports/**/vcpkg.json', 'native~/vcpkg/triplets/**/*', 'native~/extern/*toolchain.cmake') }}-
       - name: Install latest ninja and cmake
         uses: lukka/get-cmake@latest
-        with:
-          cmakeVersion: "3.31.6"
       - name: Set up MSVC developer command prompt
         uses: ilammy/msvc-dev-cmd@v1
       - name: Install nasm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,8 @@ jobs:
         uses: lukka/get-cmake@latest
         with:
           cmakeVersion: "3.31.6"
+      - name: Set up MSVC developer command prompt
+        uses: ilammy/msvc-dev-cmd@v1
       - name: Install nasm
         uses: ilammy/setup-nasm@v1.5.1
       - name: Install wget

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,8 +64,6 @@ jobs:
             vcpkg-windows-${{ hashFiles('native~/vcpkg/ports/**/vcpkg.json', 'native~/vcpkg/triplets/**/*', 'native~/extern/*toolchain.cmake') }}-
       - name: Install latest ninja and cmake
         uses: lukka/get-cmake@latest
-      - name: Set up MSVC developer command prompt
-        uses: ilammy/msvc-dev-cmd@v1
       - name: Install nasm
         uses: ilammy/setup-nasm@v1.5.1
       - name: Install wget

--- a/native~/src/Runtime/Cesium3DTilesetImpl.cpp
+++ b/native~/src/Runtime/Cesium3DTilesetImpl.cpp
@@ -10,6 +10,7 @@
 #include <Cesium3DTilesSelection/EllipsoidTilesetLoader.h>
 #include <Cesium3DTilesSelection/Tileset.h>
 #include <CesiumGeospatial/GlobeTransforms.h>
+#include <CesiumImage/Ktx2TranscodeTargets.h>
 #include <CesiumIonClient/Connection.h>
 #include <CesiumRasterOverlays/IonRasterOverlay.h>
 
@@ -627,7 +628,7 @@ void Cesium3DTilesetImpl::LoadTileset(
   TilesetContentOptions contentOptions{};
   contentOptions.generateMissingNormalsSmooth = tileset.generateSmoothNormals();
 
-  CesiumGltf::SupportedGpuCompressedPixelFormats supportedFormats;
+  CesiumImage::SupportedGpuCompressedPixelFormats supportedFormats;
   supportedFormats.ETC2_RGBA = UnityEngine::SystemInfo::IsFormatSupported(
       DotNet::UnityEngine::Experimental::Rendering::GraphicsFormat::
           RGBA_ETC2_SRGB,
@@ -683,7 +684,7 @@ void Cesium3DTilesetImpl::LoadTileset(
           DotNet::UnityEngine::Experimental::Rendering::FormatUsage::Sample);
 
   contentOptions.ktx2TranscodeTargets =
-      CesiumGltf::Ktx2TranscodeTargets(supportedFormats, false);
+      CesiumImage::Ktx2TranscodeTargets(supportedFormats, false);
 
   contentOptions.applyTextureTransform = false;
 

--- a/native~/src/Runtime/CesiumFeatureIdTextureImpl.cpp
+++ b/native~/src/Runtime/CesiumFeatureIdTextureImpl.cpp
@@ -107,7 +107,7 @@ std::int64_t CesiumFeatureIdTextureImpl::GetFeatureIdFromRaycastHit(
       this->_indexAccessor);
 
   std::array<glm::dvec2, 3> uvs;
-  std::array<glm::vec3, 3> positions;
+  std::array<glm::dvec3, 3> positions;
 
   for (size_t i = 0; i < positions.size(); i++) {
     int64_t index = vertexIndices[i];
@@ -129,7 +129,7 @@ std::int64_t CesiumFeatureIdTextureImpl::GetFeatureIdFromRaycastHit(
     if (!maybePosition) {
       return -1;
     }
-    positions[i] = glm::vec3(*maybePosition);
+    positions[i] = *maybePosition;
   }
 
   // The barycentric coordinates in RaycastHit don't align with the positions
@@ -143,9 +143,9 @@ std::int64_t CesiumFeatureIdTextureImpl::GetFeatureIdFromRaycastHit(
   glm::dvec3 barycentricCoordinates;
   bool foundIntersection = CesiumGeometry::IntersectionTests::pointInTriangle(
       glm::dvec3(localPosition.x, localPosition.y, localPosition.z),
-      glm::dvec3(positions[0]),
-      glm::dvec3(positions[1]),
-      glm::dvec3(positions[2]),
+      positions[0],
+      positions[1],
+      positions[2],
       barycentricCoordinates);
   if (!foundIntersection) {
     return -1;

--- a/native~/src/Runtime/CesiumFeatureIdTextureImpl.cpp
+++ b/native~/src/Runtime/CesiumFeatureIdTextureImpl.cpp
@@ -91,7 +91,7 @@ std::int64_t CesiumFeatureIdTextureImpl::GetFeatureIdFromRaycastHit(
     return -1;
   }
 
-  if (this->_positionAccessor.status() !=
+  if (std::visit(CesiumGltf::StatusFromAccessor{}, this->_positionAccessor) !=
       CesiumGltf::AccessorViewStatus::Valid) {
     return -1;
   }
@@ -123,10 +123,13 @@ std::int64_t CesiumFeatureIdTextureImpl::GetFeatureIdFromRaycastHit(
     }
     uvs[i] = *maybeTexCoord;
 
-    CesiumGltf::AccessorTypes::VEC3<float> position =
-        this->_positionAccessor[index];
-    positions[i] =
-        glm::vec3(position.value[0], position.value[1], position.value[2]);
+    std::optional<glm::dvec3> maybePosition = std::visit(
+        CesiumGltf::PositionFromAccessor{index},
+        this->_positionAccessor);
+    if (!maybePosition) {
+      return -1;
+    }
+    positions[i] = glm::vec3(*maybePosition);
   }
 
   // The barycentric coordinates in RaycastHit don't align with the positions

--- a/native~/src/Runtime/TextureLoader.cpp
+++ b/native~/src/Runtime/TextureLoader.cpp
@@ -15,13 +15,14 @@
 #include <cstring>
 
 using namespace CesiumGltf;
+using namespace CesiumImage;
 using namespace DotNet;
 
 namespace CesiumForUnityNative {
 
 namespace {
 UnityEngine::TextureFormat
-getCompressedPixelFormat(const CesiumGltf::ImageAsset& image) {
+getCompressedPixelFormat(const CesiumImage::ImageAsset& image) {
   switch (image.compressedPixelFormat) {
   case GpuCompressedPixelFormat::ETC1_RGB:
     return UnityEngine::TextureFormat::ETC_RGB4;
@@ -55,7 +56,7 @@ getCompressedPixelFormat(const CesiumGltf::ImageAsset& image) {
 }
 
 UnityEngine::TextureFormat
-getUncompressedPixelFormat(const CesiumGltf::ImageAsset& image) {
+getUncompressedPixelFormat(const CesiumImage::ImageAsset& image) {
   switch (image.channels) {
   case 1:
     return UnityEngine::TextureFormat::R8;
@@ -72,7 +73,7 @@ getUncompressedPixelFormat(const CesiumGltf::ImageAsset& image) {
 } // namespace
 
 UnityEngine::Texture
-TextureLoader::loadTexture(const CesiumGltf::ImageAsset& image, bool sRGB) {
+TextureLoader::loadTexture(const CesiumImage::ImageAsset& image, bool sRGB) {
   CESIUM_TRACE("TextureLoader::loadTexture");
   std::int32_t mipCount =
       image.mipPositions.empty() ? 1 : std::int32_t(image.mipPositions.size());

--- a/native~/src/Runtime/TextureLoader.h
+++ b/native~/src/Runtime/TextureLoader.h
@@ -5,8 +5,11 @@
 namespace CesiumGltf {
 struct Model;
 struct Texture;
-struct ImageAsset;
 } // namespace CesiumGltf
+
+namespace CesiumImage {
+struct ImageAsset;
+} // namespace CesiumImage
 
 namespace DotNet::UnityEngine {
 class Texture;
@@ -17,7 +20,7 @@ namespace CesiumForUnityNative {
 class TextureLoader {
 public:
   static ::DotNet::UnityEngine::Texture
-  loadTexture(const CesiumGltf::ImageAsset& image, bool sRGB);
+  loadTexture(const CesiumImage::ImageAsset& image, bool sRGB);
 
   static ::DotNet::UnityEngine::Texture loadTexture(
       const CesiumGltf::Model& model,

--- a/native~/src/Runtime/UnityPrepareRendererResources.cpp
+++ b/native~/src/Runtime/UnityPrepareRendererResources.cpp
@@ -18,6 +18,7 @@
 #include <CesiumGltf/KhrTextureTransform.h>
 #include <CesiumGltfContent/GltfUtilities.h>
 #include <CesiumGltfReader/GltfReader.h>
+#include <CesiumImage/ImageDecoder.h>
 #include <CesiumUtility/ScopeGuard.h>
 
 #include <DotNet/CesiumForUnity/Cesium3DTileInfo.h>
@@ -83,6 +84,7 @@ using namespace CesiumForUnityNative;
 using namespace CesiumGeometry;
 using namespace CesiumGeospatial;
 using namespace CesiumGltf;
+using namespace CesiumImage;
 using namespace CesiumUtility;
 using namespace DotNet;
 
@@ -283,7 +285,7 @@ void generateMipMaps(
         case CesiumGltf::Sampler::MinFilter::LINEAR_MIPMAP_NEAREST:
         case CesiumGltf::Sampler::MinFilter::NEAREST_MIPMAP_LINEAR:
         case CesiumGltf::Sampler::MinFilter::NEAREST_MIPMAP_NEAREST:
-          CesiumGltfReader::ImageDecoder::generateMipMaps(*pImage->pAsset);
+          CesiumImage::ImageDecoder::generateMipMaps(*pImage->pAsset);
         }
       }
     }
@@ -1795,7 +1797,7 @@ void UnityPrepareRendererResources::free(
 void* UnityPrepareRendererResources::prepareRasterInLoadThread(
     CesiumImage::ImageAsset& image,
     const std::any& rendererOptions) {
-  CesiumGltfReader::ImageDecoder::generateMipMaps(image);
+  CesiumImage::ImageDecoder::generateMipMaps(image);
   return nullptr;
 }
 

--- a/native~/src/Runtime/UnityPrepareRendererResources.cpp
+++ b/native~/src/Runtime/UnityPrepareRendererResources.cpp
@@ -1793,7 +1793,7 @@ void UnityPrepareRendererResources::free(
 }
 
 void* UnityPrepareRendererResources::prepareRasterInLoadThread(
-    CesiumGltf::ImageAsset& image,
+    CesiumImage::ImageAsset& image,
     const std::any& rendererOptions) {
   CesiumGltfReader::ImageDecoder::generateMipMaps(image);
   return nullptr;

--- a/native~/src/Runtime/UnityPrepareRendererResources.h
+++ b/native~/src/Runtime/UnityPrepareRendererResources.h
@@ -101,7 +101,7 @@ public:
       void* pMainThreadResult) noexcept override;
 
   virtual void* prepareRasterInLoadThread(
-      CesiumGltf::ImageAsset& image,
+      CesiumImage::ImageAsset& image,
       const std::any& rendererOptions) override;
 
   virtual void* prepareRasterInMainThread(


### PR DESCRIPTION
## Description

This PR updates code for the new `CesiumImage` namespace in cesium-native.

Depends on https://github.com/CesiumGS/cesium-native/pull/1388 so merge that first.

Additionally, fixes a Windows CI build failure due to the new runner images by removing the requirement for CMake 3.31.

## Issue number or link

## Author checklist

- [X] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [X] I have done a full self-review of my code.
- ~[ ] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).~
- ~[ ] I have added or updated unit tests to ensure consistent code coverage as necessary.~
- ~[ ] I have updated the documentation as necessary.~

## Testing plan

Spot check the samples just to ensure everything loads as expected!