### PR TITLE
Add CesiumVectorPointStyle for GeoJSON point rendering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Added support for the Linux platform (x86-64 only).
+- Added `CesiumVectorPointStyle` and a `pointStyle` field on `CesiumVectorStyle`, enabling `CesiumGeoJsonDocumentRasterOverlay` to render GeoJSON `Point` and `MultiPoint` features.
 
 ## v1.24.0 - 2026-07-01
 

--- a/Source/Runtime/CesiumVectorStyle.cs
+++ b/Source/Runtime/CesiumVectorStyle.cs
@@ -157,6 +157,61 @@ namespace CesiumForUnity
     }
 
     /// <summary>
+    /// The style used to draw points.
+    /// </summary>
+    [Serializable]
+    public struct CesiumVectorPointStyle
+    {
+        /// <summary>
+        /// The radius of the point in pixels.
+        /// </summary>
+        [Tooltip("The radius of the point in pixels.")]
+        [Min(0)]
+        public double radius;
+
+        /// <summary>
+        /// Whether the point should be filled.
+        /// </summary>
+        [Tooltip("Whether the point should be filled.")]
+        public bool fill;
+
+        /// <summary>
+        /// If fill is true, this style will be used when filling the point.
+        /// </summary>
+        [Tooltip("If fill is true, this style will be used when filling the point.")]
+        public CesiumVectorPolygonFillStyle fillStyle;
+
+        /// <summary>
+        /// Whether the point should be outlined.
+        /// </summary>
+        [Tooltip("Whether the point should be outlined.")]
+        public bool outline;
+
+        /// <summary>
+        /// If outline is true, this style will be used when outlining the point.
+        /// </summary>
+        [Tooltip("If outline is true, this style will be used when outlining the point.")]
+        public CesiumVectorLineStyle outlineStyle;
+
+        /// <summary>
+        /// Creates a default point style with a 5 pixel radius, fill enabled, and
+        /// outline disabled.
+        /// </summary>
+        /// <remarks>
+        /// Fill is enabled by default because the underlying native point style
+        /// renders nothing when neither fill nor outline is set.
+        /// </remarks>
+        public static CesiumVectorPointStyle Default => new CesiumVectorPointStyle
+        {
+            radius = 5.0,
+            fill = true,
+            fillStyle = CesiumVectorPolygonFillStyle.Default,
+            outline = false,
+            outlineStyle = CesiumVectorLineStyle.Default
+        };
+    }
+
+    /// <summary>
     /// Style information to use when drawing vector data.
     /// </summary>
     [Serializable]
@@ -175,12 +230,19 @@ namespace CesiumForUnity
         public CesiumVectorPolygonStyle polygonStyle;
 
         /// <summary>
+        /// Styles to use when drawing points.
+        /// </summary>
+        [Tooltip("Styles to use when drawing points.")]
+        public CesiumVectorPointStyle pointStyle;
+
+        /// <summary>
         /// Creates a default vector style.
         /// </summary>
         public static CesiumVectorStyle Default => new CesiumVectorStyle
         {
             lineStyle = CesiumVectorLineStyle.Default,
-            polygonStyle = CesiumVectorPolygonStyle.Default
+            polygonStyle = CesiumVectorPolygonStyle.Default,
+            pointStyle = CesiumVectorPointStyle.Default
         };
     }
 }

--- a/Source/Runtime/ConfigureReinterop.cs
+++ b/Source/Runtime/ConfigureReinterop.cs
@@ -1013,6 +1013,18 @@ namespace CesiumForUnity
             polygonStyleV.outline = outlineEnabled;
             CesiumVectorLineStyle outlineStyle = polygonStyleV.outlineStyle;
             polygonStyleV.outlineStyle = outlineStyle;
+            CesiumVectorPointStyle pointStyleV = vectorStyle.pointStyle;
+            vectorStyle.pointStyle = pointStyleV;
+            double pointRadius = pointStyleV.radius;
+            pointStyleV.radius = pointRadius;
+            bool pointFillEnabled = pointStyleV.fill;
+            pointStyleV.fill = pointFillEnabled;
+            CesiumVectorPolygonFillStyle pointFillStyle = pointStyleV.fillStyle;
+            pointStyleV.fillStyle = pointFillStyle;
+            bool pointOutlineEnabled = pointStyleV.outline;
+            pointStyleV.outline = pointOutlineEnabled;
+            CesiumVectorLineStyle pointOutlineStyle = pointStyleV.outlineStyle;
+            pointStyleV.outlineStyle = pointOutlineStyle;
             baseOverlay = geoJsonOverlay;
 
             TestGltfModel testModel = new TestGltfModel();

--- a/Tests/TestCesiumVectorStyle.cs
+++ b/Tests/TestCesiumVectorStyle.cs
@@ -106,46 +106,6 @@ public class TestCesiumVectorStyle
 
     #endregion
 
