### PR TITLE
Fixed TokenTroubleshooting for CesiumGeoJsonDocumentRasterOverlay

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 
 In addition to the above, this release updates [cesium-native](https://github.com/CesiumGS/cesium-native) from v0.61.0 to v0.62.0. See the [changelog](https://github.com/CesiumGS/cesium-native/blob/main/CHANGES.md) for a complete list of changes in cesium-native.
 
+##### Fixes :wrench:
+- Fixed a `NullReferenceException` thrown when opening the Cesium ion token troubleshooting window for a `CesiumGeoJsonDocumentRasterOverlay`.
+
 ## v1.23.3 - 2026-06-01
 
 ##### Fixes :wrench:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 - Added support for the Linux platform (x86-64 only).
 
+##### Fixes :wrench:
+
+- Fixed a `NullReferenceException` thrown when opening the Cesium ion token troubleshooting window for a `CesiumGeoJsonDocumentRasterOverlay`.
+
 ## v1.24.0 - 2026-07-01
 
 ##### Additions :tada:
@@ -13,9 +17,6 @@
 - Added support for rendering glTFs with line primitives.
 
 In addition to the above, this release updates [cesium-native](https://github.com/CesiumGS/cesium-native) from v0.61.0 to v0.62.0. See the [changelog](https://github.com/CesiumGS/cesium-native/blob/main/CHANGES.md) for a complete list of changes in cesium-native.
-
-##### Fixes :wrench:
-- Fixed a `NullReferenceException` thrown when opening the Cesium ion token troubleshooting window for a `CesiumGeoJsonDocumentRasterOverlay`.
 
 ## v1.23.3 - 2026-06-01
 

--- a/EditorTests/TestIonTokenTroubleshootingWindow.cs
+++ b/EditorTests/TestIonTokenTroubleshootingWindow.cs
@@ -1,0 +1,36 @@
+using CesiumForUnity;
+using NUnit.Framework;
+using UnityEngine;
+
+public class TestIonTokenTroubleshootingWindow
+{
+    [Test]
+    public void ShowWindowForGeoJsonDocumentRasterOverlayDoesNotThrow()
+    {
+        GameObject go = new GameObject("GeoJsonOverlay");
+        CesiumGeoJsonDocumentRasterOverlay overlay = go.AddComponent<CesiumGeoJsonDocumentRasterOverlay>();
+
+        try
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                IonTokenTroubleshootingWindow.ShowWindow(overlay, false);
+            });
+
+            CesiumIonAsset asset = new CesiumIonAsset(overlay);
+            Assert.IsFalse(asset.IsNull());
+            Assert.AreEqual(overlay, asset.geoJsonOverlay);
+            Assert.AreEqual(overlay.ionServer, asset.geoJsonOverlay.ionServer);
+        }
+        finally
+        {
+            IonTokenTroubleshootingWindow[] openWindows = Resources.FindObjectsOfTypeAll<IonTokenTroubleshootingWindow>();
+            foreach (IonTokenTroubleshootingWindow window in openWindows)
+            {
+                window.Close();
+            }
+
+            Object.DestroyImmediate(go);
+        }
+    }
+}

--- a/EditorTests/TestIonTokenTroubleshootingWindow.cs.meta
+++ b/EditorTests/TestIonTokenTroubleshootingWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f7a1c2e9d8b4a4e8c6f0a1b2c3d4e5f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/Editor/ConfigureReinteropEditor.cs
+++ b/Source/Editor/ConfigureReinteropEditor.cs
@@ -226,6 +226,9 @@ namespace CesiumForUnity
             ionOverlay = asset.overlay;
             server = ionOverlay.ionServer;
 
+            CesiumGeoJsonDocumentRasterOverlay geoJsonDocOverlay = asset.geoJsonOverlay;
+            server = geoJsonDocOverlay.ionServer;
+
             AssetTroubleshootingDetails assetDetails = troubleshootingWindow.assetDetails;
             assetDetails.assetExistsInUserAccount = true;
             assetDetails.loaded = true;

--- a/native~/src/Editor/IonTokenTroubleshootingWindowImpl.cpp
+++ b/native~/src/Editor/IonTokenTroubleshootingWindowImpl.cpp
@@ -5,6 +5,7 @@
 
 #include <DotNet/CesiumForUnity/AssetTroubleshootingDetails.h>
 #include <DotNet/CesiumForUnity/Cesium3DTileset.h>
+#include <DotNet/CesiumForUnity/CesiumGeoJsonDocumentRasterOverlay.h>
 #include <DotNet/CesiumForUnity/CesiumIonAsset.h>
 #include <DotNet/CesiumForUnity/CesiumIonRasterOverlay.h>
 #include <DotNet/CesiumForUnity/CesiumIonServer.h>
@@ -31,6 +32,8 @@ getServer(const DotNet::CesiumForUnity::IonTokenTroubleshootingWindow& window) {
     return asset.tileset().ionServer();
   } else if (asset.overlay() != nullptr) {
     return asset.overlay().ionServer();
+  } else if (asset.geoJsonOverlay() != nullptr) {
+    return asset.geoJsonOverlay().ionServer();
   } else {
     return CesiumForUnity::CesiumIonServer(nullptr);
   }


### PR DESCRIPTION
## Description

tldr: 

Clicking "Troubleshoot Token" on a `CesiumGeoJsonDocumentRasterOverlay` Component causes a `NullReferenceException`, because of a missing Implementation.

non-tldr:

The main root of the issue lies in a missing implementation inside the `getServer` function of `IonTokenTroubleshootingWindowImpl.cpp`.

When the `CesiumIonAsset` used in the window is created, this constructor is called:
```csharp
public CesiumIonAsset(CesiumGeoJsonDocumentRasterOverlay overlay)
{
    this._type = AssetType.GeoJsonOverlay;
    this._geoJsonOverlay = overlay;
}
```
Consequently, `getServer` returns a `nullptr` in the final else block because both `asset.tileset` and `asset.overlay` are never set.
However, the constructor in `CesiumIonAsset.cs` specifically sets the `_geoJsonOverlay` variable (which has a public getter), which we can use here.

(This follows the same pattern as `_tileset` and `_overlay`)

So. Eventually, the issue can be fixed by adding a check for `asset.geoJsonOverlay` (and adding it to `ConfigureReinteropEditor.cs`'s `ExposeToCPP` of course).

## Issue number or link

I very briefly mentioned this bug [here](https://community.cesium.com/t/introducing-efficient-geojson-cutouts/46510/11)

## Author checklist

- [x] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [x] I have done a full self-review of my code.
- [x] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
_(However, I wasn't sure where to put it, so I just added it to the latest changes....😅)_
- [x] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [x] I have updated the documentation as necessary.

## Testing plan

In the current version of the plugin clicking "Troubleshoot Token" on a `CesiumGeoJsonDocumentRasterOverlay` Component causes a `NullReferenceException`.

After implementing the fix, everything works as expected.