### PR TITLE
Move Android build from Windows job to Linux job in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install Unity
         run: |
           Start-Process -FilePath "C:/Program Files/Unity Hub/Unity Hub.exe" -Args "-- --headless install --version 2022.3.41f1 --changeset 0f988161febf" -Wait
-          Start-Process -FilePath "C:/Program Files/Unity Hub/Unity Hub.exe" -Args "-- --headless install-modules --version 2022.3.41f1 --changeset 0f988161febf --module android android-sdk-ndk-tools android-open-jdk-11.0.14.1+1 universal-windows-platform" -Wait
+          Start-Process -FilePath "C:/Program Files/Unity Hub/Unity Hub.exe" -Args "-- --headless install-modules --version 2022.3.41f1 --changeset 0f988161febf --module universal-windows-platform" -Wait
       - name: Create SSH tunnel to Unity License Server
         env:
           UNITY_LICENSE_SERVER_SSH_KEY: ${{ secrets.UNITY_LICENSE_SERVER_SSH_KEY }}
@@ -136,12 +136,10 @@ jobs:
           $ENV:TEMP="d:\cesium\temp"
           # We only need a release build of vcpkg dependencies
           $ENV:CESIUM_VCPKG_RELEASE_ONLY="TRUE"
-          # Clear ANDROID_NDK_ROOT so that we use Unity's version
-          Remove-Item Env:ANDROID_NDK_ROOT
           # Explicitly set the ezvcpkg path. Otherwise it will be `/.ezvcpkg` and the drive letter is ambiguous.
           $ENV:EZVCPKG_BASEDIR="D:/.ezvcpkg"
           # Run the build
-          dotnet run --project Build~ package --platform Editor --platform Windows --platform UWP --platform Android
+          dotnet run --project Build~ package --platform Editor --platform Windows --platform UWP
       - name: Print disk space 2
         if: success() || failure()    # run this step even if previous step failed
         run: |
@@ -359,6 +357,8 @@ jobs:
           key: vcpkg-linux-alma-${{ hashFiles('native~/vcpkg/ports/**/vcpkg.json', 'native~/vcpkg/triplets/**/*', 'native~/extern/*toolchain.cmake') }}-${{ hashFiles('native~/extern/cesium-native/CMakeLists.txt', 'native~/CMakeLists.txt') }}
           restore-keys: |
             vcpkg-linux-alma-${{ hashFiles('native~/vcpkg/ports/**/vcpkg.json', 'native~/vcpkg/triplets/**/*', 'native~/extern/*toolchain.cmake') }}-
+      - name: Install nasm
+        uses: ilammy/setup-nasm@v1.5.1
       - name: Install Unity Hub
         run: |
           sudo apt-get install -y gnupg libgbm1 xvfb
@@ -372,6 +372,9 @@ jobs:
         continue-on-error: true
         run: |
           xvfb-run -a /usr/bin/unityhub --no-sandbox --headless install --version 2022.3.41f1 --changeset 0f988161febf
+      - name: Install Unity Android Support
+        run: |
+          xvfb-run -a /usr/bin/unityhub --no-sandbox --headless install-modules --version 2022.3.41f1 --changeset 0f988161febf --module android android-sdk-ndk-tools android-open-jdk-11.0.14.1+1
       - name: Configure Unity to Use the License Server
         run: |
           sudo mkdir -p /usr/share/unity3d/config
@@ -422,8 +425,10 @@ jobs:
         run: |
           # We only need a release build of vcpkg dependencies
           export CESIUM_VCPKG_RELEASE_ONLY="TRUE"
+          # Clear ANDROID_NDK_ROOT so that we use Unity's version
+          unset ANDROID_NDK_ROOT
           cd ~/cesium/CesiumForUnityBuildProject/Packages/com.cesium.unity
-          dotnet run --project Build~ package --platform Editor --platform Linux
+          dotnet run --project Build~ package --platform Editor --platform Linux --platform Android
           ls -l ~/cesium/CesiumForUnityBuildProject
       - name: Publish Logs
         if: success() || failure()    # run this step even if previous step failed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -374,7 +374,8 @@ jobs:
           xvfb-run -a /usr/bin/unityhub --no-sandbox --headless install --version 2022.3.41f1 --changeset 0f988161febf
       - name: Install Unity Android Support
         run: |
-          xvfb-run -a /usr/bin/unityhub --no-sandbox --headless install-modules --version 2022.3.41f1 --changeset 0f988161febf --module android android-sdk-ndk-tools android-open-jdk-11.0.14.1+1
+          # --childModules avoids an interactive prompt asking to confirm installing the NDK submodule
+          xvfb-run -a /usr/bin/unityhub --no-sandbox --headless install-modules --version 2022.3.41f1 --changeset 0f988161febf --module android android-sdk-ndk-tools android-open-jdk-11.0.14.1+1 --childModules
       - name: Configure Unity to Use the License Server
         run: |
           sudo mkdir -p /usr/share/unity3d/config


### PR DESCRIPTION
## What
Moves the Android player build from the Windows CI job to the Linux CI job.

## Why
Windows was consistently the longest-running job in CI, in large part because it also built the Android target (SDK/NDK module install + native compile) on top of Windows/UWP. Android's native build logic is already OS-agnostic (`CompileCesiumForUnityNative.cs`/`Build~/Package.cs` just set up the Android NDK toolchain regardless of host), and Android builds directly on the host rather than in the Linux job's `almalinux:8` container, so moving it to Linux lets Windows and Linux build parallel workloads more evenly instead of stacking three platforms onto Windows.

## Changes
- **Windows job**: drop the `android`/`android-sdk-ndk-tools`/`android-open-jdk-11.0.14.1+1` Unity modules, drop `--platform Android`, remove the now-unneeded `ANDROID_NDK_ROOT` clearing step.
- **Linux job**: install `nasm` (needed for vcpkg asm-optimized ports on the host, previously only installed inside the container), install the Android Unity modules (with `--childModules` so `unityhub` doesn't block on an interactive prompt to confirm installing the NDK submodule), unset `ANDROID_NDK_ROOT` so Unity's bundled NDK is used, and add `--platform Android` to the build command.
- No source (`.cs`) changes were needed - the native build logic was already OS-agnostic for Android.

## Verification
- Pushed the branch and ran the full CI workflow to completion: https://github.com/CesiumGS/cesium-unity/actions/runs/30605283921 (all jobs green).
- Downloaded and inspected the actual artifact contents (not just job status):
  - Linux Package now contains `Plugins/Android/{arm64,x86_64}/libCesiumForUnityNative.so`.
  - Combined Package still contains both Android `.so` files, correctly merged in.
  - Windows Package shrank (~38MB vs. previously much larger) and contains no Android files.
- PlayMode "Run Tests"/"Test Report" steps passed in both the Linux and Windows jobs.

*Opened by GitHub Copilot on behalf of @kring.*