-    #region CesiumVectorPointStyle Tests
-
-    [Test]
-    public void PointStyleDefaultHasFillEnabledOutlineDisabled()
-    {
-        CesiumVectorPointStyle style = CesiumVectorPointStyle.Default;
-
-        Assert.AreEqual(5.0, style.radius, 0.001);
-        Assert.IsTrue(style.fill);
-        Assert.IsFalse(style.outline);
-    }
-
-    [Test]
-    public void PointStyleCanEnableBothFillAndOutline()
-    {
-        CesiumVectorPointStyle style = new CesiumVectorPointStyle();
-        style.radius = 8.0;
-        style.fill = true;
-        style.fillStyle = CesiumVectorPolygonFillStyle.Default;
-        style.outline = true;
-        style.outlineStyle = CesiumVectorLineStyle.Default;
-
-        Assert.AreEqual(8.0, style.radius, 0.001);
-        Assert.IsTrue(style.fill);
-        Assert.IsTrue(style.outline);
-    }
-
-    [Test]
-    public void PointStyleCanDisableBothFillAndOutline()
-    {
-        CesiumVectorPointStyle style = new CesiumVectorPointStyle();
-        style.fill = false;
-        style.outline = false;
-
-        Assert.IsFalse(style.fill);
-        Assert.IsFalse(style.outline);
-    }
-
-    #endregion
-
     #region CesiumVectorStyle Tests
 
     [Test]

--- a/Tests/TestCesiumVectorStyle.cs
+++ b/Tests/TestCesiumVectorStyle.cs
@@ -106,6 +106,46 @@ public class TestCesiumVectorStyle
 
     #endregion
 
+    #region CesiumVectorPointStyle Tests
+
+    [Test]
+    public void PointStyleDefaultHasFillEnabledOutlineDisabled()
+    {
+        CesiumVectorPointStyle style = CesiumVectorPointStyle.Default;
+
+        Assert.AreEqual(5.0, style.radius, 0.001);
+        Assert.IsTrue(style.fill);
+        Assert.IsFalse(style.outline);
+    }
+
+    [Test]
+    public void PointStyleCanEnableBothFillAndOutline()
+    {
+        CesiumVectorPointStyle style = new CesiumVectorPointStyle();
+        style.radius = 8.0;
+        style.fill = true;
+        style.fillStyle = CesiumVectorPolygonFillStyle.Default;
+        style.outline = true;
+        style.outlineStyle = CesiumVectorLineStyle.Default;
+
+        Assert.AreEqual(8.0, style.radius, 0.001);
+        Assert.IsTrue(style.fill);
+        Assert.IsTrue(style.outline);
+    }
+
+    [Test]
+    public void PointStyleCanDisableBothFillAndOutline()
+    {
+        CesiumVectorPointStyle style = new CesiumVectorPointStyle();
+        style.fill = false;
+        style.outline = false;
+
+        Assert.IsFalse(style.fill);
+        Assert.IsFalse(style.outline);
+    }
+
+    #endregion
+
     #region CesiumVectorStyle Tests
 
     [Test]
@@ -120,6 +160,11 @@ public class TestCesiumVectorStyle
         // Polygon style defaults
         Assert.IsTrue(style.polygonStyle.fill);
         Assert.IsFalse(style.polygonStyle.outline);
+
+        // Point style defaults
+        Assert.AreEqual(5.0, style.pointStyle.radius, 0.001);
+        Assert.IsTrue(style.pointStyle.fill);
+        Assert.IsFalse(style.pointStyle.outline);
     }
 
     [Test]

--- a/native~/src/Runtime/CesiumVectorStyleConversions.h
+++ b/native~/src/Runtime/CesiumVectorStyleConversions.h
@@ -6,6 +6,7 @@
 #include <DotNet/CesiumForUnity/CesiumVectorColorMode.h>
 #include <DotNet/CesiumForUnity/CesiumVectorLineStyle.h>
 #include <DotNet/CesiumForUnity/CesiumVectorLineWidthMode.h>
+#include <DotNet/CesiumForUnity/CesiumVectorPointStyle.h>
 #include <DotNet/CesiumForUnity/CesiumVectorPolygonFillStyle.h>
 #include <DotNet/CesiumForUnity/CesiumVectorPolygonStyle.h>
 #include <DotNet/CesiumForUnity/CesiumVectorStyle.h>
@@ -52,6 +53,22 @@ inline CesiumVectorData::ColorStyle fromUnityFillStyle(
   return native;
 }
 
+inline CesiumVectorData::PointStyle fromUnityPointStyle(
+    const DotNet::CesiumForUnity::CesiumVectorPointStyle& pointStyle) {
+  CesiumVectorData::PointStyle native;
+  native.radius = pointStyle.radius;
+
+  if (pointStyle.fill) {
+    native.fill = fromUnityFillStyle(pointStyle.fillStyle);
+  }
+
+  if (pointStyle.outline) {
+    native.outline = fromUnityLineStyle(pointStyle.outlineStyle);
+  }
+
+  return native;
+}
+
 inline CesiumVectorData::VectorStyle
 fromUnityStyle(const DotNet::CesiumForUnity::CesiumVectorStyle& style) {
   CesiumVectorData::VectorStyle native;
@@ -65,6 +82,8 @@ fromUnityStyle(const DotNet::CesiumForUnity::CesiumVectorStyle& style) {
     native.polygon.outline =
         fromUnityLineStyle(style.polygonStyle.outlineStyle);
   }
+
+  native.point = fromUnityPointStyle(style.pointStyle);
 
   return native;
 }
