### PR TITLE
Fix Linux CI build failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -350,10 +350,16 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "10.0.103"
+      - name: Debug build problem
+        run: |
+          ls -la /home/runner
+          df -h
+          echo "EZVCPKG_BASEDIR=/home/runner/ezvcpkg" >> $GITHUB_ENV
+          mkdir ~/ezvcpkg
       - name: Cache vcpkg artifacts
         uses: actions/cache@v4
         with:
-          path: "~/.ezvcpkg"
+          path: "~/ezvcpkg"
           key: vcpkg-linux-alma-${{ hashFiles('native~/vcpkg/ports/**/vcpkg.json', 'native~/vcpkg/triplets/**/*', 'native~/extern/*toolchain.cmake') }}-${{ hashFiles('native~/extern/cesium-native/CMakeLists.txt', 'native~/CMakeLists.txt') }}
           restore-keys: |
             vcpkg-linux-alma-${{ hashFiles('native~/vcpkg/ports/**/vcpkg.json', 'native~/vcpkg/triplets/**/*', 'native~/extern/*toolchain.cmake') }}-


### PR DESCRIPTION
The failure was an error while running ezvcpkg during the configure step:

```
"/home/runner/.ezvcpkg/56bb2411609227288b70117ead2c47585ba07713.lock"
  creation failed (check permissions).
```

Why would we be unable to write that file? One possibility was that the runner was out of disk space, but that seemed unlikely. The runner has plenty of disk space, and Unity builds don't need an excessive amount like Unreal builds do. Plus it would be quite a coincidence to consistently run out just as we try to write that tiny file.

So I think maybe it truly is a permission problem. The runner isn't allowing us to write to a dot directory under the home directory perhaps? I tried to find something in the runner or GitHub Actions changelog about that, but came up empty. But lacking a better idea, I tried changing the ezvcpkg root to `~/ezvcpkg` instead of `~/.ezvcpkg`, and that seems to have worked.

Or there was some unrelated problem in GitHub's infrastructure that just happened to be fixed just as I submitted this... 🤷 