@@ -131,6 +150,27 @@ toUnityStyle(const CesiumVectorData::VectorStyle& style) {
     result.polygonStyle.outlineStyle.width = style.polygon.outline->width;
     result.polygonStyle.outlineStyle.widthMode =
         toUnityLineWidthMode(style.polygon.outline->widthMode);
+  }
+
+  // Point style
+  result.pointStyle.radius = style.point.radius;
+
+  result.pointStyle.fill = style.point.fill.has_value();
+  if (style.point.fill.has_value()) {
+    result.pointStyle.fillStyle.color = toUnityColor(style.point.fill->color);
+    result.pointStyle.fillStyle.colorMode =
+        toUnityColorMode(style.point.fill->colorMode);
+  }
+
+  result.pointStyle.outline = style.point.outline.has_value();
+  if (style.point.outline.has_value()) {
+    result.pointStyle.outlineStyle.color =
+        toUnityColor(style.point.outline->color);
+    result.pointStyle.outlineStyle.colorMode =
+        toUnityColorMode(style.point.outline->colorMode);
+    result.pointStyle.outlineStyle.width = style.point.outline->width;
+    result.pointStyle.outlineStyle.widthMode =
+        toUnityLineWidthMode(style.point.outline->widthMode);
   }
 
   return result;


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review the [Contributor Guide](https://cesium.com/learn/cesium-unity/ref-doc/contributing-unity.html) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://cesium.com/learn/cesium-unity/ref-doc/contributing-unity.html#opening-a-pull-request).

-->

@j9liu 
@azrogers 

<img width="831" height="479" alt="image" src="https://github.com/user-attachments/assets/5ce6c018-edc7-4101-9930-9f55d25fa4f0" />

## Description

Exposes a managed point style so `CesiumGeoJsonDocumentRasterOverlay` can render GeoJSON `Point` and `MultiPoint` features, which were previously dropped.

## Changes

- Add `CesiumVectorPointStyle` (radius, fill + fill style, outline + outline style) and a `pointStyle` field on `CesiumVectorStyle`. The default enables fill, since the native `PointStyle` default (no fill, no outline) renders nothing.
- Wire `pointStyle` to/from the native `VectorStyle::point` in `CesiumVectorStyleConversions.h`, mirroring the existing polygon style.
- Exercise the new type in `ConfigureReinterop.cs` so Reinterop generates its interop header.
- Add point-style tests to `TestCesiumVectorStyle.cs`.
- Changelog entry.

The overlay's inspector needs no change - `CesiumGeoJsonDocumentRasterOverlayEditor` draws the style with `PropertyField(..., includeChildren: true)`, so the new **Point Style** section appears automatically.

## Native dependency

This PR is the managed side only and **intentionally does not bump the cesium-native submodule**.

It compiles against the currently pinned native (`PointStyle` and `VectorStyle::point` already exist there), but **points will not actually render until the cesium-native submodule is advanced to a version that includes the `GeoJsonDocumentRasterOverlay` point-rasterization support** - which is already merged in cesium-native `main`. Until that bump lands, `pointStyle` is configurable but has no visible effect.

Suggested follow-up: bump the submodule to a cesium-native version containing that support (coordinated separately / with the next native update).

## Issue number or link

https://github.com/CesiumGS/cesium-unity/issues/707

## Author checklist

- [x] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [x] I have done a full self-review of my code.
- [x] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- [x] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [x] I have updated the documentation as necessary.

## Remaining Tasks

Bump the submodule to a cesium-native version containing the `GeoJsonDocumentRasterOverlay` point-rasterization support.

## Testing plan

- Added unit tests for `CesiumVectorPointStyle` defaults and configuration.
- Verified end-to-end locally against a cesium-native build that includes the point-rasterization support: `Point`/`MultiPoint` features from a GeoJSON document rendered onto a tileset via `CesiumGeoJsonDocumentRasterOverlay`.

## Reviewer checklist

Thank you for taking the time to review this PR. By approving a PR you are taking as much responsibility for these changes as the author.

As you review, please go through the checklist below:

- [ ] Review and run all parts of the test plan on this branch and verify it matches expectations.
    - [ ] If the issue is a bug please make sure you can reproduce the bug in the main branch and then checkout this branch to make sure it actually solved the issue.
- [ ] Review the code and make sure you do not have any remaining questions or concerns. You should understand the code change and the chosen approach. If you are not confident or have doubts about the code, please do not hesitate to ask questions.
    - [ ] Code should follow the [C++ Style Guide](https://cesium.com/learn/cesium-native/ref-doc/style-guide.html)
- [ ] Review the unit tests and make sure there are no missing tests or edge cases.
- [ ] Review documentation changes and updates to `CHANGES.md` to make sure they accurately cover the work in this PR.
- [ ] Verify that the [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) has been submitted, if needed.